### PR TITLE
feat: compress proof image before upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@vueuse/core": "^10.6.1",
     "@vueuse/integrations": "^10.6.1",
+    "compressorjs": "^1.2.1",
     "html5-qrcode": "^2.3.8",
     "universal-cookie": "^6.1.1",
     "vue": "^3.3.9",

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -12,7 +12,6 @@
           <v-divider></v-divider>
           <v-card-text>
             <v-file-input
-              show-size
               accept="image/*"
               label="Proof"
               v-model="proofImage"

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -136,9 +136,18 @@
 </template>
 
 <script>
+import Compressor from 'compressorjs'
 import api from '../services/api'
 import BarcodeScanner from '../components/BarcodeScanner.vue'
 import LocationSelector from '../components/LocationSelector.vue'
+
+Compressor.setDefaults({
+  checkOrientation: true,  // default
+  retainExif: true,
+  quality: 0.6,
+  // mimeType: 'image/webp',
+  maxWidth: 3000
+})
 
 export default {
   components: {
@@ -185,19 +194,34 @@ export default {
     },
     uploadProof() {
       this.createProofLoading = true
-      api
-        .createProof(this.proofImage[0])
-        .then((data) => {
-          this.addPriceSingleForm.proof_id = data['id']
-          this.proofImagePreview = URL.createObjectURL(this.proofImage[0])
-          this.createProofLoading = false
-          this.proofSuccessMessage = true
-        })
-        .catch((error) => {
-          alert('Error: server error')
-          console.log(error)
-          this.createProofLoading = false
-        })
+      new Promise((resolve, reject) => {
+        new Compressor(this.proofImage[0], {
+          success: resolve,
+          error: reject
+        });
+      })
+      .then((proofImageCompressed) => {
+        api
+          .createProof(proofImageCompressed)
+          .then((data) => {
+            this.addPriceSingleForm.proof_id = data['id']
+            this.proofImagePreview = URL.createObjectURL(proofImageCompressed)
+            this.createProofLoading = false
+            this.proofSuccessMessage = true
+          })
+          .catch((error) => {
+            alert('Error: server error')
+            console.log(error)
+            this.createProofLoading = false
+          })
+      })
+      .catch((error) => {
+        alert('Error: compression')
+        console.log(error)
+      })
+      // .finally(() => {
+      //   console.log('Compress complete')
+      // })
     },
     createPrice() {
       this.createPriceLoading = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,6 +280,11 @@ autoprefixer@^10.4.16:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
+blueimp-canvas-to-blob@^3.29.0:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz#d965f06cb1a67fdae207a2be56683f55ef531466"
+  integrity sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg==
+
 browserslist@^4.21.10:
   version "4.21.10"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz"
@@ -299,6 +304,14 @@ caniuse-lite@^1.0.30001538:
   version "1.0.30001538"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz"
   integrity sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==
+
+compressorjs@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/compressorjs/-/compressorjs-1.2.1.tgz#4dee18ef5032f8166bd0a3258f045eda2cd07671"
+  integrity sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==
+  dependencies:
+    blueimp-canvas-to-blob "^3.29.0"
+    is-blob "^2.1.0"
 
 cookie@^0.5.0:
   version "0.5.0"
@@ -383,6 +396,11 @@ html5-qrcode@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/html5-qrcode/-/html5-qrcode-2.3.8.tgz#0b0cdf7a9926cfd4be530e13a51db47592adfa0d"
   integrity sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==
+
+is-blob@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
+  integrity sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==
 
 isexe@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What

Use [compressor.js](https://github.com/fengyuanchen/compressorjs) to compress the proof image before uploading it to the backend.

Tested with 7.1 MB JPEG image --> 677 KB output