### PR TITLE
feat: send proof type on proof upload

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -69,6 +69,7 @@ export default {
   createProof(proofImage) {
     let formData = new FormData()
     formData.append('file', proofImage)
+    formData.append('type', 'PRICE_TAG')
     return fetch(`${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/upload`, {
       method: 'POST',
       headers: {

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -203,10 +203,15 @@ export default {
         api
           .createProof(proofImageCompressed)
           .then((data) => {
-            this.addPriceSingleForm.proof_id = data['id']
-            this.proofImagePreview = URL.createObjectURL(proofImageCompressed)
             this.createProofLoading = false
-            this.proofSuccessMessage = true
+            if (data['id']) {
+              this.addPriceSingleForm.proof_id = data['id']
+              this.proofImagePreview = URL.createObjectURL(proofImageCompressed)
+              this.proofSuccessMessage = true
+            } else {
+              alert('Error: server error')
+              console.log(data)
+            }
           })
           .catch((error) => {
             alert('Error: server error')


### PR DESCRIPTION
### What

When uploading a proof, also send `type=PRICE_TAG` info

Related backend PR : https://github.com/openfoodfacts/open-prices/pull/95
