### PR TITLE
feat: price create form: convert proof image to webp before upload

### DIFF
--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -154,7 +154,7 @@ Compressor.setDefaults({
   checkOrientation: true,  // default
   retainExif: true,
   quality: 0.6,
-  // mimeType: 'image/webp',
+  mimeType: 'image/webp',
   maxWidth: 3000
 })
 


### PR DESCRIPTION
### What

Following #41 

We needed to manage webp images in the backend (PR here: https://github.com/openfoodfacts/open-prices/pull/98) before using this filetype in the frontend