### PR TITLE
feat(user detail): new basic User detail page

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,7 @@ import AddPriceSingle from './views/AddPriceSingle.vue'
 import PriceList from './views/PriceList.vue'
 import ProductDetail from './views/ProductDetail.vue'
 import LocationDetail from './views/LocationDetail.vue'
+import UserDetail from './views/UserDetail.vue'
 import Stats from './views/Stats.vue'
 import NotFound from './views/NotFound.vue'
 
@@ -21,6 +22,7 @@ const routes = [
   { path: '/prices', name: 'prices', component: PriceList, meta: { title: 'Latest prices', icon: 'mdi-tag-multiple-outline', drawerMenu: true }},
   { path: '/products/:id', name: 'product-detail', component: ProductDetail, meta: { title: 'Product detail' }},
   { path: '/locations/:id', name: 'location-detail', component: LocationDetail, meta: { title: 'Location detail' }},
+  { path: '/users/:username', name: 'user-detail', component: UserDetail, meta: { title: 'User detail' }},
   { path: '/stats', name: 'stats', component: Stats, meta: { title: 'Stats' }},
   { path: '/:path(.*)', component: NotFound },
 ]

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-row>
+    <v-col cols="12" sm="6">
+      <v-card :title="username" prepend-icon="mdi-account"></v-card>
+    </v-col>
+  </v-row>
+
+  <br />
+
+  <h2 class="mb-1">
+    Latest prices
+    <small>{{ userPriceCount }}</small>
+  </h2>
+
+  <v-row>
+    <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
+      <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import api from '../services/api'
+import PriceCard from '../components/PriceCard.vue'
+
+export default {
+  components: {
+    PriceCard,
+  },
+  data() {
+    return {
+      userPriceList: [],
+      userPriceCount: null,
+      loading: false,
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    username() {
+      return this.$route.params.username
+    },
+  },
+  mounted() {
+    this.getUserPrices()
+  },
+  methods: {
+    getUserPrices() {
+      this.loading = true
+      return api.getPrices({ owner: this.username, order_by: '-created' })
+        .then((data) => {
+          this.userPriceList = data.items
+          this.userPriceCount = data.total
+          this.loading = false
+        })
+    },
+  }
+}
+</script>


### PR DESCRIPTION
### What

When selecting a user from a PriceCard, we are now presented with a User page:
- basic info (username)
- last prices + count

API call made available thanks to this commit : https://github.com/openfoodfacts/open-prices/commit/6e922f30029a9f9558ff070d3dc7c4330dd7e08f

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/5d35535e-4ce3-450c-ac89-454f863add1a)

