### PR TITLE
feat: fetch latest prices by batches of 10 + load more button

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -47,7 +47,8 @@ export default {
   },
 
   getPrices(params = {}) {
-    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/prices?${new URLSearchParams(params)}`
+    const defaultParams = {page: 1, size: 10, order_by: '-created'}
+    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/prices?${new URLSearchParams({...defaultParams, ...params})}`
     return fetch(url, {
       method: 'GET',
       headers: {

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -69,7 +69,7 @@ export default {
     },
     getLocationPrices() {
       this.loading = true
-      return api.getPrices({ location_id: this.$route.params.id, order_by: '-created' })
+      return api.getPrices({ location_id: this.$route.params.id })
         .then((data) => {
           this.locationPriceList = data.items
           this.locationPriceCount = data.total

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -24,13 +24,19 @@
 
   <h2 class="mb-1">
     Latest prices
-    <small>{{ locationPriceCount }}</small>
+    <small>{{ locationPriceTotal }}</small>
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in locationPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" :hidePriceLocation="true" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="locationPriceList.length < locationPriceTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getLocationPrices">Load more</v-btn>
     </v-col>
   </v-row>
 </template>
@@ -48,7 +54,8 @@ export default {
     return {
       location: null,
       locationPriceList: [],
-      locationPriceCount: null,
+      locationPriceTotal: null,
+      locationPricePage: 0,
       loading: false,
     }
   },
@@ -58,21 +65,20 @@ export default {
   },
   methods: {
     getLocation() {
-      this.loading = true
       return api.getLocationById(this.$route.params.id)
         .then((data) => {
           if (data.id) {
             this.location = data
-            this.loading = false
           }
         })
     },
     getLocationPrices() {
       this.loading = true
-      return api.getPrices({ location_id: this.$route.params.id })
+      this.locationPricePage += 1
+      return api.getPrices({ location_id: this.$route.params.id, page: this.locationPricePage })
         .then((data) => {
-          this.locationPriceList = data.items
-          this.locationPriceCount = data.total
+          this.locationPriceList.push(...data.items)
+          this.locationPriceTotal = data.total
           this.loading = false
         })
     },

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -29,7 +29,7 @@ export default {
     return {
       priceList: [],
       priceTotal: null,
-      page: 0,
+      pricePage: 0,
       loading: false,
     }
   },
@@ -39,8 +39,8 @@ export default {
   methods: {
     getPrices() {
       this.loading = true
-      this.page += 1
-      return api.getPrices({ page: this.page })
+      this.pricePage += 1
+      return api.getPrices({ page: this.pricePage })
         .then((data) => {
           this.priceList.push(...data.items)
           this.priceTotal = data.total

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -5,8 +5,14 @@
   </h1>
 
   <v-row>
-    <v-col cols="12" sm="6" md="4" v-for="price in prices" :key="price">
+    <v-col cols="12" sm="6" md="4" v-for="price in priceList" :key="price">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="priceList.length < priceTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getPrices">Load more</v-btn>
     </v-col>
   </v-row>
 </template>
@@ -21,7 +27,9 @@ export default {
   },
   data() {
     return {
-      prices: [],
+      priceList: [],
+      priceTotal: null,
+      page: 0,
       loading: false,
     }
   },
@@ -31,9 +39,11 @@ export default {
   methods: {
     getPrices() {
       this.loading = true
-      return api.getPrices({ order_by: '-created' })
+      this.page += 1
+      return api.getPrices({ page: this.page })
         .then((data) => {
-          this.prices = data.items
+          this.priceList.push(...data.items)
+          this.priceTotal = data.total
           this.loading = false
         })
     }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -20,13 +20,19 @@
 
   <h2 class="mb-1">
     Latest prices
-    <small>{{ productPriceCount }}</small>
+    <small>{{ productPriceTotal }}</small>
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in productPriceList" :key="price">
       <PriceCard :price="price" :product="product" :hideProductImage="true" :hideProductInfo="true" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="productPriceList.length < productPriceTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getProductPrices">Load more</v-btn>
     </v-col>
   </v-row>
 </template>
@@ -43,7 +49,8 @@ export default {
     return {
       product: null,
       productPriceList: [],
-      productPriceCount: null,
+      productPriceTotal: null,
+      productPricePage: 0,
       loading: false,
     }
   },
@@ -53,21 +60,20 @@ export default {
   },
   methods: {
     getProduct() {
-      this.loading = true
       return api.getProductById(this.$route.params.id)
         .then((data) => {
           if (data.id) {
             this.product = data
-            this.loading = false
           }
         })
     },
     getProductPrices() {
       this.loading = true
-      return api.getPrices({ product_id: this.$route.params.id })
+      this.productPricePage += 1
+      return api.getPrices({ product_id: this.$route.params.id, page: this.productPricePage })
         .then((data) => {
-          this.productPriceList = data.items
-          this.productPriceCount = data.total
+          this.productPriceList.push(...data.items)
+          this.productPriceTotal = data.total
           this.loading = false
         })
     },

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -64,7 +64,7 @@ export default {
     },
     getProductPrices() {
       this.loading = true
-      return api.getPrices({ product_id: this.$route.params.id, order_by: '-created' })
+      return api.getPrices({ product_id: this.$route.params.id })
         .then((data) => {
           this.productPriceList = data.items
           this.productPriceCount = data.total

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -6,7 +6,7 @@
 
   <v-row>
     <v-col cols="12" md="6" lg="4">
-      <v-card title="Price count" :text="priceCount"></v-card>
+      <v-card title="Price count" :text="priceTotal"></v-card>
     </v-col>
   </v-row>
 </template>
@@ -17,7 +17,7 @@ import api from '../services/api'
 export default {
   data() {
     return {
-      priceCount: null,
+      priceTotal: null,
       loading: false,
     }
   },
@@ -29,7 +29,7 @@ export default {
       this.loading = true
       return api.getPrices({ size: 1 })
         .then((data) => {
-          this.priceCount = data.total
+          this.priceTotal = data.total
           this.loading = false
         })
     }

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -27,7 +27,7 @@ export default {
   methods: {
     getPrices() {
       this.loading = true
-      return api.getPrices()
+      return api.getPrices({ size: 1 })
         .then((data) => {
           this.priceCount = data.total
           this.loading = false

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -1,7 +1,6 @@
 <template>
   <h1 class="mb-1">
     Dashboard
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h1>
 
   <v-row>
@@ -14,12 +13,19 @@
 
   <h2 class="mb-1">
     Latest prices
-    <small>{{ userPriceCount }}</small>
+    <small>{{ userPriceTotal }}</small>
+    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="userPriceList.length < userPriceTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getUserPrices">Load more</v-btn>
     </v-col>
   </v-row>
 </template>
@@ -37,7 +43,8 @@ export default {
   data() {
     return {
       userPriceList: [],
-      userPriceCount: null,
+      userPriceTotal: null,
+      userPricePage: 0,
       loading: false,
     }
   },
@@ -53,10 +60,11 @@ export default {
   methods: {
     getUserPrices() {
       this.loading = true
-      return api.getPrices({ owner: this.username })
+      this.userPricePage += 1
+      return api.getPrices({ owner: this.username, page: this.userPricePage })
         .then((data) => {
-          this.userPriceList = data.items
-          this.userPriceCount = data.total
+          this.userPriceList.push(...data.items)
+          this.userPriceTotal = data.total
           this.loading = false
         })
     },

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -53,7 +53,7 @@ export default {
   methods: {
     getUserPrices() {
       this.loading = true
-      return api.getPrices({ owner: this.username, order_by: '-created' })
+      return api.getPrices({ owner: this.username })
         .then((data) => {
           this.userPriceList = data.items
           this.userPriceCount = data.total

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -49,7 +49,7 @@ export default {
   methods: {
     getUserPrices() {
       this.loading = true
-      return api.getPrices({ owner: this.username, order_by: '-created' })
+      return api.getPrices({ owner: this.username })
         .then((data) => {
           this.userPriceList = data.items
           this.userPriceCount = data.total

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -9,13 +9,19 @@
 
   <h2 class="mb-1">
     Latest prices
-    <small>{{ userPriceCount }}</small>
+    <small>{{ userPriceTotal }}</small>
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="userPriceList.length < userPriceTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getUserPrices">Load more</v-btn>
     </v-col>
   </v-row>
 </template>
@@ -33,7 +39,8 @@ export default {
   data() {
     return {
       userPriceList: [],
-      userPriceCount: null,
+      userPriceTotal: null,
+      userPricePage: 0,
       loading: false,
     }
   },
@@ -49,10 +56,11 @@ export default {
   methods: {
     getUserPrices() {
       this.loading = true
-      return api.getPrices({ owner: this.username })
+      this.userPricePage += 1
+      return api.getPrices({ owner: this.username, page: this.userPricePage })
         .then((data) => {
-          this.userPriceList = data.items
-          this.userPriceCount = data.total
+          this.userPriceList.push(...data.items)
+          this.userPriceTotal = data.total
           this.loading = false
         })
     },


### PR DESCRIPTION
### What

We currently fetch prices by batches of 50, which is often slow to load...
- reduced the size to 10
- add a load more button to allow "scrolling"

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/6b10087c-75e8-4bc6-a449-4624284b08f9)

