### PR TITLE
feat(product detail): manage category tags

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -61,7 +61,6 @@
 
 <script>
 import utils from '../utils.js'
-import CategoryTags from '../data/category-tags.json'
 import OriginTags from '../data/origins-tags.json'
 import LabelsTags from '../data/labels-tags.json'
 
@@ -117,7 +116,13 @@ export default {
     },
     hasPriceLabels() {
       return this.hasPrice && !!this.price.labels_tags && this.price.labels_tags.length
-    }
+    },
+    getPriceCategoryName() {
+      if (this.price && this.price.category_tag) {
+        const tag = utils.getCategory(this.price.category_tag)
+        return tag ? tag.name : this.price.category_tag
+      }
+    },
   },
   methods: {
     initPriceCard() {
@@ -131,15 +136,9 @@ export default {
       } else if (this.hasPrice && this.price.product_code) {
         return this.price.product_code
       } else if (this.hasPrice && this.hasCategoryTag) {
-        return this.getPriceCategoryName()
+        return this.getPriceCategoryName
       }
       return 'unknown'
-    },
-    getPriceCategoryName() {
-      if (this.price && this.price.category_tag) {
-        const tag = CategoryTags.find(ct => ct.id === this.price.category_tag)
-        return tag.name
-      }
     },
     getPriceOriginTag() {
       if (this.price && this.price.origins_tags) {

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -7,9 +7,9 @@
           <v-img v-if="!product || !product.image_url" :src="productImageDefault" style="height:100px;width:100px;filter:invert(.9);"></v-img>
         </v-col>
         <v-col style="max-width:75%">
-          <h3 v-if="!hideProductInfo" @click="goToProduct()">{{ getPriceProductTitle() }}</h3>
+          <h3 v-if="!hideProductTitle" @click="goToProduct()">{{ getPriceProductTitle() }}</h3>
 
-          <p v-if="!hideProductInfo" class="mb-2">
+          <p v-if="!hideProductDetails" class="mb-2">
             <span v-if="hasProductBrands">
               <v-chip label size="small" density="comfortable" class="mr-1">{{ product.brands }}</v-chip>
             </span>
@@ -71,7 +71,8 @@ export default {
     'price': null,
     'product': null,
     'hideProductImage': false,
-    'hideProductInfo': false,
+    'hideProductTitle': false,
+    'hideProductDetails': false,
     'hidePriceLocation': false,
     'readonly': false
   },
@@ -188,10 +189,10 @@ export default {
       return utils.prettyRelativeDateTime(dateTimeString, true)
     },
     goToProduct() {
-      if (this.readonly || !this.hasProduct) {
+      if (this.readonly) {
         return
       }
-      this.$router.push({ path: `/products/${this.product.id}` })
+      this.$router.push({ path: `/products/${this.hasProduct ? this.product.id : this.price.category_tag}` })
     },
     goToLocation() {
       if (this.readonly) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import CategoryTags from './data/category-tags.json'
 import CountriesWithEmoji from './data/countries-with-emoji.json'
 
 
@@ -46,6 +47,10 @@ function prettyRelativeDateTime(dateTimeString, short=false) {
   diff < 60 && "just now" || diff < 120 && "1 minute ago" || diff < 3600 && Math.floor(diff / 60) + " minutes ago" || diff < 7200 && "1 hour ago" || diff < 86400 && Math.floor(diff / 3600) + " hours ago") || day_diff == 1 && "Yesterday" || day_diff < 7 && day_diff + " days ago" || day_diff < 31 && Math.ceil(day_diff / 7) + " weeks ago";
 }
 
+function getCategory(categoryId) {
+  return CategoryTags.find(ct => ct.id === categoryId)
+}
+
 function getCountryEmojiFromName(countryString) {
   const country = CountriesWithEmoji.find(c => c.name === countryString || (c.name_original && c.name_original.length && c.name_original.indexOf(countryString) > -1))
   return country ? country.emoji : null
@@ -64,6 +69,7 @@ export default {
   addObjectToArray,
   prettyDate,
   prettyRelativeDateTime,
+  getCategory,
   getCountryEmojiFromName,
   getLocationTitle,
 }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -2,6 +2,7 @@
   <v-row>
     <v-col cols="12" sm="6">
       <PriceCard v-if="product" :product="product" :readonly="true" elevation="1"></PriceCard>
+      <v-card v-if="productIsCategory" :title="productId" prepend-icon="mdi-fruit-watermelon"></v-card>
     </v-col>
   </v-row>
 
@@ -26,7 +27,7 @@
 
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in productPriceList" :key="price">
-      <PriceCard :price="price" :product="product" :hideProductImage="true" :hideProductInfo="true" elevation="1" height="100%"></PriceCard>
+      <PriceCard :price="price" :product="product" :hideProductImage="true" :hideProductTitle="true" :hideProductDetails="productIsCategory ? false : true" elevation="1" height="100%"></PriceCard>
     </v-col>
   </v-row>
 
@@ -47,6 +48,7 @@ export default {
   },
   data() {
     return {
+      productId: this.$route.params.id,
       product: null,
       productPriceList: [],
       productPriceTotal: null,
@@ -58,19 +60,26 @@ export default {
     this.getProduct(),
     this.getProductPrices()
   },
+  computed: {
+    productIsCategory() {
+      return this.productId.startsWith('en')
+    }
+  },
   methods: {
     getProduct() {
-      return api.getProductById(this.$route.params.id)
-        .then((data) => {
-          if (data.id) {
-            this.product = data
-          }
-        })
+      if (!this.productIsCategory) {
+        return api.getProductById(this.productId)
+          .then((data) => {
+            if (data.id) {
+              this.product = data
+            }
+          })
+      }
     },
     getProductPrices() {
       this.loading = true
       this.productPricePage += 1
-      return api.getPrices({ product_id: this.$route.params.id, page: this.productPricePage })
+      return api.getPrices({ [this.productIsCategory ? 'category_tag' : 'product_id']: this.productId, page: this.productPricePage })
         .then((data) => {
           this.productPriceList.push(...data.items)
           this.productPriceTotal = data.total

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -2,7 +2,7 @@
   <v-row>
     <v-col cols="12" sm="6">
       <PriceCard v-if="product" :product="product" :readonly="true" elevation="1"></PriceCard>
-      <v-card v-if="productIsCategory" :title="productId" prepend-icon="mdi-fruit-watermelon"></v-card>
+      <v-card v-if="productIsCategory" :title="getCategoryName" prepend-icon="mdi-fruit-watermelon"></v-card>
     </v-col>
   </v-row>
 
@@ -39,6 +39,7 @@
 </template>
 
 <script>
+import utils from '../utils.js'
 import api from '../services/api'
 import PriceCard from '../components/PriceCard.vue'
 
@@ -63,7 +64,13 @@ export default {
   computed: {
     productIsCategory() {
       return this.productId.startsWith('en')
-    }
+    },
+    getCategoryName() {
+      if (this.productIsCategory) {
+        const tag = utils.getCategory(this.productId)
+        return tag ? tag.name : this.productId
+      }
+    },
   },
   methods: {
     getProduct() {


### PR DESCRIPTION
### What

Following #55
Allow displaying the product page for categories, such as `/products/en:tomatoes`

To fetch prices per category_tag, we'll need to merge https://github.com/openfoodfacts/open-prices/pull/113 in the backend

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/fbe30e0b-9b04-42a7-b009-ca803d82880d)

