### PR TITLE
style: Add small separation in scan barcode button

### DIFF
--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -61,7 +61,7 @@
               </v-item-group>
             </h3>
             <v-sheet v-if="productMode === 'barcode'">
-              <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click="showBarcodeScanner">Scan a barcode</v-btn>
+              <v-btn class="mb-2 mt-1" size="small" prepend-icon="mdi-plus" @click="showBarcodeScanner">Scan a barcode</v-btn>
               <v-text-field
                 v-if="dev"
                 :prepend-inner-icon="productBarcodeFormFilled ? 'mdi-barcode' : 'mdi-barcode-scan'"


### PR DESCRIPTION
Adds a slight separation between buttons. Can be increased to `mt-2` but this should work for mobile devices.

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/1145001/84ac5a19-a192-4a91-975e-30d106f395ef)
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/1145001/13b5610e-e446-46b2-82d8-e2df65ffa39b)
