### PR TITLE
feat(price create form): move product scanning first

### DIFF
--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -25,7 +25,7 @@
               </v-item-group>
             </h3>
             <v-sheet v-if="productMode === 'barcode'">
-              <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click="showBarcodeScanner">Scan a barcode</v-btn>
+              <v-btn class="mb-2" size="small" prepend-icon="mdi-barcode-scan" @click="showBarcodeScanner">Scan a barcode</v-btn>
               <v-text-field
                 v-if="dev"
                 :prepend-inner-icon="productBarcodeFormFilled ? 'mdi-barcode' : 'mdi-barcode-scan'"
@@ -102,7 +102,7 @@
             </v-row>
             <v-row>
               <v-col>
-                <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click.prevent="$refs.proof.click()" :loading="createProofLoading" :disabled="createProofLoading">Proof</v-btn>
+                <v-btn class="mb-2" size="small" prepend-icon="mdi-camera" @click.prevent="$refs.proof.click()" :loading="createProofLoading" :disabled="createProofLoading">Proof</v-btn>
                 <v-file-input
                   class="overflow-hidden d-none"
                   ref="proof"
@@ -146,7 +146,7 @@
               <v-icon start :icon="isSelectedLocation(location) ? 'mdi-checkbox-marked-circle' : 'mdi-history'"></v-icon>
               {{ location.display_name }}
             </v-chip>
-            <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click="showLocationSelector">Find</v-btn>
+            <v-btn class="mb-2" size="small" prepend-icon="mdi-magnify" @click="showLocationSelector">Find</v-btn>
             <p v-if="!locationFormFilled" class="text-red mb-2"><i>Select your location</i></p>
 
             <h3 class="mt-4 mb-1">Date</h3>

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -14,7 +14,7 @@
           :style="productFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
           <v-divider></v-divider>
           <v-card-text>
-            <h3 class="mb-1">
+            <h3 class="mb-2">
               <v-item-group v-model="productMode" class="d-inline" mandatory>
                 <v-item v-for="pm in productModeList" :key="pm.key" :value="pm.key" v-slot="{ isSelected, toggle }">
                   <v-chip class="mr-1" @click="toggle">
@@ -71,14 +71,14 @@
         </v-card>
       </v-col>
 
-      <!-- Step 2: price -->
+      <!-- Step 2: price & proof -->
       <v-col cols="12" md="6" lg="4">
         <v-card
           title="Price details"
-          subtitle=""
-          :prepend-icon="priceFormFilled ? 'mdi-tag-check-outline' : 'mdi-tag-outline'"
+          subtitle="With a proof"
+          :prepend-icon="priceProofFormFilled ? 'mdi-tag-check-outline' : 'mdi-tag-outline'"
           height="100%"
-          :style="priceFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
+          :style="priceProofFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
           <v-divider></v-divider>
           <v-card-text>
             <h3 class="mb-1">Price <span v-if="productMode === 'category'">per kg</span></h3>
@@ -88,6 +88,7 @@
                   v-model="addPriceSingleForm.price"
                   label="Price"
                   type="number"
+                  hide-details="auto"
                 ></v-text-field>
               </v-col>
               <v-col cols="6">
@@ -95,61 +96,10 @@
                   v-model="addPriceSingleForm.currency"
                   label="Currency"
                   :items="currencyList"
+                  hide-details="auto"
                 ></v-autocomplete>
               </v-col>
             </v-row>
-          </v-card-text>
-        </v-card>
-      </v-col>
-
-      <!-- Step 3: location & date -->
-      <v-col cols="12" md="6" lg="4">
-        <v-card
-          title="Where & when?"
-          subtitle=""
-          :prepend-icon="locationDateFormFilled ? 'mdi-map-marker-check-outline' : 'mdi-map-marker-outline'"
-          height="100%"
-          :style="locationDateFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
-          <v-divider></v-divider>
-          <v-card-text>
-            <h3 class="mb-1">
-              Location
-            </h3>
-            <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click="showLocationSelector">Find</v-btn>
-            <v-chip
-              class="mb-2"
-              :style="isSelectedLocation(location) ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'"
-              v-for="location in recentLocations"
-              @click="setLocationData(location)">
-              <v-icon start :icon="isSelectedLocation(location) ? 'mdi-checkbox-marked-circle' : 'mdi-history'"></v-icon>
-              {{ location.display_name }}
-            </v-chip>
-            <p v-if="!locationFormFilled" class="text-red mb-2"><i>Select your location</i></p>
-
-            <h3 class="mt-4 mb-1">Date</h3>
-            <v-row>
-              <v-col>
-                <v-text-field
-                  v-model="addPriceSingleForm.date"
-                  label="Date"
-                  type="date"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-card-text>
-        </v-card>
-      </v-col>
-
-      <!-- Step 4: proof -->
-      <v-col cols="12" md="6" lg="4">
-        <v-card
-          title="Take a picture of the price tag"
-          subtitle="We need this for proof"
-          :prepend-icon="proofFormFilled ? 'mdi-image-check' : 'mdi-camera'"
-          height="100%"
-          :style="proofFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
-          <v-divider></v-divider>
-          <v-card-text>
             <v-row>
               <v-col>
                 <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click.prevent="$refs.proof.click()" :loading="createProofLoading" :disabled="createProofLoading">Proof</v-btn>
@@ -169,6 +119,44 @@
               </v-col>
               <v-col v-if="proofFormFilled">
                 <v-img :src="proofImagePreview" style="max-height:200px"></v-img>
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <!-- Step 3: location & date -->
+      <v-col cols="12" md="6" lg="4">
+        <v-card
+          title="Where & when?"
+          subtitle="Final step!"
+          :prepend-icon="locationDateFormFilled ? 'mdi-map-marker-check-outline' : 'mdi-map-marker-outline'"
+          height="100%"
+          :style="locationDateFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
+          <v-divider></v-divider>
+          <v-card-text>
+            <h3 class="mb-1">
+              Location
+            </h3>
+            <v-chip
+              class="mb-2"
+              :style="isSelectedLocation(location) ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'"
+              v-for="location in recentLocations"
+              @click="setLocationData(location)">
+              <v-icon start :icon="isSelectedLocation(location) ? 'mdi-checkbox-marked-circle' : 'mdi-history'"></v-icon>
+              {{ location.display_name }}
+            </v-chip>
+            <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click="showLocationSelector">Find</v-btn>
+            <p v-if="!locationFormFilled" class="text-red mb-2"><i>Select your location</i></p>
+
+            <h3 class="mt-4 mb-1">Date</h3>
+            <v-row>
+              <v-col>
+                <v-text-field
+                  v-model="addPriceSingleForm.date"
+                  label="Date"
+                  type="date"
+                ></v-text-field>
               </v-col>
             </v-row>
           </v-card-text>
@@ -281,8 +269,13 @@ export default {
     productFormFilled() {
       return this.productBarcodeFormFilled || this.productCategoryFormFilled
     },
-    priceFormFilled() {
-      return !!this.addPriceSingleForm.price && !!this.addPriceSingleForm.currency
+    priceProofFormFilled() {
+      let keys = ['price', 'currency', 'proof_id']
+      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
+    },
+    proofFormFilled() {
+      let keys = ['proof_id']
+      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
     },
     recentLocations() {
       return this.appStore.getRecentLocations(3)
@@ -295,12 +288,8 @@ export default {
       let keys = ['location_osm_id', 'location_osm_type', 'date']
       return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
     },
-    proofFormFilled() {
-      let keys = ['proof_id']
-      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
-    },
     formFilled() {
-      return this.productFormFilled && this.priceFormFilled && this.locationDateFormFilled && this.proofFormFilled
+      return this.productFormFilled && this.priceProofFormFilled && this.locationDateFormFilled
     },
   },
   mounted() {

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -4,53 +4,17 @@
   <v-form @submit.prevent="createPrice">
     <v-row>
 
-      <!-- Step 1: proof -->
+      <!-- Step 1: product -->
       <v-col cols="12" md="6" lg="4">
         <v-card
-          title="Take a picture of the price tag"
-          subtitle="We need this for proof"
-          :prepend-icon="proofFormFilled ? 'mdi-image-check' : 'mdi-camera'"
+          title="Product details"
+          subtitle=""
+          :prepend-icon="productFormFilled ? 'mdi-database-check-outline' : 'mdi-database-outline'"
           height="100%"
-          :style="proofFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
-          <v-divider></v-divider>
-          <v-card-text>
-            <v-row>
-              <v-col>
-                <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click.prevent="$refs.proof.click()" :loading="createProofLoading" :disabled="createProofLoading">Proof</v-btn>
-                <v-file-input
-                  class="overflow-hidden d-none"
-                  ref="proof"
-                  :prepend-icon="proofFormFilled ? 'mdi-image-check' : 'mdi-camera'"
-                  v-model="proofImage"
-                  capture="environment"
-                  accept="image/*"
-                  @change="uploadProof"
-                  @click:clear="clearProof"
-                  :loading="createProofLoading">
-                </v-file-input>
-                <p v-if="proofFormFilled && !createProofLoading" class="text-green mb-2"><i>Proof uploaded!</i></p>
-                <p v-if="!proofFormFilled && !createProofLoading" class="text-red mb-2"><i>Upload a proof</i></p>
-              </v-col>
-              <v-col v-if="proofFormFilled">
-                <v-img :src="proofImagePreview" style="max-height:200px"></v-img>
-              </v-col>
-            </v-row>
-          </v-card-text>
-        </v-card>
-      </v-col>
-
-      <!-- Step 2: product & price -->
-      <v-col cols="12" md="6" lg="4">
-        <v-card
-          title="Product & price details"
-          subtitle="The most important :)"
-          :prepend-icon="productPriceFormFilled ? 'mdi-tag-check-outline' : 'mdi-tag-outline'"
-          height="100%"
-          :style="productPriceFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
+          :style="productFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
           <v-divider></v-divider>
           <v-card-text>
             <h3 class="mb-1">
-              Product
               <v-item-group v-model="productMode" class="d-inline" mandatory>
                 <v-item v-for="pm in productModeList" :key="pm.key" :value="pm.key" v-slot="{ isSelected, toggle }">
                   <v-chip class="mr-1" @click="toggle">
@@ -69,6 +33,7 @@
                 label="Product code"
                 type="text"
                 hint="EAN"
+                hide-details="auto"
                 @click:prepend="showBarcodeScanner"
               ></v-text-field>
               <PriceCard v-if="product" class="mb-4" :product="product" :readonly="true" elevation="1"></PriceCard>
@@ -102,7 +67,20 @@
               </div>
             </v-sheet>
             <p v-if="(productMode === 'barcode' && !productBarcodeFormFilled) || (productMode === 'category' && !productCategoryFormFilled)" class="text-red mb-2"><i>Set a product</i></p>
+          </v-card-text>
+        </v-card>
+      </v-col>
 
+      <!-- Step 2: price -->
+      <v-col cols="12" md="6" lg="4">
+        <v-card
+          title="Price details"
+          subtitle=""
+          :prepend-icon="priceFormFilled ? 'mdi-tag-check-outline' : 'mdi-tag-outline'"
+          height="100%"
+          :style="priceFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
+          <v-divider></v-divider>
+          <v-card-text>
             <h3 class="mb-1">Price <span v-if="productMode === 'category'">per kg</span></h3>
             <v-row>
               <v-col cols="6">
@@ -128,7 +106,7 @@
       <v-col cols="12" md="6" lg="4">
         <v-card
           title="Where & when?"
-          subtitle="Final step!"
+          subtitle=""
           :prepend-icon="locationDateFormFilled ? 'mdi-map-marker-check-outline' : 'mdi-map-marker-outline'"
           height="100%"
           :style="locationDateFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
@@ -156,6 +134,41 @@
                   label="Date"
                   type="date"
                 ></v-text-field>
+              </v-col>
+            </v-row>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <!-- Step 4: proof -->
+      <v-col cols="12" md="6" lg="4">
+        <v-card
+          title="Take a picture of the price tag"
+          subtitle="We need this for proof"
+          :prepend-icon="proofFormFilled ? 'mdi-image-check' : 'mdi-camera'"
+          height="100%"
+          :style="proofFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'">
+          <v-divider></v-divider>
+          <v-card-text>
+            <v-row>
+              <v-col>
+                <v-btn class="mb-2" size="small" prepend-icon="mdi-plus" @click.prevent="$refs.proof.click()" :loading="createProofLoading" :disabled="createProofLoading">Proof</v-btn>
+                <v-file-input
+                  class="overflow-hidden d-none"
+                  ref="proof"
+                  :prepend-icon="proofFormFilled ? 'mdi-image-check' : 'mdi-camera'"
+                  v-model="proofImage"
+                  capture="environment"
+                  accept="image/*"
+                  @change="uploadProof"
+                  @click:clear="clearProof"
+                  :loading="createProofLoading">
+                </v-file-input>
+                <p v-if="proofFormFilled && !createProofLoading" class="text-green mb-2"><i>Proof uploaded!</i></p>
+                <p v-if="!proofFormFilled && !createProofLoading" class="text-red mb-2"><i>Upload a proof</i></p>
+              </v-col>
+              <v-col v-if="proofFormFilled">
+                <v-img :src="proofImagePreview" style="max-height:200px"></v-img>
               </v-col>
             </v-row>
           </v-card-text>
@@ -223,7 +236,6 @@ export default {
       dev: import.meta.env.DEV,
       // price form
       addPriceSingleForm: {
-        proof_id: null,
         product_code: '',
         category_tag: null,
         origins_tags: '',
@@ -232,14 +244,10 @@ export default {
         currency: null,  // see initPriceSingleForm
         location_osm_id: null,
         location_osm_type: '',
-        date: new Date().toISOString().substr(0, 10)
+        date: new Date().toISOString().substr(0, 10),
+        proof_id: null,
       },
       createPriceLoading: false,
-      // proof data
-      proofImage: null,
-      proofImagePreview: null,
-      createProofLoading: false,
-      proofSuccessMessage: false,
       // product data
       product: null,
       productModeList: [{key: 'barcode', value: 'Barcode', icon: 'mdi-barcode-scan'}, {key: 'category', value: 'Category', icon: 'mdi-basket-outline'}],
@@ -253,14 +261,15 @@ export default {
       // location data
       locationSelector: false,
       locationSelectedDisplayName: '',
+      // proof data
+      proofImage: null,
+      proofImagePreview: null,
+      createProofLoading: false,
+      proofSuccessMessage: false,
     }
   },
   computed: {
     ...mapStores(useAppStore),
-    proofFormFilled() {
-      let keys = ['proof_id']
-      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
-    },
     productBarcodeFormFilled() {
       let keys = ['product_code']
       return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
@@ -269,8 +278,11 @@ export default {
       let keys = ['category_tag', 'origins_tags']
       return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
     },
-    productPriceFormFilled() {
-      return (this.productBarcodeFormFilled || this.productCategoryFormFilled) && !!this.addPriceSingleForm.price && !!this.addPriceSingleForm.currency
+    productFormFilled() {
+      return this.productBarcodeFormFilled || this.productCategoryFormFilled
+    },
+    priceFormFilled() {
+      return !!this.addPriceSingleForm.price && !!this.addPriceSingleForm.currency
     },
     recentLocations() {
       return this.appStore.getRecentLocations(3)
@@ -283,8 +295,12 @@ export default {
       let keys = ['location_osm_id', 'location_osm_type', 'date']
       return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
     },
+    proofFormFilled() {
+      let keys = ['proof_id']
+      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
+    },
     formFilled() {
-      return this.proofFormFilled && this.productPriceFormFilled && this.locationDateFormFilled
+      return this.productFormFilled && this.priceFormFilled && this.locationDateFormFilled && this.proofFormFilled
     },
   },
   mounted() {


### PR DESCRIPTION
### What

Currently the price proof is asked first. We change this to the product scanning, so that we can display info about the product (details, number of scans...)

### Details

- move product selection first
- group price & proof together
- change button icons (scan product / image proof / location find)

|Before|After|
|---|---|
|1. Proof<br>2. Product & price<br>3. Location & date|1. Product<br>2. Price & proof<br>3. Location & date|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/4a5bb04e-b2d6-4bf0-97a4-3624eba346c8)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/65817306-9f71-44c9-84ef-bdc10e72280b)|