### PR TITLE
fix(price card): make bottom labels smaller

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -41,16 +41,16 @@
       </v-row>
 
       <div class="d-flex flex-wrap ga-1 mt-2" v-if="price">
-        <v-chip v-if="!hidePriceLocation" class="mr-1" label size="small" @click="goToLocation()">
+        <v-chip v-if="!hidePriceLocation" class="mr-1" label size="small"  density="comfortable" @click="goToLocation()">
           <v-icon v-if="!priceLocationEmoji" start icon="mdi-map-marker-outline"></v-icon>
           <span v-if="priceLocationEmoji" style="margin-inline-start:-5px;margin-inline-end:5px">{{ priceLocationEmoji }}</span>
           {{ getPriceLocationTitle() }}
         </v-chip>
-        <v-chip class="mr-1" label size="small" @click="goToUser()">
+        <v-chip class="mr-1" label size="small" density="comfortable" @click="goToUser()">
           <v-icon start icon="mdi-account"></v-icon>
           {{ price.owner }}
         </v-chip>
-        <v-chip label size="small">
+        <v-chip label size="small" density="comfortable">
           <v-icon start icon="mdi-clock-outline"></v-icon>
           {{ getRelativeDateTimeFormatted(price.created) }}
         </v-chip>


### PR DESCRIPTION
### What

Reduce the size of the bottom labels (similar to the product labels above)

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/13057baa-6842-4296-9f39-3d61abdba206)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/36604c6a-9aa4-450c-af30-9334919911c9)|
