### PR TITLE
fix(price card): improve created date info (further weeks, remove ago, tooltip)

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -59,6 +59,7 @@
         <v-chip label size="small" density="comfortable">
           <v-icon start icon="mdi-clock-outline"></v-icon>
           {{ getRelativeDateTimeFormatted(price.created) }}
+          <v-tooltip activator="parent" location="top">{{ getDateTimeFormatted(price.created) }}</v-tooltip>
         </v-chip>
       </div>
     </v-container>
@@ -189,6 +190,9 @@ export default {
     },
     getDateFormatted(dateString) {
       return utils.prettyDate(dateString)
+    },
+    getDateTimeFormatted(dateString) {
+      return utils.prettyDateTime(dateString)
     },
     getRelativeDateTimeFormatted(dateTimeString) {
       return utils.prettyRelativeDateTime(dateTimeString, 'shortest')

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -191,7 +191,7 @@ export default {
       return utils.prettyDate(dateString)
     },
     getRelativeDateTimeFormatted(dateTimeString) {
-      return utils.prettyRelativeDateTime(dateTimeString, true)
+      return utils.prettyRelativeDateTime(dateTimeString, 'shortest')
     },
     goToProduct() {
       if (this.readonly) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,16 @@ function addObjectToArray(arr, obj, unshift = false, avoidDuplicates = true) {
  */
 function prettyDate(dateString) {
   const date = new Date(dateString)
-  return new Intl.DateTimeFormat('default').format(date)
+  return new Intl.DateTimeFormat(navigator.language, {dateStyle: 'short'}).format(date)
+}
+
+/**
+ * input: '2023-12-27T17:08:19.021410+01:00'
+ * output: '12/27/2023, 8:19AM'
+ */
+function prettyDateTime(dateTimeString) {
+  const date = new Date(dateTimeString)
+  return new Intl.DateTimeFormat(navigator.language, {dateStyle: 'short', timeStyle: 'short'}).format(date)
 }
 
 /**
@@ -72,6 +81,7 @@ function getLocationTitle(locationObject, withEmoji=false) {
 export default {
   addObjectToArray,
   prettyDate,
+  prettyDateTime,
   prettyRelativeDateTime,
   getCategory,
   getCountryEmojiFromName,

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,21 +30,21 @@ function prettyDate(dateString) {
  * https://johnresig.com/blog/javascript-pretty-date/
  * input: '2023-12-27T17:08:19.021410+01:00'
  * output: '5 hours ago', 'Yesterday', '2 days ago'...
+ * changes: add short (replace 'days' with 'd', remove 'Yesterday'), extend days & weeks
  */
 function prettyRelativeDateTime(dateTimeString, short=false) {
   var date = new Date((dateTimeString || "").replace(/-/g, "/").replace(/[TZ]/g, " ")),
       diff = (((new Date()).getTime() - date.getTime()) / 1000),
       day_diff = Math.floor(diff / 86400);
 
-  if (isNaN(day_diff) || day_diff < 0 || day_diff >= 31) return;
+  if (isNaN(day_diff) || day_diff < 0) return;
 
   if (short) {
-    // replace 'days' with 'd', remove 'Yesterday'
     return day_diff == 0 && (
-      diff < 60 && "just now" || diff < 120 && "1m ago" || diff < 3600 && Math.floor(diff / 60) + "m ago" || diff < 7200 && "1h ago" || diff < 86400 && Math.floor(diff / 3600) + "h ago") || day_diff < 7 && day_diff + "d ago" || day_diff < 31 && Math.ceil(day_diff / 7) + "w ago";
+      diff < 60 && "just now" || diff < 120 && "1m ago" || diff < 3600 && Math.floor(diff / 60) + "m ago" || diff < 7200 && "1h ago" || diff < 86400 && Math.floor(diff / 3600) + "h ago") || day_diff < 10 && day_diff + "d ago" || Math.ceil(day_diff / 7) + "w ago";
   }
   return day_diff == 0 && (
-  diff < 60 && "just now" || diff < 120 && "1 minute ago" || diff < 3600 && Math.floor(diff / 60) + " minutes ago" || diff < 7200 && "1 hour ago" || diff < 86400 && Math.floor(diff / 3600) + " hours ago") || day_diff == 1 && "Yesterday" || day_diff < 7 && day_diff + " days ago" || day_diff < 31 && Math.ceil(day_diff / 7) + " weeks ago";
+  diff < 60 && "just now" || diff < 120 && "1 minute ago" || diff < 3600 && Math.floor(diff / 60) + " minutes ago" || diff < 7200 && "1 hour ago" || diff < 86400 && Math.floor(diff / 3600) + " hours ago") || day_diff == 1 && "Yesterday" || day_diff < 10 && day_diff + " days ago" || Math.ceil(day_diff / 7) + " weeks ago";
 }
 
 function getCategory(categoryId) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,16 +30,20 @@ function prettyDate(dateString) {
  * https://johnresig.com/blog/javascript-pretty-date/
  * input: '2023-12-27T17:08:19.021410+01:00'
  * output: '5 hours ago', 'Yesterday', '2 days ago'...
- * changes: add short (replace 'days' with 'd', remove 'Yesterday'), extend days & weeks
+ * changes: add short (replace 'days' with 'd', remove 'Yesterday') & shortest (remove 'ago'), extend days & weeks
  */
-function prettyRelativeDateTime(dateTimeString, short=false) {
+function prettyRelativeDateTime(dateTimeString, size=null) {
   var date = new Date((dateTimeString || "").replace(/-/g, "/").replace(/[TZ]/g, " ")),
       diff = (((new Date()).getTime() - date.getTime()) / 1000),
       day_diff = Math.floor(diff / 86400);
 
   if (isNaN(day_diff) || day_diff < 0) return;
 
-  if (short) {
+  if (size == 'shortest') {
+    return day_diff == 0 && (
+      diff < 60 && "just now" || diff < 120 && "1m" || diff < 3600 && Math.floor(diff / 60) + "m" || diff < 7200 && "1h" || diff < 86400 && Math.floor(diff / 3600) + "h") || day_diff < 10 && day_diff + "d" || Math.ceil(day_diff / 7) + "w";
+  }
+  if (size == 'short') {
     return day_diff == 0 && (
       diff < 60 && "just now" || diff < 120 && "1m ago" || diff < 3600 && Math.floor(diff / 60) + "m ago" || diff < 7200 && "1h ago" || diff < 86400 && Math.floor(diff / 3600) + "h ago") || day_diff < 10 && day_diff + "d ago" || Math.ceil(day_diff / 7) + "w ago";
   }


### PR DESCRIPTION
### What

Price card : 
- fix old dates later than 4 weeks (was blank before)
- remove 'ago' to reduce size
- show tooltip on created label hover

|Before|After|
|---|---|
|![Screenshot from 2024-01-07 09-40-39](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/62f3beeb-a166-4fce-bf00-d624d87e9e4c)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/5ef7da04-2328-4662-ad8b-47d0158eac8a)|