### PR TITLE
feat(product page): change url (code instead of id)

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -32,12 +32,13 @@
               </v-chip>
             </span>
             <span v-if="!price">
+              <br />
               <v-chip label size="small" density="comfortable" class="mr-1">{{ product.code }}</v-chip>
             </span>
           </p>
 
           <v-sheet v-if="price">
-            <p class="mb-2">
+            <p>
               <span>{{ getPriceValueDisplay() }}</span>
               <span v-if="hasProductQuantity"> ({{  getPricePerKilo() }})</span>
               <span> on <i>{{ getDateFormatted(price.date) }}</i></span>
@@ -201,7 +202,7 @@ export default {
       if (this.readonly) {
         return
       }
-      this.$router.push({ path: `/products/${this.hasProduct ? this.product.id : this.price.category_tag}` })
+      this.$router.push({ path: `/products/${this.price.product_code || this.price.category_tag}` })
     },
     goToLocation() {
       if (this.readonly) {

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -146,7 +146,7 @@ export default {
       } else if (this.hasPrice && this.hasCategoryTag) {
         return this.getPriceCategoryName
       }
-      return 'unknown'
+      return 'Unknown product'
     },
     getPriceOriginTag() {
       if (this.price && this.price.origins_tags) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -69,6 +69,17 @@ export default {
     .then((response) => response.json())
   },
 
+  getProductByCode(productCode) {
+    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/products/code/${productCode}`
+    return fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    .then((response) => response.json())
+  },
+
   getLocationById(locationId) {
     const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/locations/${locationId}`
     return fetch(url, {
@@ -94,6 +105,4 @@ export default {
     .then((response) => response.json())
     .then((data) => data.filter(l => !NOMINATIM_RESULT_TYPE_EXCLUDE_LIST.includes(l.type)))
   },
-
-
 }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -49,7 +49,7 @@ export default {
   },
   data() {
     return {
-      productId: this.$route.params.id,
+      productId: this.$route.params.id,  // product_code or product_category
       product: null,
       productPriceList: [],
       productPriceTotal: null,
@@ -75,7 +75,7 @@ export default {
   methods: {
     getProduct() {
       if (!this.productIsCategory) {
-        return api.getProductById(this.productId)
+        return api.getProductByCode(this.productId)
           .then((data) => {
             if (data.id) {
               this.product = data
@@ -86,7 +86,7 @@ export default {
     getProductPrices() {
       this.loading = true
       this.productPricePage += 1
-      return api.getPrices({ [this.productIsCategory ? 'category_tag' : 'product_id']: this.productId, page: this.productPricePage })
+      return api.getPrices({ [this.productIsCategory ? 'category_tag' : 'product_code']: this.productId, page: this.productPricePage })
         .then((data) => {
           this.productPriceList.push(...data.items)
           this.productPriceTotal = data.total


### PR DESCRIPTION
### What

Thanks to https://github.com/openfoodfacts/open-prices/pull/106 we can now retrieve product info by code.

This change will simplify and clarify urls : 
- before `/products/12`
- after `/products/8001505005707`

Also improve display of unknown product (show card with product code)