### PR TITLE
feat(brand detail): new Brand detail page

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -11,7 +11,7 @@
 
           <p v-if="!hideProductDetails" class="mb-2">
             <span v-if="hasProductBrands">
-              <v-chip v-for="brand in getPriceProductBrandsList" label size="small" density="comfortable" class="mr-1">
+              <v-chip v-for="brand in getPriceProductBrandsList" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
                 {{ brand }}
               </v-chip>
             </span>
@@ -208,6 +208,12 @@ export default {
         return
       }
       this.$router.push({ path: `/products/${this.price.product_code || this.price.category_tag}` })
+    },
+    goToBrand(brand) {
+      if (this.readonly) {
+        return
+      }
+      this.$router.push({ path: `/brands/${brand}` })
     },
     goToLocation() {
       if (this.readonly) {

--- a/src/router.js
+++ b/src/router.js
@@ -10,6 +10,7 @@ import PriceList from './views/PriceList.vue'
 import ProductList from './views/ProductList.vue'
 import ProductDetail from './views/ProductDetail.vue'
 import LocationDetail from './views/LocationDetail.vue'
+import BrandDetail from './views/BrandDetail.vue'
 import UserDetail from './views/UserDetail.vue'
 import Stats from './views/Stats.vue'
 import NotFound from './views/NotFound.vue'
@@ -26,6 +27,7 @@ const routes = [
   { path: '/products', name: 'products', component: ProductList, meta: { title: 'Top products', icon: 'mdi-database-outline', drawerMenu: true }},
   { path: '/products/:id', name: 'product-detail', component: ProductDetail, meta: { title: 'Product detail' }},
   { path: '/locations/:id', name: 'location-detail', component: LocationDetail, meta: { title: 'Location detail' }},
+  { path: '/brands/:id', name: 'brand-detail', component: BrandDetail, meta: { title: 'Brand detail' }},
   { path: '/users/:username', name: 'user-detail', component: UserDetail, meta: { title: 'User detail' }},
   { path: '/stats', name: 'stats', component: Stats, meta: { title: 'Stats' }},
   { path: '/:path(.*)', component: NotFound },

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -1,0 +1,76 @@
+<template>
+  <v-row>
+    <v-col cols="12" sm="6">
+      <v-card
+        :title="brand"
+        prepend-icon="mdi-database-outline">
+      </v-card>
+    </v-col>
+  </v-row>
+
+  <v-row class="mt-0">
+    <v-col cols="12" sm="6">
+      <v-btn size="small" append-icon="mdi-open-in-new" :href="getBrandOFFUrl()" target="_blank">
+        Open Food Facts
+      </v-btn>
+    </v-col>
+  </v-row>
+
+  <br />
+
+  <h2 class="mb-1">
+    Top products
+    <small>{{ brandProductTotal }}</small>
+    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+  </h2>
+
+  <v-row>
+    <v-col cols="12" sm="6" md="4" v-for="product in brandProductList" :key="product">
+      <PriceCard :product="product" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="brandProductList.length < brandProductTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getBrandProducts">Load more</v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import api from '../services/api'
+import PriceCard from '../components/PriceCard.vue'
+
+export default {
+  components: {
+    PriceCard,
+  },
+  data() {
+    return {
+      brand: this.$route.params.id,
+      brandProductList: [],
+      brandProductTotal: null,
+      brandProductPage: 0,
+      loading: false,
+    }
+  },
+  mounted() {
+    this.getBrandProducts()
+  },
+  methods: {
+    getBrandProducts() {
+      this.loading = true
+      this.brandProductPage += 1
+      return api.getProducts({ brands__like: this.brand, unique_scans_n__gte: 1, order_by: '-unique_scans_n', page: this.brandProductPage })
+        .then((data) => {
+          this.brandProductList.push(...data.items)
+          this.brandProductTotal = data.total
+          this.loading = false
+        })
+    },
+    getBrandOFFUrl() {
+      return `https://world.openfoodfacts.org/brand/${this.brand}`
+    }
+  }
+}
+</script>

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -66,7 +66,7 @@ export default {
     getBrandProducts() {
       this.loading = true
       this.brandProductPage += 1
-      return api.getProducts({ brands__like: this.brand, unique_scans_n__gte: 1, order_by: '-unique_scans_n', page: this.brandProductPage })
+      return api.getProducts({ brands__like: this.brand, order_by: '-unique_scans_n', page: this.brandProductPage })
         .then((data) => {
           this.brandProductList.push(...data.items)
           this.brandProductTotal = data.total

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -47,7 +47,7 @@ export default {
   },
   data() {
     return {
-      brand: this.$route.params.id,
+      brand: null,  // see init
       brandProductList: [],
       brandProductTotal: null,
       brandProductPage: 0,
@@ -55,9 +55,14 @@ export default {
     }
   },
   mounted() {
-    this.getBrandProducts()
+    this.initBrand()
   },
   methods: {
+    initBrand() {
+      this.brand = this.$route.params.id
+      this.brandProductPage = 0
+      this.getBrandProducts()
+    },
     getBrandProducts() {
       this.loading = true
       this.brandProductPage += 1
@@ -70,6 +75,13 @@ export default {
     },
     getBrandOFFUrl() {
       return `https://world.openfoodfacts.org/brand/${this.brand}`
+    }
+  },
+  watch: {
+    $route (newBrand, oldBrand) {
+      if (oldBrand && newBrand && newBrand.name == 'brand-detail' && oldBrand.fullPath != newBrand.fullPath) {
+        this.initBrand()
+      }
     }
   }
 }


### PR DESCRIPTION
### What

For each product we have the `brands` info. And since #109 they are new split into different chips if there are multiple.

New page to display the brand's products
Accessible when clicking on a product's brand

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/f79f10aa-a5fb-411d-8bcc-34a91d5b77bf)

