### PR TITLE
feat(location detail): change url (osm type & id instead of id)

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -213,7 +213,7 @@ export default {
       if (this.readonly) {
         return
       }
-      this.$router.push({ path: `/locations/${this.price.location_id}` })
+      this.$router.push({ path: `/locations/${this.price.location_osm_type.toLowerCase()}/${this.price.location_osm_id}` })
     },
     goToUser() {
       if (this.readonly) {

--- a/src/router.js
+++ b/src/router.js
@@ -21,7 +21,7 @@ const routes = [
   { path: '/add/single', name: 'add-price-single', component: AddPriceSingle, meta: { title: 'Add a single price', requiresAuth: true }},
   { path: '/prices', name: 'prices', component: PriceList, meta: { title: 'Latest prices', icon: 'mdi-tag-multiple-outline', drawerMenu: true }},
   { path: '/products/:id', name: 'product-detail', component: ProductDetail, meta: { title: 'Product detail' }},
-  { path: '/locations/:id', name: 'location-detail', component: LocationDetail, meta: { title: 'Location detail' }},
+  { path: '/locations/:osmtype/:osmid', name: 'location-detail', component: LocationDetail, meta: { title: 'Location detail' }},
   { path: '/users/:username', name: 'user-detail', component: UserDetail, meta: { title: 'User detail' }},
   { path: '/stats', name: 'stats', component: Stats, meta: { title: 'Stats' }},
   { path: '/:path(.*)', component: NotFound },

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -103,6 +103,17 @@ export default {
     .then((response) => response.json())
   },
 
+  getLocationByOSMTypeAndId(locationOSMType, locationOSMId) {
+    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/locations/osm/${locationOSMType}/${locationOSMId}`
+    return fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    .then((response) => response.json())
+  },
+
   openfoodfactsProductSearch(code) {
     return fetch(`${OPENFOODFACTS_PRODUCT_URL}/${code}.json`, {
       method: 'GET',

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -9,13 +9,18 @@
     </v-col>
   </v-row>
 
-  <v-row class="mt-0" v-if="location">
-    <v-col cols="12" sm="6" v-if="location.osm_id">
-      <v-btn size="small" append-icon="mdi-open-in-new" :href="getLocationOSMUrl(location)" target="_blank">
+  <v-row class="mt-0">
+    <v-col cols="12" sm="6">
+      <v-btn size="small" append-icon="mdi-open-in-new" :href="getLocationOSMUrl()" target="_blank">
         OpenStreetMap
       </v-btn>
-      <p v-if="!location.osm_id" class="text-red">
-        <i>Location not found in OpenStreetMap... Don't hesitate to add it :)</i>
+    </v-col>
+  </v-row>
+
+  <v-row class="mt-0">
+    <v-col cols="12" sm="6">
+      <p v-if="!location" class="text-red">
+        <i>Location not found in our database...</i>
       </p>
     </v-col>
   </v-row>
@@ -88,8 +93,11 @@ export default {
       }
       return `${this.$route.params.osmtype} ${this.$route.params.osmid}`
     },
-    getLocationOSMUrl(location) {
-      return `https://www.openstreetmap.org/${location.osm_type.toLowerCase()}/${location.osm_id}`
+    getLocationOSMUrl() {
+      if (this.location) {
+        return `https://www.openstreetmap.org/${this.location.osm_type.toLowerCase()}/${this.location.osm_id}`
+      }
+      return `https://www.openstreetmap.org/${this.$route.params.osmtype.toLowerCase()}/${this.$route.params.osmid}`
     }
   }
 }

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -65,7 +65,7 @@ export default {
   },
   methods: {
     getLocation() {
-      return api.getLocationById(this.$route.params.id)
+      return api.getLocationByOSMTypeAndId(this.$route.params.osmtype, this.$route.params.osmid)
         .then((data) => {
           if (data.id) {
             this.location = data
@@ -75,7 +75,7 @@ export default {
     getLocationPrices() {
       this.loading = true
       this.locationPricePage += 1
-      return api.getPrices({ location_id: this.$route.params.id, page: this.locationPricePage })
+      return api.getPrices({ location_osm_type: this.$route.params.osmtype.toUpperCase(), location_osm_id: this.$route.params.osmid, page: this.locationPricePage })
         .then((data) => {
           this.locationPriceList.push(...data.items)
           this.locationPriceTotal = data.total
@@ -86,7 +86,7 @@ export default {
       if (location) {
         return utils.getLocationTitle(location, true)
       }
-      return this.$route.params.id
+      return `${this.$route.params.osmtype} ${this.$route.params.osmid}`
     },
     getLocationOSMUrl(location) {
       return `https://www.openstreetmap.org/${location.osm_type.toLowerCase()}/${location.osm_id}`


### PR DESCRIPTION
### What

Thanks to https://github.com/openfoodfacts/open-prices/pull/108 we can now retrieve product info by code.

This change will simplify and clarify urls : 
- before `/locations/1`
- after `/locations/node/652825274`

Also improve display of unknown location (show card with location type & id)