### PR TITLE
feat(price create form): hide currency selector

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -34,7 +34,6 @@ export default {
   createPrice(priceData) {
     const store = useAppStore()
     store.user.last_product_mode_used = priceData.product_code ? 'barcode' : 'category'
-    store.setLastCurrencyUsed(priceData.currency)
     return fetch(`${import.meta.env.VITE_OPEN_PRICES_API_URL}/prices`, {
       method: 'POST',
       headers: {

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -81,21 +81,14 @@
           <v-card-text>
             <h3 class="mb-1">Price <span v-if="productMode === 'category'">per kg</span></h3>
             <v-row>
-              <v-col cols="6">
+              <v-col cols="12" sm="6">
                 <v-text-field
                   v-model="addPriceSingleForm.price"
                   label="Price"
                   type="number"
                   hide-details="auto"
+                  :suffix="addPriceSingleForm.currency"
                 ></v-text-field>
-              </v-col>
-              <v-col cols="6">
-                <v-autocomplete
-                  v-model="addPriceSingleForm.currency"
-                  label="Currency"
-                  :items="currencyList"
-                  hide-details="auto"
-                ></v-autocomplete>
               </v-col>
             </v-row>
             <v-row>
@@ -194,7 +187,6 @@
 import Compressor from 'compressorjs'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
-import constants from '../constants'
 import api from '../services/api'
 import utils from '../utils.js'
 import PriceCard from '../components/PriceCard.vue'
@@ -243,8 +235,6 @@ export default {
       originsTags: OriginsTags,  // list of origins tags for autocomplete
       labelsTags: LabelsTags,
       barcodeScanner: false,
-      // price data
-      currencyList: constants.CURRENCY_LIST,
       // location data
       locationSelector: false,
       locationSelectedDisplayName: '',

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -14,7 +14,6 @@
               v-model="userSettingsForm.currency"
               label="Currency"
               :items="currencyList"
-              hide-details="auto"
             ></v-autocomplete>
           </v-card-text>
         </v-card>


### PR DESCRIPTION
### What

Following #121 the currency is now editable in the user settings.
We can hide it in the price create form, and display it as a suffix in the price field.

### Screenshots

||Image|
|---|---|
|Before|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/3622d6af-9882-4058-832a-020474b176f0)|
|After|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/8e14a854-aee3-4557-bbc3-479c38b21157)|