### PR TITLE
feat(product list): add order button to toggle between scan & price count

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -12,11 +12,11 @@
           <v-btn v-bind="props" icon="mdi-account-circle"></v-btn>
         </template>
         <v-list>
-          <v-list-item slim="true" prepend-icon="mdi-account" disabled>{{ username }}</v-list-item>
+          <v-list-item :slim="true" prepend-icon="mdi-account" disabled>{{ username }}</v-list-item>
           <v-divider></v-divider>
-          <v-list-item slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard">Dashboard</v-list-item>
-          <v-list-item slim="true" prepend-icon="mdi-cog-outline" to="/settings">Settings</v-list-item>
-          <v-list-item slim="true" prepend-icon="mdi-logout" @click="signOut">Sign out</v-list-item>
+          <v-list-item :slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard">Dashboard</v-list-item>
+          <v-list-item :slim="true" prepend-icon="mdi-cog-outline" to="/settings">Settings</v-list-item>
+          <v-list-item :slim="true" prepend-icon="mdi-logout" @click="signOut">Sign out</v-list-item>
         </v-list>
       </v-menu>
     </template>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -12,11 +12,11 @@
           <v-btn v-bind="props" icon="mdi-account-circle"></v-btn>
         </template>
         <v-list>
-          <v-list-item prepend-icon="mdi-account" disabled>{{ username }}</v-list-item>
+          <v-list-item slim="true" prepend-icon="mdi-account" disabled>{{ username }}</v-list-item>
           <v-divider></v-divider>
-          <v-list-item prepend-icon="mdi-view-dashboard-outline" to="/dashboard">Dashboard</v-list-item>
-          <v-list-item prepend-icon="mdi-cog-outline" to="/settings">Settings</v-list-item>
-          <v-list-item prepend-icon="mdi-logout" @click="signOut">Sign out</v-list-item>
+          <v-list-item slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard">Dashboard</v-list-item>
+          <v-list-item slim="true" prepend-icon="mdi-cog-outline" to="/settings">Settings</v-list-item>
+          <v-list-item slim="true" prepend-icon="mdi-logout" @click="signOut">Sign out</v-list-item>
         </v-list>
       </v-menu>
     </template>

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -5,7 +5,7 @@
 
     <v-menu v-if="!loading">
       <template v-slot:activator="{ props }">
-        <v-btn v-bind="props" size="small" prepend-icon="mdi-order-bool-ascending">Order</v-btn>
+        <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentProductOrderIcon">Order</v-btn>
       </template>
       <v-list>
         <v-list-item :slim="true" v-for="order in productOrderList" :key="order.key" :prepend-icon="order.icon" :active="productOrder === order.key" @click="selectProductOrder(order.key)">
@@ -51,6 +51,12 @@ export default {
   },
   mounted() {
     this.initProductList()
+  },
+  computed: {
+    getCurrentProductOrderIcon() {
+      let currentProductOrder = this.productOrderList.find(o => o.key === this.productOrder)
+      return currentProductOrder ? currentProductOrder.icon : ''
+    }
   },
   methods: {
     initProductList() {

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -1,8 +1,18 @@
 <template>
   <h1 class="mb-1">
     Top products
-    <span class="text-caption">by popularity</span>
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+
+    <v-menu v-if="!loading">
+      <template v-slot:activator="{ props }">
+        <v-btn v-bind="props" size="small" prepend-icon="mdi-order-bool-ascending">Order</v-btn>
+      </template>
+      <v-list>
+        <v-list-item :slim="true" v-for="order in productOrderList" :key="order.key" :prepend-icon="order.icon" :active="productOrder === order.key" @click="selectProductOrder(order.key)">
+          {{ order.value }}
+        </v-list-item>
+      </v-list>
+    </v-menu>
   </h1>
 
   <v-row>
@@ -28,6 +38,11 @@ export default {
   },
   data() {
     return {
+      productOrder: '-unique_scans_n',
+      productOrderList: [
+        {key: '-unique_scans_n', value: 'Number of scans', icon: 'mdi-barcode-scan'},
+        {key: '-price_count', value: 'Number of prices', icon: 'mdi-tag-multiple-outline'},
+      ],
       productList: [],
       productTotal: null,
       productPage: 0,
@@ -35,18 +50,29 @@ export default {
     }
   },
   mounted() {
-    this.getProducts()
+    this.initProductList()
   },
   methods: {
+    initProductList() {
+      this.productList = []
+      this.productPage = 0
+      this.getProducts()
+    },
     getProducts() {
       this.loading = true
       this.productPage += 1
-      return api.getProducts({ page: this.productPage, order_by: '-unique_scans_n' })
+      return api.getProducts({ page: this.productPage, order_by: `${this.productOrder}` })
         .then((data) => {
           this.productList.push(...data.items)
           this.productTotal = data.total
           this.loading = false
         })
+    },
+    selectProductOrder(orderKey) {
+      if (this.productOrder !== orderKey) {
+        this.productOrder = orderKey
+        this.initProductList()
+      }
     }
   }
 }


### PR DESCRIPTION
### What

Allow ordering the top products by "Number of prices" (was "popularity" = "number of scans" by default before)

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/7e463ded-59db-426f-b4c4-69886689a909)
