### PR TITLE
feat(price create form): on barcode scan, fetch product details from OP (instead of OFF)

### DIFF
--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -378,12 +378,12 @@ export default {
       this.addPriceSingleForm.product_code = code
       this.product = null
       api
-        .openfoodfactsProductSearch(code)
+        .getProductByCode(code)
         .then((data) => {
-          this.product = data['product'] || {'code': code}
+          this.product = data.id ? data : {'code': code}
         })
         .catch((error) => {
-          alert("Error: Open Food Facts server error")
+          alert("Error: Open Prices server error")
         })
     },
     showLocationSelector() {


### PR DESCRIPTION
### What

In the price create form, when a user scans a product, we currently fetch data from OFF (see #73).

But we now have all the products in OP + their `price_count` - which is an interesting info to display to the users.

So we switch the API call :)

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/579c3ffc-5c89-41de-98da-82c9c3c26482)
