### PR TITLE
feat(location list): new location list page ordered by price_count

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,7 @@ import AddPriceSingle from './views/AddPriceSingle.vue'
 import PriceList from './views/PriceList.vue'
 import ProductList from './views/ProductList.vue'
 import ProductDetail from './views/ProductDetail.vue'
+import LocationList from './views/LocationList.vue'
 import LocationDetail from './views/LocationDetail.vue'
 import BrandDetail from './views/BrandDetail.vue'
 import UserDetail from './views/UserDetail.vue'
@@ -24,8 +25,9 @@ const routes = [
   { path: '/add', name: 'add-price', component: AddPriceHome, meta: { title: 'Add a price', icon: 'mdi-plus', drawerMenu: true, requiresAuth: true }},
   { path: '/add/single', name: 'add-price-single', component: AddPriceSingle, meta: { title: 'Add a single price', requiresAuth: true }},
   { path: '/prices', name: 'prices', component: PriceList, meta: { title: 'Latest prices', icon: 'mdi-tag-multiple-outline', drawerMenu: true }},
-  { path: '/products', name: 'products', component: ProductList, meta: { title: 'Top products', icon: 'mdi-database-outline', drawerMenu: true }},
+  { path: '/products', name: 'products', component: ProductList, meta: { title: 'Top products', icon: 'mdi-medal-outline', drawerMenu: true }},
   { path: '/products/:id', name: 'product-detail', component: ProductDetail, meta: { title: 'Product detail' }},
+  { path: '/locations', name: 'locations', component: LocationList, meta: { title: 'Top locations', icon: 'mdi-medal-outline', drawerMenu: true }},
   { path: '/locations/:id', name: 'location-detail', component: LocationDetail, meta: { title: 'Location detail' }},
   { path: '/brands/:id', name: 'brand-detail', component: BrandDetail, meta: { title: 'Brand detail' }},
   { path: '/users/:username', name: 'user-detail', component: UserDetail, meta: { title: 'User detail' }},

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -1,0 +1,86 @@
+<template>
+  <h1 class="mb-1">
+    Top locations
+    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+  </h1>
+
+  <v-row>
+    <v-col cols="12" sm="6" md="4" v-for="location in locationList" :key="location">
+      <v-card
+        :title="getLocationTitle(location)"
+        :subtitle="location.osm_display_name"
+        prepend-icon="mdi-map-marker-outline"
+        elevation="1"
+        height="100%"
+        @click="goToLocation(location)">
+        <v-card-text>
+          <v-chip label size="small" density="comfortable" :color="getLocationPriceCountColor(location)" class="mr-1">
+            <v-icon start icon="mdi-tag-outline"></v-icon>
+            {{ location.price_count }} prices
+          </v-chip>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="locationList.length < locationTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getLocations">Load more</v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import api from '../services/api'
+import utils from '../utils.js'
+
+export default {
+  data() {
+    return {
+      // data
+      locationList: [],
+      locationTotal: null,
+      locationPage: 0,
+      loading: false,
+    }
+  },
+  computed: {},
+  mounted() {
+    this.initLocationList()
+  },
+  methods: {
+    initLocationList() {
+      this.locationList = []
+      this.locationPage = 0
+      this.getLocations()
+    },
+    getLocations() {
+      this.loading = true
+      this.locationPage += 1
+      return api.getLocations({ order_by: '-price_count', page: this.locationPage })
+        .then((data) => {
+          this.locationList.push(...data.items)
+          this.locationTotal = data.total
+          this.loading = false
+        })
+    },
+    getLocationTitle(location) {
+      return utils.getLocationTitle(location, true, false, true, true)
+    },
+    getLocationPriceCountColor(location) {
+      if (location.price_count === 0) {
+        return 'error'
+      }
+      if (location.price_count === 1) {
+        return 'warning'
+      }
+      if (location.price_count > 1) {
+        return 'success'
+      }
+    },
+    goToLocation(location) {
+      this.$router.push({ path: `/locations/${location.id}` })
+    },
+  }
+}
+</script>


### PR DESCRIPTION
### What

Similar to #113
Following #138 
And thanks to https://github.com/openfoodfacts/open-prices/pull/140 we now have a new field `Location.price_count`

Creation of a new `/locations` page ordered by price count
This page is accessible from the left drawer