### PR TITLE
feat(user list): new user list page ordered by price_count

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,7 @@ import ProductDetail from './views/ProductDetail.vue'
 import LocationList from './views/LocationList.vue'
 import LocationDetail from './views/LocationDetail.vue'
 import BrandDetail from './views/BrandDetail.vue'
+import UserList from './views/UserList.vue'
 import UserDetail from './views/UserDetail.vue'
 import Stats from './views/Stats.vue'
 import NotFound from './views/NotFound.vue'
@@ -30,6 +31,7 @@ const routes = [
   { path: '/locations', name: 'locations', component: LocationList, meta: { title: 'Top locations', icon: 'mdi-medal-outline', drawerMenu: true }},
   { path: '/locations/:id', name: 'location-detail', component: LocationDetail, meta: { title: 'Location detail' }},
   { path: '/brands/:id', name: 'brand-detail', component: BrandDetail, meta: { title: 'Brand detail' }},
+  { path: '/users', name: 'users', component: UserList, meta: { title: 'Top contributors', icon: 'mdi-medal-outline', drawerMenu: true }},
   { path: '/users/:username', name: 'user-detail', component: UserDetail, meta: { title: 'User detail' }},
   { path: '/stats', name: 'stats', component: Stats, meta: { title: 'Stats' }},
   { path: '/:path(.*)', component: NotFound },

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -56,7 +56,7 @@ export default {
     getUsers() {
       this.loading = true
       this.userPage += 1
-      return api.getUsers({ order_by: '-price_count', page: this.userPage })
+      return api.getUsers({ price_count__gte: 1, order_by: '-price_count', page: this.userPage })
         .then((data) => {
           this.userList.push(...data.items)
           this.userTotal = data.total

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -1,0 +1,85 @@
+<template>
+  <h1 class="mb-1">
+    Top contributors
+    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+  </h1>
+
+  <v-row>
+    <v-col cols="12" sm="6" md="4" v-for="user in userList" :key="user">
+      <v-card
+        :title="user.user_id"
+        prepend-icon="mdi-account"
+        elevation="1"
+        height="100%"
+        @click="goToUser(user)">
+        <v-card-text>
+          <v-chip label size="small" density="comfortable" :color="getUserPriceCountColor(user)" class="mr-1">
+            <v-icon start icon="mdi-tag-outline"></v-icon>
+            {{ user.price_count }} prices
+          </v-chip>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="userList.length < userTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" @click="getUsers">Load more</v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import api from '../services/api'
+import utils from '../utils.js'
+
+export default {
+  data() {
+    return {
+      // data
+      userList: [],
+      userTotal: null,
+      userPage: 0,
+      loading: false,
+    }
+  },
+  computed: {},
+  mounted() {
+    this.initUserList()
+  },
+  methods: {
+    initUserList() {
+      this.userList = []
+      this.userPage = 0
+      this.getUsers()
+    },
+    getUsers() {
+      this.loading = true
+      this.userPage += 1
+      return api.getUsers({ order_by: '-price_count', page: this.userPage })
+        .then((data) => {
+          this.userList.push(...data.items)
+          this.userTotal = data.total
+          this.loading = false
+        })
+    },
+    getUserTitle(user) {
+      return utils.getUserTitle(user, true, false, true, true)
+    },
+    getUserPriceCountColor(user) {
+      if (user.price_count === 0) {
+        return 'error'
+      }
+      if (user.price_count === 1) {
+        return 'warning'
+      }
+      if (user.price_count > 1) {
+        return 'success'
+      }
+    },
+    goToUser(user) {
+      this.$router.push({ path: `/users/${user.id}` })
+    },
+  }
+}
+</script>


### PR DESCRIPTION
### What

Similar to #113 & #145
Following #148
And thanks to https://github.com/openfoodfacts/open-prices/pull/143 we now have a new field `User.price_count`

Creation of a new `/users` page ordered by price count (only users with at least 1 price)
This page is accessible from the left drawer