### PR TITLE
feat(price create form): allow typing the barcode manually

### DIFF
--- a/src/components/BarcodeManualInput.vue
+++ b/src/components/BarcodeManualInput.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-dialog persistent>
+    <v-card>
+      <v-card-title>
+        {{ $t('BarcodeManualInput.Title') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+      </v-card-title>
+
+      <v-divider></v-divider>
+
+      <v-form @submit.prevent="onSubmit">
+        <v-card-text>
+          <v-text-field
+            v-model="barcodeForm.barcode"
+            :label="$t('BarcodeManualInput.Barcode')"
+            type="input"
+            prepend-inner-icon="mdi-barcode"
+            :hint="barcodeForm.barcode.length.toString()"
+            persistent-hint
+          ></v-text-field>
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-text>
+          <v-btn
+            type="submit"
+            class="mt-2"
+            :disabled="!formFilled"
+          >{{ $t('BarcodeManualInput.Submit') }}</v-btn>
+        </v-card-text>
+      </v-form>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      barcodeForm: {
+        barcode: '',
+      }
+    }
+  },
+  computed: {
+    formFilled() {
+      return Object.values(this.barcodeForm).every(x => !!x)
+    }
+  },
+  mounted() {
+  },
+  methods: {
+    onSubmit() {
+      this.$emit('barcode', this.barcodeForm.barcode)
+      this.close()
+    },
+    close() {
+      this.$emit('close')
+    },
+  }
+}
+</script>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -30,7 +30,7 @@
 			"OriginLabel": "Origin",
 			"ProductCode": "Product code",
 			"ScanBarcode": "Scan a barcode",
-			"TypeBarcode": "Type the barcode",
+			"TypeBarcode": "Type a barcode",
 			"SetProduct": "Set a product",
 			"Title": "Product info"
 		},
@@ -57,7 +57,7 @@
 	"BarcodeManualInput": {
 		"Barcode": "Barcode",
 		"Submit": "Submit",
-		"Title": "Enter a barcode"
+		"Title": "Type a barcode"
 	},
 	"BrandDetail": {
 		"LoadMore": "Load more",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -30,6 +30,7 @@
 			"OriginLabel": "Origin",
 			"ProductCode": "Product code",
 			"ScanBarcode": "Scan a barcode",
+			"TypeBarcode": "Type the barcode",
 			"SetProduct": "Set a product",
 			"Title": "Product info"
 		},
@@ -52,6 +53,11 @@
 			"Text": "powered by {url}"
 		},
 		"Scan": "Scan a barcode"
+	},
+	"BarcodeManualInput": {
+		"Barcode": "Barcode",
+		"Submit": "Submit",
+		"Title": "Enter a barcode"
 	},
 	"BrandDetail": {
 		"LoadMore": "Load more",

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -24,7 +24,8 @@
               </v-item-group>
             </h3>
             <v-sheet v-if="productMode === 'barcode'">
-              <v-btn class="mb-2" size="small" prepend-icon="mdi-barcode-scan" @click="showBarcodeScanner">{{ $t('AddPriceSingle.ProductInfo.ScanBarcode') }}</v-btn>
+              <v-btn class="mb-2 mr-2" size="small" prepend-icon="mdi-barcode-scan" @click="showBarcodeScanner">{{ $t('AddPriceSingle.ProductInfo.ScanBarcode') }}</v-btn>
+              <a href="#" @click.prevent="showBarcodeManualInput">{{ $t('AddPriceSingle.ProductInfo.TypeBarcode') }}</a>
               <v-text-field
                 v-if="dev"
                 :prepend-inner-icon="productBarcodeFormFilled ? 'mdi-barcode' : 'mdi-barcode-scan'"
@@ -189,6 +190,13 @@
     @close="barcodeScanner = false"
   ></BarcodeScanner>
 
+  <BarcodeManualInput
+    v-if="barcodeManualInput"
+    v-model="barcodeManualInput"
+    @barcode="setProductCode($event)"
+    @close="barcodeManualInput = false"
+  ></BarcodeManualInput>
+
   <LocationSelector
     v-if="locationSelector"
     v-model="locationSelector"
@@ -205,6 +213,7 @@ import api from '../services/api'
 import utils from '../utils.js'
 import ProductCard from '../components/ProductCard.vue'
 import BarcodeScanner from '../components/BarcodeScanner.vue'
+import BarcodeManualInput from '../components/BarcodeManualInput.vue'
 import LocationSelector from '../components/LocationSelector.vue'
 import CategoryTags from '../data/category-tags.json'
 import OriginsTags from '../data/origins-tags.json'
@@ -222,6 +231,7 @@ export default {
   components: {
     ProductCard,
     BarcodeScanner,
+    BarcodeManualInput,
     LocationSelector
   },
   data() {
@@ -249,6 +259,7 @@ export default {
       originsTags: OriginsTags,  // list of origins tags for autocomplete
       labelsTags: LabelsTags,
       barcodeScanner: false,
+      barcodeManualInput: false,
       // location data
       locationSelector: false,
       locationSelectedDisplayName: '',
@@ -387,6 +398,9 @@ export default {
     },
     showBarcodeScanner() {
       this.barcodeScanner = true
+    },
+    showBarcodeManualInput() {
+      this.barcodeManualInput = true
     },
     setProductCode(code) {
       this.addPriceSingleForm.product_code = code


### PR DESCRIPTION
### What

Add a link next to the barcode scan button, that allows entering the barcode manually

Why a popup ? So that we can fetch the product details on submit

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/96b099dc-609b-4e66-97db-de4f7f88dff5)
