### PR TITLE
feat(price create form): init form with code param from product detail CTA

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -120,6 +120,7 @@
 		"UnknownProduct": "Unknown product name"
 	},
 	"ProductDetail": {
+		"AddPrice": "Add a price",
 		"CategoryNotFound": "Category not found...",
 		"LatestPrices": "Latest prices",
 		"LoadMore": "Load more",

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -307,6 +307,9 @@ export default {
     },
   },
   mounted() {
+    if (this.$route.query.code) {
+      this.setProductCode(this.$route.query.code)
+    }
     this.initPriceSingleForm()
   },
   methods: {
@@ -317,7 +320,7 @@ export default {
       /**
        * init product mode, currency & last location
        */
-      this.productMode = this.appStore.user.last_product_mode_used
+      this.productMode = this.addPriceSingleForm.product_code ? 'barcode' : this.appStore.user.last_product_mode_used
       this.addPriceSingleForm.currency = this.appStore.user.last_currency_used
       if (this.recentLocations.length) {
         this.setLocationData(this.recentLocations[0])

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -8,7 +8,7 @@
 
   <v-row class="mt-0" v-if="!productNotFound">
     <v-col cols="12">
-      <v-btn class="mr-2" size="small" color="primary" prepend-icon="mdi-plus" to="/add">Add a price</v-btn>
+      <v-btn class="mr-2" size="small" color="primary" prepend-icon="mdi-plus" :to="'/add/single?code=' + product.code">{{ $t('ProductDetail.AddPrice') }}</v-btn>
       <v-btn v-if="product.code && product.source" size="small" append-icon="mdi-open-in-new" :href="getProductOFFUrl(product)" target="_blank">
         Open Food Facts
       </v-btn>


### PR DESCRIPTION
### What

When clicking on "Add a price" in the product detail page, the price create form is now initialisez with the corresponding product code

### How

By passing the code as a URL param
`/add/single?code=8001505005592`