### PR TITLE
fix(crowdin): change config to simplify PR from crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,6 +2,8 @@ project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 pull_request_title: "feat(l10n): New Crowdin translations to review and merge"
 pull_request_body: '### What\n- Automated pull request pulling in new or updated translations from Crowdin (https://translate.openfoodfacts.org).\n## Checklist\n- [ ] Check that they are no bad translations. If there are, correct them directly in Crowdin so that they are not resynced again. Then you can correct them here as well, or wait 24 hours for the sync to happen automatically.\n- [ ] Put extra attention on Acholi, which is used mistakenly as a sandbox by people discovering the self-service translation button on Open Food Facts\n- [ ] Once you are happy, that automated checks pass, you can approve the PR and merge it.\n### Part of\n- Translations' 
+commit_message: "[ci skip] New translations from Crowdin"
+append_commit_message: false
 files:
   - source: /src/i18n/locales/en.json
     translation: /src/i18n/locales/%two_letters_code%.json


### PR DESCRIPTION
### What
- Replace commit message from crowdin with the same message. This should simplify a squash to only display this message
- Added [ci skip] tag to not trigger a build for each commit

https://developer.crowdin.com/configuration-file/
