### PR TITLE
feat(PWA): improve manifest configuration

### DIFF
--- a/.env.preprod
+++ b/.env.preprod
@@ -1,4 +1,4 @@
 VITE_OPEN_PRICES_API_URL = "https://prices.openfoodfacts.net/api/v1"
-VITE_MANIFEST_PATH = "/app/manifest.json"
+VITE_MANIFEST_PATH = "/app/manifest.preprod.json"
 VITE_DEFAULT_LOCALE = en
 VITE_FALLBACK_LOCALE = en

--- a/.env.prod
+++ b/.env.prod
@@ -1,4 +1,4 @@
 VITE_OPEN_PRICES_API_URL = "https://prices.openfoodfacts.org/api/v1"
-VITE_MANIFEST_PATH = "/app/manifest.json"
+VITE_MANIFEST_PATH = "/app/manifest.prod.json"
 VITE_DEFAULT_LOCALE = en
 VITE_FALLBACK_LOCALE = en

--- a/public/manifest.local.json
+++ b/public/manifest.local.json
@@ -1,6 +1,6 @@
 {
     "name": "Open Prices (Local)",
-    "short_name": "Open Prices (Local)",
+    "short_name": "OpenPrices (Local)",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",

--- a/public/manifest.preprod.json
+++ b/public/manifest.preprod.json
@@ -1,6 +1,6 @@
 {
     "name": "Open Prices (Preprod)",
-    "short_name": "Open Prices (Preprod)",
+    "short_name": "OpenPrices (Preprod)",
     "icons": [
         {
             "src": "/app/android-chrome-192x192.png",

--- a/public/manifest.preprod.json
+++ b/public/manifest.preprod.json
@@ -1,6 +1,6 @@
 {
-    "name": "Open Prices",
-    "short_name": "Open Prices",
+    "name": "Open Prices (Preprod)",
+    "short_name": "Open Prices (Preprod)",
     "icons": [
         {
             "src": "/app/android-chrome-192x192.png",
@@ -15,6 +15,7 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "start_url": "/app/",
+    "scope": "https://prices.openfoodfacts.net/app/",
+    "start_url": "https://prices.openfoodfacts.net/app",
     "display": "standalone"
 }

--- a/public/manifest.prod.json
+++ b/public/manifest.prod.json
@@ -1,20 +1,21 @@
 {
-    "name": "Open Prices (Local)",
-    "short_name": "Open Prices (Local)",
+    "name": "Open Prices",
+    "short_name": "Open Prices",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/app/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "/app/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "start_url": "/",
+    "scope": "https://prices.openfoodfacts.com/app/",
+    "start_url": "https://prices.openfoodfacts.com/app",
     "display": "standalone"
 }

--- a/public/manifest.prod.json
+++ b/public/manifest.prod.json
@@ -1,6 +1,6 @@
 {
     "name": "Open Prices",
-    "short_name": "Open Prices",
+    "short_name": "OpenPrices",
     "icons": [
         {
             "src": "/app/android-chrome-192x192.png",


### PR DESCRIPTION
### What

Following #93 

- split prod & preprod manifest configuration
- improved the manifest config by adding a `scope`. Hopefully this will help with external links.
- also reduced the name to `OpenPrices` to match with the `OpenFoodFacts` android app name.
