### PR TITLE
feat(price card): allow displaying price proofs (if is public)

### DIFF
--- a/src/components/PriceFooter.vue
+++ b/src/components/PriceFooter.vue
@@ -5,22 +5,30 @@
       {{ getPriceLocationTitle() }}
       <span v-if="priceLocationEmoji" style="margin-inline-start:5px">{{ priceLocationEmoji }}</span>
     </v-chip>
+
     <v-chip class="mr-1" label size="small" density="comfortable" @click="goToUser()">
       <v-icon start icon="mdi-account"></v-icon>
       {{ price.owner }}
     </v-chip>
-    <v-chip label size="small" density="comfortable">
+
+    <v-chip class="mr-1" label size="small" density="comfortable">
       <v-icon start icon="mdi-clock-outline"></v-icon>
       {{ getRelativeDateTimeFormatted(price.created) }}
       <v-tooltip activator="parent" location="top">{{ getDateTimeFormatted(price.created) }}</v-tooltip>
     </v-chip>
+
+    <PriceProof v-if="price.proof && price.proof.is_public" :proof="price.proof"></PriceProof>
   </div>
 </template>
 
 <script>
 import utils from '../utils.js'
+import PriceProof from '../components/PriceProof.vue'
 
 export default {
+  components: {
+    PriceProof
+  },
   props: {
     'price': null,
     'hidePriceLocation': false,

--- a/src/components/PriceProof.vue
+++ b/src/components/PriceProof.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-chip
+    style="padding-left:5px;padding-right:5px"
+    label
+    size="small"
+    density="comfortable"
+    :title="$t('PriceCard.Proof')"
+    @click="openDialog">
+    <v-icon icon="mdi-image"></v-icon>
+  </v-chip>
+
+  <v-dialog v-model="dialog" max-height="80%" width="80%">
+    <v-card>
+      <v-card-title>
+        {{ $t('PriceCard.Proof') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="closeDialog"></v-btn>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text>
+        <v-img :src="proofUrl"></v-img>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  props: {
+    'proof': null,
+    'readonly': false
+  },
+  data() {
+    return {
+      dialog: false
+    }
+  },
+  computed: {
+    proofIcon() {
+      if (this.proof.type === 'PRICE_TAG') {
+        return 'mdi-tag-outline'
+      }
+      else if (this.proof.type === 'RECEIPT') {
+        return 'mdi-receipt-text-outline'
+      }
+    },
+    proofUrl() {
+      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.file_path}`
+    }
+  },
+  methods: {
+    openDialog() {
+      this.dialog = true
+    },
+    closeDialog() {
+      this.dialog = false
+    }
+  }
+}
+</script>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -144,6 +144,7 @@
 		"Discount": "Discount",
 		"PriceDate": "on {date}",
 		"PriceValueDisplay": "{0} / kg",
+		"Proof": "Proof",
 		"ProductQuantity": "{0} g",
 		"FullPrice": "Full price",
 		"UnknownProduct": "Unknown product"


### PR DESCRIPTION
### What

Allow users to display price proofs

### Screenshot

|Price card|Proof dialog|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/ba114f78-8c68-4e28-abd8-68d782bc8eae)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/625b3c82-3d1f-4e50-8fc9-e6a355727d9d)|

