### PR TITLE
feat: improve price discount (full_price not mandatory anymore)

### DIFF
--- a/src/components/PricePrice.vue
+++ b/src/components/PricePrice.vue
@@ -2,10 +2,10 @@
   <p>
     <span class="mr-1">{{ getPriceValueDisplay(priceValue) }}</span>
     <span v-if="hasProductQuantity" class="mr-1">({{ getPricePerKilo() }})</span>
-    <span v-if="priceWithoutDiscountValue">
+    <span v-if="price.price_is_discounted">
       <v-chip class="mr-1" color="red" variant="outlined" size="small" density="comfortable">
         {{ $t('PriceCard.Discount') }}
-        <v-tooltip activator="parent" location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(priceWithoutDiscountValue) }}</v-tooltip>
+        <v-tooltip v-if="priceWithoutDiscountValue" activator="parent" location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(priceWithoutDiscountValue) }}</v-tooltip>
       </v-chip>
     </span>
     <i18n-t v-if="!hidePriceDate" keypath="PriceCard.PriceDate" tag="span">

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -207,16 +207,16 @@
             </i18n-t>
           </h3>
           <v-row>
-            <v-col :cols="priceDiscounted ? '6' : '12'" sm="6">
+            <v-col :cols="productPriceForm.price_is_discounted ? '6' : '12'" sm="6">
               <v-text-field
                 v-model="productPriceForm.price"
-                :label="priceDiscounted ? $t('AddPriceSingle.PriceDetails.LabelDiscounted') : $t('AddPriceSingle.PriceDetails.Label')"
+                :label="productPriceForm.price_is_discounted ? $t('AddPriceSingle.PriceDetails.LabelDiscounted') : $t('AddPriceSingle.PriceDetails.Label')"
                 type="number"
                 hide-details="auto"
                 :suffix="productPriceForm.currency"
               ></v-text-field>
             </v-col>
-            <v-col v-if="priceDiscounted" cols="6">
+            <v-col v-if="productPriceForm.price_is_discounted" cols="6">
               <v-text-field
                 v-model="productPriceForm.price_without_discount"
                 :label="$t('AddPriceSingle.PriceDetails.LabelFull')"
@@ -227,7 +227,7 @@
             </v-col>
           </v-row>
           <div class="d-inline">
-            <v-checkbox v-model="priceDiscounted" :label="$t('AddPriceSingle.PriceDetails.Discount')" hide-details="auto"></v-checkbox>
+            <v-checkbox v-model="productPriceForm.price_is_discounted" :label="$t('AddPriceSingle.PriceDetails.Discount')" hide-details="auto"></v-checkbox>
           </div>
         </v-card-text>
         <v-divider></v-divider>
@@ -357,6 +357,7 @@ export default {
         origins_tags: '',
         labels_tags: [],
         price: null,
+        price_is_discounted: false,
         price_without_discount: null,
         currency: null,  // see initPriceMultipleForm
         uploaded: false
@@ -372,7 +373,6 @@ export default {
       labelsTags: LabelsTags,
       barcodeScanner: false,
       barcodeManualInput: false,
-      priceDiscounted: false,
     }
   },
   computed: {
@@ -408,12 +408,7 @@ export default {
     },
     priceFormFilled() {
       let keys = ['price', 'currency']
-      if (!this.priceDiscounted) {
-        return Object.keys(this.productPriceForm).filter(k => keys.includes(k)).every(k => !!this.productPriceForm[k])
-      } else {
-        keys.push('price_without_discount')
-        return Object.keys(this.productPriceForm).filter(k => keys.includes(k)).every(k => !!this.productPriceForm[k])
-      }
+      return Object.keys(this.productPriceForm).filter(k => keys.includes(k)).every(k => !!this.productPriceForm[k])
     },
     productPriceFormFilled() {
       return this.productFormFilled && this.priceFormFilled
@@ -522,7 +517,6 @@ export default {
     clearProductPriceForm() {
       this.productPriceForm = {}
       this.product = null
-      this.priceDiscounted = false
     },
     initNewProductPriceForm() {
       this.clearProductPriceForm()
@@ -544,7 +538,7 @@ export default {
       if (this.productPriceForm.labels_tags.length == 0) {
         this.productPriceForm.labels_tags = null
       }
-      if (!this.priceDiscounted) {
+      if (!this.productPriceForm.price_is_discounted) {
         this.productPriceForm.price_without_discount = null
       }
       // create price

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -102,16 +102,16 @@
               </i18n-t>
             </h3>
             <v-row>
-              <v-col :cols="priceDiscounted ? '6' : '12'" sm="6">
+              <v-col :cols="addPriceSingleForm.price_is_discounted ? '6' : '12'" sm="6">
                 <v-text-field
                   v-model="addPriceSingleForm.price"
-                  :label="priceDiscounted ? $t('AddPriceSingle.PriceDetails.LabelDiscounted') : $t('AddPriceSingle.PriceDetails.Label')"
+                  :label="addPriceSingleForm.price_is_discounted ? $t('AddPriceSingle.PriceDetails.LabelDiscounted') : $t('AddPriceSingle.PriceDetails.Label')"
                   type="number"
                   hide-details="auto"
                   :suffix="addPriceSingleForm.currency"
                 ></v-text-field>
               </v-col>
-              <v-col v-if="priceDiscounted" cols="6">
+              <v-col v-if="addPriceSingleForm.price_is_discounted" cols="6">
                 <v-text-field
                   v-model="addPriceSingleForm.price_without_discount"
                   :label="$t('AddPriceSingle.PriceDetails.LabelFull')"
@@ -122,7 +122,7 @@
               </v-col>
             </v-row>
             <div class="d-inline">
-              <v-checkbox v-model="priceDiscounted" :label="$t('AddPriceSingle.PriceDetails.Discount')" hide-details="auto"></v-checkbox>
+              <v-checkbox v-model="addPriceSingleForm.price_is_discounted" :label="$t('AddPriceSingle.PriceDetails.Discount')" hide-details="auto"></v-checkbox>
             </div>
             <h3 class="mt-4 mb-1">{{ $t('AddPriceSingle.PriceDetails.Proof') }}</h3>
             <v-row>
@@ -282,7 +282,7 @@ export default {
         origins_tags: '',
         labels_tags: [],
         price: null,
-        priceDiscounted: false,
+        price_is_discounted: false,
         price_without_discount: null,
         currency: null,  // see initPriceSingleForm
         location_osm_id: null,
@@ -303,8 +303,6 @@ export default {
       labelsTags: LabelsTags,
       barcodeScanner: false,
       barcodeManualInput: false,
-      // price data
-      priceDiscounted: false,
       // location data
       locationSelector: false,
       locationSelectedDisplayName: '',
@@ -330,12 +328,7 @@ export default {
     },
     priceFormFilled() {
       let keys = ['price', 'currency']
-      if (!this.priceDiscounted) {
-        return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
-      } else {
-        keys.push('price_without_discount')
-        return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
-      }
+      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
     },
     proofFormFilled() {
       let keys = ['proof_id']
@@ -472,7 +465,7 @@ export default {
       if (this.addPriceSingleForm.labels_tags.length == 0) {
         this.addPriceSingleForm.labels_tags = null
       }
-      if (!this.priceDiscounted) {
+      if (!this.addPriceSingleForm.price_is_discounted) {
         this.addPriceSingleForm.price_without_discount = null
       }
       // create price


### PR DESCRIPTION
### What

Following #171 & #173
And thanks to https://github.com/openfoodfacts/open-prices/pull/163

A new field `price_is_discounted` stores the info in the price has a discount or not.
The user is not forced to enter the `price_without_discount` anymore
