### PR TITLE
feat(dashboard): move prices to seperate page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -222,6 +222,8 @@
 	"UserDashboard": {
 		"LatestPrices": "Latest prices",
 		"LoadMore": "Load more",
+		"MyPrices": "My prices",
+		"Settings": "Settings",
 		"Title": "Dashboard"
 	},
 	"UserDetail": {

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import { useAppStore } from './store'
 import Home from './views/Home.vue'
 import SignIn from './views/SignIn.vue'
 import UserDashboard from './views/UserDashboard.vue'
+import UserDashboardPriceList from './views/UserDashboardPriceList.vue'
 import UserSettings from './views/UserSettings.vue'
 import Search from './views/Search.vue'
 import AddPriceHome from './views/AddPriceHome.vue'
@@ -25,6 +26,7 @@ const routes = [
   { path: '/', name: 'home', component: Home, meta: { title: 'Home', icon: 'mdi-home', drawerMenu: true } },
   { path: '/sign-in', name: 'sign-in', component: SignIn, meta: { title: 'SignIn', icon: 'mdi-login', drawerMenu: true, requiresAuth: false } },
   { path: '/dashboard', name: 'dashboard', component: UserDashboard, meta: { title: 'Dashboard', requiresAuth: true } },
+  { path: '/dashboard/prices', name: 'dashboard-prices', component: UserDashboardPriceList, meta: { title: 'My prices', requiresAuth: true } },
   { path: '/settings', name: 'settings', component: UserSettings, meta: { title: 'Settings', requiresAuth: true } },
   { path: '/search', name: 'search', component: Search, meta: { title: 'Search', icon: 'mdi-magnify', drawerMenu: true }},
   { path: '/add', name: 'add-price', component: AddPriceHome, meta: { title: 'AddPrice', icon: 'mdi-plus', drawerMenu: true, color: 'primary', requiresAuth: true }},

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -4,33 +4,25 @@
   </h1>
 
   <v-row>
-    <v-col cols="12" sm="6">
-      <v-card :title="username" prepend-icon="mdi-account"></v-card>
+    <v-col>
+      <v-chip class="mr-2" label variant="text" prepend-icon="mdi-account">
+        {{ username }}
+      </v-chip>
+      <v-btn size="small" prepend-icon="mdi-cog-outline" to="/settings">
+        {{ $t('UserDashboard.Settings') }}
+      </v-btn>
     </v-col>
   </v-row>
-
-  <v-row class="mt-0">
-    <v-col cols="12" sm="6">
-      <v-chip label class="mr-2">{{ userPriceTotal }} prices</v-chip>
-    </v-col>
-  </v-row>
-
-  <br />
-
-  <h2 class="text-h6 mb-1">
-    {{ $t('UserDashboard.LatestPrices') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h2>
 
   <v-row>
-    <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
-      <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
-    </v-col>
-  </v-row>
-
-  <v-row v-if="userPriceList.length < userPriceTotal" class="mb-2">
-    <v-col align="center">
-      <v-btn size="small" :loading="loading" @click="getUserPrices">{{ $t('UserDashboard.LoadMore') }}</v-btn>
+    <v-col cols="12" sm="6" lg="4">
+      <v-card
+        :title="$t('UserDashboard.MyPrices')"
+        :subtitle="userPriceTotal"
+        prepend-icon="mdi-tag-multiple-outline"
+        height="100%"
+        to="/dashboard/prices">
+      </v-card>
     </v-col>
   </v-row>
 </template>
@@ -39,15 +31,10 @@
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
-import PriceCard from '../components/PriceCard.vue'
 
 export default {
-  components: {
-    PriceCard,
-  },
   data() {
     return {
-      userPriceList: [],
       userPriceTotal: null,
       userPricePage: 0,
       loading: false,
@@ -60,15 +47,14 @@ export default {
     },
   },
   mounted() {
-    this.getUserPrices()
+    this.getUserPriceCount()
   },
   methods: {
-    getUserPrices() {
+    getUserPriceCount() {
       this.loading = true
       this.userPricePage += 1
-      return api.getPrices({ owner: this.username, page: this.userPricePage })
+      return api.getPrices({ owner: this.username, size: 1 })
         .then((data) => {
-          this.userPriceList.push(...data.items)
           this.userPriceTotal = data.total
           this.loading = false
         })

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -1,0 +1,77 @@
+<template>
+  <h1 class="text-h5 mb-1">
+    {{ $t('UserDashboard.MyPrices') }}
+  </h1>
+
+  <v-row>
+    <v-col>
+      <v-chip class="mr-2" label variant="text" prepend-icon="mdi-tag-multiple-outline">
+        {{ userPriceTotal }}<span class="d-none d-sm-inline">&nbsp;prices</span>
+      </v-chip>
+      <v-btn size="small" prepend-icon="mdi-arrow-left" to="/dashboard">
+        {{ $t('UserDashboard.Title') }}
+      </v-btn>
+    </v-col>
+  </v-row>
+
+  <br />
+
+  <h2 class="text-h6 mb-1">
+    {{ $t('UserDashboard.LatestPrices') }}
+    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+  </h2>
+
+  <v-row>
+    <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
+      <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
+    </v-col>
+  </v-row>
+
+  <v-row v-if="userPriceList.length < userPriceTotal" class="mb-2">
+    <v-col align="center">
+      <v-btn size="small" :loading="loading" @click="getUserPrices">{{ $t('UserDashboard.LoadMore') }}</v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import api from '../services/api'
+import PriceCard from '../components/PriceCard.vue'
+
+export default {
+  components: {
+    PriceCard,
+  },
+  data() {
+    return {
+      userPriceList: [],
+      userPriceTotal: null,
+      userPricePage: 0,
+      loading: false,
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    username() {
+      return this.appStore.user.username
+    },
+  },
+  mounted() {
+    this.getUserPrices()
+  },
+  methods: {
+    getUserPrices() {
+      this.loading = true
+      this.userPricePage += 1
+      return api.getPrices({ owner: this.username, page: this.userPricePage })
+        .then((data) => {
+          this.userPriceList.push(...data.items)
+          this.userPriceTotal = data.total
+          this.loading = false
+        })
+    },
+  }
+}
+</script>


### PR DESCRIPTION
### What

Start improving the user dashboard
- add link to settings
- move price list to separate page
- upcoming PR : list of proofs

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/545751b9-5bd7-4fcf-bb0c-8c4893796cb5)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/02cd9075-2286-4daa-91bf-9543c0d6df3e)|