### PR TITLE
docs: improve setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,19 @@
 
 ## Installation
 
-```sh
-yarn
-```
+If you don't already have Node.js install, we recommend using [`nvm`](https://github.com/nvm-sh/nvm) to manage different node versions.
 
-## Development
+We use the [yarn](https://yarnpkg.com/getting-started/install) for package management.
 
-```sh
-yarn dev
-```
+## Run the project
+
+1. Install/update packages with command `yarn`
+2. Run in development mode with `yarn dev`
+
+    After this you should be able to access the website at <http://localhost:5173/>.
+
+3. Run the back-end on your device. To do so, get and run the code of the server here: <https://github.com/openfoodfacts/open-prices>.
+4. You can start your first contribution :tada:
 
 ## Build
 


### PR DESCRIPTION
I propose to move the instruction directly in the README.md to avoid contributor missing it. For now, we don't miss places on this document so no need to split

Added a section for newbies to give them correct tools, plus a direct link to the server project
