### PR TITLE
feat: Make the sign-in button similar to Open Food Facts

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -6,14 +6,12 @@
       {{ APP_NAME }}
     </v-app-bar-title>
     <template v-slot:append>
-      <v-btn v-if="!username" to="/sign-in" icon="mdi-login"></v-btn>
+      <v-btn v-if="!username" to="/sign-in" prepend-icon="mdi-account" class="text-none">Sign in</v-btn>
       <v-menu v-if="username">
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" icon="mdi-account-circle"></v-btn>
+          <v-btn v-bind="props" prepend-icon="mdi-account" class="text-none">{{ username }}</v-btn>
         </template>
         <v-list>
-          <v-list-item :slim="true" prepend-icon="mdi-account" disabled>{{ username }}</v-list-item>
-          <v-divider></v-divider>
           <v-list-item :slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard">{{ $t('Header.Dashboard') }}</v-list-item>
           <v-list-item :slim="true" prepend-icon="mdi-cog-outline" to="/settings">{{ $t('Header.Settings') }}</v-list-item>
           <v-list-item :slim="true" prepend-icon="mdi-logout" @click="signOut">{{ $t('Header.Sign-out') }}</v-list-item>


### PR DESCRIPTION
From #65 

> The user menu has a logout icon if you're not logged in

I think Pierre got mislead by the sign in  icon which is very close to the sign out. I propose To follow OFF behavior: if sign in display the name otherwise display "sign in"

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/45398769/d21f6084-bf0b-44d4-8191-e8214ebbd65c)

This PR is mostly for me to get familiar back with vue.js If you prefer the previouse behavior no pb