### PR TITLE
feat: allow user to delete its own prices

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card :id="'price_' + price.id">
     <v-container class="pa-2">
       <v-row>
         <v-col v-if="!hideProductImage" style="max-width:25%">
@@ -109,7 +109,7 @@ export default {
       if (this.hasProductBrands) {
         return this.product.brands.split(',')
       }
-    }
+    },
   },
   methods: {
     initPriceCard() {

--- a/src/components/PriceDeleteChip.vue
+++ b/src/components/PriceDeleteChip.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-chip
+    style="padding-left:5px;padding-right:5px"
+    label
+    size="small"
+    density="comfortable"
+    color="error"
+    :title="$t('PriceDeleteChip.Delete')"
+    @click="openDialog">
+    <v-icon icon="mdi-delete"></v-icon>
+  </v-chip>
+
+  <v-dialog v-model="dialog" max-height="80%" max-width="80%">
+    <v-card>
+      <v-card-title>
+        {{ $t('PriceDeleteChip.DeleteTitle') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="closeDialog"></v-btn>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text>
+        <p class="mb-1">{{ $t('PriceDeleteChip.Confirmation') }}</p>
+        <v-row>
+          <v-col cols="12" sm="6" md="4">
+            <PriceCard v-if="price" :price="price" :hidePriceFooter="true" :readonly="true"></PriceCard>
+          </v-col>
+        </v-row>
+        <v-btn
+          class="mt-2"
+          size="small"
+          color="error"
+          prepend-icon="mdi-delete"
+          :loading="loading"
+          @click="deletePrice"
+        >{{ $t('PriceDeleteChip.Delete') }}</v-btn>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { defineAsyncComponent } from 'vue'
+import api from '../services/api'
+// import PriceCard from '../components/PriceCard.vue'
+
+export default {
+  components: {
+    'PriceCard': defineAsyncComponent(() => import('../components/PriceCard.vue'))
+  },
+  props: {
+    'price': null,
+  },
+  data() {
+    return {
+      loading: false,
+      dialog: false
+    }
+  },
+  computed: {
+  },
+  methods: {
+    deletePrice() {
+      this.loading = true
+      api
+        .deletePrice(this.price.id)
+        .then((response) => {
+          // if response.status == 204
+          this.loading = false
+          this.removePriceCard()
+          this.closeDialog()
+        })
+    },
+    removePriceCard() {
+      const priceCardCol = document.getElementById(`price_${this.price.id}`)
+      priceCardCol.remove()
+    },
+    openDialog() {
+      this.dialog = true
+    },
+    closeDialog() {
+      this.dialog = false
+    }
+  }
+}
+</script>

--- a/src/components/PriceFooter.vue
+++ b/src/components/PriceFooter.vue
@@ -14,18 +14,24 @@
     <RelativeDateTimeChip :dateTime="price.created"></RelativeDateTimeChip>
 
     <PriceProof v-if="price.proof && price.proof.is_public" :proof="price.proof"></PriceProof>
+
+    <PriceDeleteChip v-if="userIsPriceOwner" :price="price"></PriceDeleteChip>
   </div>
 </template>
 
 <script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
 import utils from '../utils.js'
-import PriceProof from '../components/PriceProof.vue'
 import RelativeDateTimeChip from '../components/RelativeDateTimeChip.vue'
+import PriceProof from '../components/PriceProof.vue'
+import PriceDeleteChip from '../components/PriceDeleteChip.vue'
 
 export default {
   components: {
     RelativeDateTimeChip,
     PriceProof,
+    PriceDeleteChip,
   },
   props: {
     'price': null,
@@ -35,6 +41,15 @@ export default {
   data() {
     return {
       priceLocationEmoji: null
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    username() {
+      return this.appStore.user.username
+    },
+    userIsPriceOwner() {
+      return this.username && (this.price.owner === this.username)
     }
   },
   mounted() {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -157,6 +157,11 @@
 	"PriceCountChip": {
 		"PriceCount": "{count} prices"
 	},
+	"PriceDeleteChip": {
+		"Confirmation": "Are you sure you want to delete this price?",
+		"Delete": "Delete",
+		"DeleteTitle": "Delete a price"
+	},
 	"PriceList": {
 		"LoadMore": "Load more",
 		"Title": "Latest prices"

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -85,6 +85,17 @@ export default {
     .then((response) => response.json())
   },
 
+  deletePrice(priceId) {
+    const store = useAppStore()
+    return fetch(`${import.meta.env.VITE_OPEN_PRICES_API_URL}/prices/${priceId}`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${store.user.token}`
+      },
+    })
+    // .then((response) => response.json())
+  },
+
   getProducts(params = {}) {
     const defaultParams = {page: 1, size: 10}  // order_by default ?
     const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/products?${new URLSearchParams({...defaultParams, ...params})}`


### PR DESCRIPTION
### What

Thanks to https://github.com/openfoodfacts/open-prices/pull/179 a user can now delete it's own prices.

Added a chip in the price footer, with a confirmation dialog

### Screenshots

||Image|
|---|---|
|Price card|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/bc98c2e4-f44d-4bde-a0d4-b1f1680ea984)|
|Confirmation dialog|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/6167f074-34c8-49b9-81b3-0d6b8d6ee4e6)|