### PR TITLE
feat: display product quantity (g or mL) depending on product_quantity_unit

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -16,9 +16,7 @@
               </v-chip>
             </span>
             <span v-if="hasProductQuantity">
-              <v-chip label size="small" density="comfortable" class="mr-1">
-                {{ $t('PriceCard.ProductQuantity', [product.product_quantity]) }}
-              </v-chip>
+              <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
             <span v-if="hasPriceOrigin && priceOrigin">
               <v-chip label size="small" density="comfortable" class="mr-1">
@@ -46,11 +44,13 @@
 import utils from '../utils.js'
 import OriginTags from '../data/origins-tags.json'
 import LabelsTags from '../data/labels-tags.json'
+import ProductQuantityChip from '../components/ProductQuantityChip.vue'
 import PricePrice from '../components/PricePrice.vue'
 import PriceFooter from '../components/PriceFooter.vue'
 
 export default {
   components: {
+    ProductQuantityChip,
     PricePrice,
     PriceFooter
   },

--- a/src/components/PricePrice.vue
+++ b/src/components/PricePrice.vue
@@ -23,7 +23,7 @@ export default {
   props: {
     'price': null,
     'productQuantity': null,
-    'productQuantityUnit': null,  // 'g', 'mL'
+    'productQuantityUnit': 'g',  // 'mL'
     'hidePriceDate': false
   },
   data() {

--- a/src/components/PricePrice.vue
+++ b/src/components/PricePrice.vue
@@ -67,14 +67,14 @@ export default {
           return this.$t('PriceCard.PriceValueDisplayUnit', [this.getPriceValue(price, this.priceCurrency)])
         }
         // default to 'KILOGRAM'
-        return this.$t('PriceCard.PriceValueDisplay', [this.getPriceValue(price, this.priceCurrency)])
+        return this.$t('PriceCard.PriceValueDisplayKilogram', [this.getPriceValue(price, this.priceCurrency)])
       }
       if (this.hasProductQuantity) {
         const pricePerUnit = (price / this.productQuantity) * 1000
         if (this.productQuantityUnit === 'mL') {
           return this.$t('PriceCard.PriceValueDisplayLitre', [this.getPriceValue(pricePerUnit, this.priceCurrency)])
         }
-        return this.$t('PriceCard.PriceValueDisplay', [this.getPriceValue(pricePerUnit, this.priceCurrency)])
+        return this.$t('PriceCard.PriceValueDisplayKilogram', [this.getPriceValue(pricePerUnit, this.priceCurrency)])
       }
     },
     getPriceValueDisplay(price) {

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -19,9 +19,7 @@
               </v-chip>
             </span>
             <span v-if="hasProductQuantity">
-              <v-chip label size="small" density="comfortable" class="mr-1">
-                {{ $t('ProductCard.ProductQuantity', [product.product_quantity]) }}
-              </v-chip>
+              <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
             <span>
               <br />
@@ -43,12 +41,14 @@
 
 <script>
 import PriceCountChip from '../components/PriceCountChip.vue'
+import ProductQuantityChip from '../components/ProductQuantityChip.vue'
 import PricePrice from '../components/PricePrice.vue'
 import PriceFooter from '../components/PriceFooter.vue'
 
 export default {
   components: {
     PriceCountChip,
+    ProductQuantityChip,
     PricePrice,
     PriceFooter,
   },

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-chip label size="small" density="comfortable">
+    {{ $t('ProductCard.ProductQuantity', [productQuantity]) }}
+  </v-chip>
+</template>
+
+<script>
+export default {
+  props: {
+    productQuantity: null,
+    productQuantityUnit: null
+  },
+  computed: {
+
+  }
+}
+</script>

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -1,6 +1,6 @@
 <template>
   <v-chip label size="small" density="comfortable">
-    {{ $t('ProductCard.ProductQuantity', [productQuantity]) }}
+    {{ productQuantityWithUnitDisplay }}
   </v-chip>
 </template>
 
@@ -8,10 +8,15 @@
 export default {
   props: {
     productQuantity: null,
-    productQuantityUnit: null
+    productQuantityUnit: 'g'  // 'mL'
   },
   computed: {
-
+    productQuantityWithUnitDisplay() {
+      if (this.productQuantityUnit === 'mL') {
+        return this.$t('ProductCard.ProductQuantityLitre', [this.productQuantity])
+      }
+      return this.$t('ProductCard.ProductQuantity', [this.productQuantity])
+    }
   }
 }
 </script>

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -13,9 +13,9 @@ export default {
   computed: {
     productQuantityWithUnitDisplay() {
       if (this.productQuantityUnit === 'mL') {
-        return this.$t('ProductCard.ProductQuantityLitre', [this.productQuantity])
+        return this.$t('ProductCard.ProductQuantityMililitre', [this.productQuantity])
       }
-      return this.$t('ProductCard.ProductQuantity', [this.productQuantity])
+      return this.$t('ProductCard.ProductQuantityGram', [this.productQuantity])
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -152,6 +152,7 @@
 		"PriceValueDisplayUnit": "{0} / unit",
 		"Proof": "Proof",
 		"ProductQuantity": "{0} g",
+		"ProductQuantityLitre": "{0} mL",
 		"FullPrice": "Full price",
 		"UnknownProduct": "Unknown product"
 	},
@@ -171,6 +172,7 @@
 	"ProductCard": {
 		"LatestPrice": "Latest price",
 		"ProductQuantity": "{0} g",
+		"ProductQuantityLitre": "{0} mL",
 		"UnknownProduct": "Unknown product name"
 	},
 	"ProductDetail": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -147,12 +147,10 @@
 	"PriceCard": {
 		"Discount": "Discount",
 		"PriceDate": "on {date}",
-		"PriceValueDisplay": "{0} / kg",
+		"PriceValueDisplayKilogram": "{0} / kg",
 		"PriceValueDisplayLitre": "{0} / L",
 		"PriceValueDisplayUnit": "{0} / unit",
 		"Proof": "Proof",
-		"ProductQuantity": "{0} g",
-		"ProductQuantityLitre": "{0} mL",
 		"FullPrice": "Full price",
 		"UnknownProduct": "Unknown product"
 	},
@@ -171,8 +169,10 @@
 	},
 	"ProductCard": {
 		"LatestPrice": "Latest price",
-		"ProductQuantity": "{0} g",
-		"ProductQuantityLitre": "{0} mL",
+		"ProductQuantityGram": "{0} g",
+		"ProductQuantityKilogram": "{0} kg",
+		"ProductQuantityMililitre": "{0} mL",
+		"ProductQuantityLitre": "{0} L",
 		"UnknownProduct": "Unknown product name"
 	},
 	"ProductDetail": {


### PR DESCRIPTION
### What

Similar to #311

Better display the product quantity (`ProductCard`)
New `ProductQuantityChip`

### Screenshots

||Image|
|---|---|
|Before|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/ef183ec0-50bd-4cfe-834c-8233255acf04)|
|After|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/5f11a348-08cc-44cf-a607-137880b887e5)|