### PR TITLE
feat: header background color (same as OFF)

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-app-bar :elevation="1" style="background-color: rgb(242, 233, 228);">
+  <v-app-bar :elevation="1" style="background-color: rgb(242, 233, 228);">
     <v-app-bar-nav-icon @click.stop="showDrawerMenu = !showDrawerMenu"></v-app-bar-nav-icon>
     <v-app-bar-title style="cursor:pointer" @click="$router.push('/')">
       <img src="/favicon.svg" height="28" style="vertical-align:bottom">

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar :elevation="1">
+    <v-app-bar :elevation="1" style="background-color: rgb(242, 233, 228);">
     <v-app-bar-nav-icon @click.stop="showDrawerMenu = !showDrawerMenu"></v-app-bar-nav-icon>
     <v-app-bar-title style="cursor:pointer" @click="$router.push('/')">
       <img src="/favicon.svg" height="28" style="vertical-align:bottom">


### PR DESCRIPTION
### What
The header's background color has been updated to RGB(242, 233, 228) to align it with the color scheme used in other OFF projects.

### Screenshot

Before the changes:

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/84929607/d70bd1be-2a65-45b8-bc37-62fecd81269e)

After the header background color has been updated:

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/84929607/280b9be8-3f84-468d-a0da-980f30320de5)


### Part of 
#298 
