### PR TITLE
feat(l10n): translate origin list in price add form depending on user locale

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,10 @@ function getCategoryName(categoryId) {
   return category ? category.name : categoryId
 }
 
+function getLocaleOriginTags(locale) {
+  return import(`./data/origins/${locale}.json`)
+}
+
 function getCountryEmojiFromName(countryString) {
   const country = CountriesWithEmoji.find(c => c.name === countryString || (c.name_original && c.name_original.length && c.name_original.indexOf(countryString) > -1))
   return country ? country.emoji : null
@@ -151,6 +155,7 @@ export default {
   prettyRelativeDateTime,
   getLocaleCategoryTags,
   getCategoryName,
+  getLocaleOriginTags,
   getCountryEmojiFromName,
   getLocationTitle,
 }

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -181,7 +181,7 @@
                 <v-autocomplete
                   v-model="productPriceForm.origins_tags"
                   :label="$t('AddPriceSingle.ProductInfo.OriginLabel')"
-                  :items="originsTags"
+                  :items="originTags"
                   :item-title="item => item.name"
                   :item-value="item => item.id"
                   hide-details="auto"
@@ -377,8 +377,8 @@ export default {
         {key: 'category', value: this.$t('AddPriceSingle.ProductModeList.Category'), icon: 'mdi-basket-outline'}
       ],
       productMode: null,
-      categoryTags: null,  // list of category tags for autocomplete  // see initPriceMultipleForm
-      originsTags: null,  // list of origins tags for autocomplete  // see initPriceMultipleForm
+      categoryTags: [],  // list of category tags for autocomplete  // see initPriceMultipleForm
+      originTags: [],  // list of origins tags for autocomplete  // see initPriceMultipleForm
       labelsTags: LabelsTags,
       barcodeScanner: false,
       barcodeManualInput: false,

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -318,8 +318,6 @@ import PriceCard from '../components/PriceCard.vue'
 import ProductCard from '../components/ProductCard.vue'
 import BarcodeScanner from '../components/BarcodeScanner.vue'
 import BarcodeManualInput from '../components/BarcodeManualInput.vue'
-import CategoryTags from '../data/category-tags.json'
-import OriginsTags from '../data/origins-tags.json'
 import LabelsTags from '../data/labels-tags.json'
 
 Compressor.setDefaults({
@@ -380,7 +378,7 @@ export default {
       ],
       productMode: null,
       categoryTags: null,  // list of category tags for autocomplete  // see initPriceMultipleForm
-      originsTags: OriginsTags,  // list of origins tags for autocomplete
+      originsTags: null,  // list of origins tags for autocomplete  // see initPriceMultipleForm
       labelsTags: LabelsTags,
       barcodeScanner: false,
       barcodeManualInput: false,
@@ -444,12 +442,15 @@ export default {
   methods: {
     initPriceMultipleForm() {
       /**
-       * init form config (product mode, categories, last locations)
+       * init form config (product mode, categories, origins, last locations)
        * (init form done in initNewProductPriceForm)
        */
       this.proofType = this.$route.path.endsWith('/receipt') ? 'RECEIPT' : 'PRICE_TAG'
       utils.getLocaleCategoryTags(this.appStore.getUserLanguage).then((module) => {
         this.categoryTags = module.default
+      })
+      utils.getLocaleOriginTags(this.appStore.getUserLanguage).then((module) => {
+        this.originTags = module.default
       })
       if (this.recentLocations.length) {
         this.setLocationData(this.recentLocations[0])

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -264,7 +264,6 @@ import ProductCard from '../components/ProductCard.vue'
 import BarcodeScanner from '../components/BarcodeScanner.vue'
 import BarcodeManualInput from '../components/BarcodeManualInput.vue'
 import LocationSelector from '../components/LocationSelector.vue'
-import OriginsTags from '../data/origins-tags.json'
 import LabelsTags from '../data/labels-tags.json'
 
 Compressor.setDefaults({
@@ -310,7 +309,7 @@ export default {
       ],
       productMode: null,  // 'barcode' or 'category'  // see initPriceSingleForm
       categoryTags: null,  // list of category tags for autocomplete  // see initPriceSingleForm
-      originsTags: OriginsTags,  // list of origins tags for autocomplete
+      originsTags: null,  // list of origins tags for autocomplete  // see initPriceSingleForm
       labelsTags: LabelsTags,
       barcodeScanner: false,
       barcodeManualInput: false,
@@ -380,12 +379,15 @@ export default {
     },
     initPriceSingleForm() {
       /**
-       * init form config (product mode, categories, last locations)
+       * init form config (product mode, categories, origins, last locations)
        * init form
        */
       this.productMode = this.addPriceSingleForm.product_code ? 'barcode' : this.appStore.user.last_product_mode_used
       utils.getLocaleCategoryTags(this.appStore.getUserLanguage).then((module) => {
         this.categoryTags = module.default
+      })
+      utils.getLocaleOriginTags(this.appStore.getUserLanguage).then((module) => {
+        this.originTags = module.default
       })
       if (this.recentLocations.length) {
         this.setLocationData(this.recentLocations[0])

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -60,7 +60,7 @@
                   <v-autocomplete
                     v-model="addPriceSingleForm.origins_tags"
                     :label="$t('AddPriceSingle.ProductInfo.OriginLabel')"
-                    :items="originsTags"
+                    :items="originTags"
                     :item-title="item => item.name"
                     :item-value="item => item.id"
                     hide-details="auto"
@@ -308,8 +308,8 @@ export default {
         {key: 'category', value: this.$t('AddPriceSingle.ProductModeList.Category'), icon: 'mdi-basket-outline'}
       ],
       productMode: null,  // 'barcode' or 'category'  // see initPriceSingleForm
-      categoryTags: null,  // list of category tags for autocomplete  // see initPriceSingleForm
-      originsTags: null,  // list of origins tags for autocomplete  // see initPriceSingleForm
+      categoryTags: [],  // list of category tags for autocomplete  // see initPriceSingleForm
+      originTags: [],  // list of origins tags for autocomplete  // see initPriceSingleForm
       labelsTags: LabelsTags,
       barcodeScanner: false,
       barcodeManualInput: false,


### PR DESCRIPTION
### What

Following #321 (and similar to #275)
- we now have the translated origins
- we can display the corresponding origin list depending on the user locale

### Screenshot

example with French locale

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/bd8a2ecb-0595-4e21-8ea3-9369c753defd)
