### PR TITLE
fix: show tooltip on click (discount, date)

### DIFF
--- a/src/components/PricePrice.vue
+++ b/src/components/PricePrice.vue
@@ -5,7 +5,7 @@
     <span v-if="price.price_is_discounted">
       <v-chip class="mr-1" color="red" variant="outlined" size="small" density="comfortable">
         {{ $t('PriceCard.Discount') }}
-        <v-tooltip v-if="priceWithoutDiscountValue" activator="parent" location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(priceWithoutDiscountValue) }}</v-tooltip>
+        <v-tooltip v-if="priceWithoutDiscountValue" activator="parent" open-on-click location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(priceWithoutDiscountValue) }}</v-tooltip>
       </v-chip>
     </span>
     <i18n-t v-if="!hidePriceDate" keypath="PriceCard.PriceDate" tag="span">

--- a/src/components/RelativeDateTimeChip.vue
+++ b/src/components/RelativeDateTimeChip.vue
@@ -2,7 +2,7 @@
   <v-chip label size="small" density="comfortable">
     <v-icon start icon="mdi-clock-outline"></v-icon>
     {{ getRelativeDateTimeFormatted(dateTime) }}
-    <v-tooltip activator="parent" location="top">{{ getDateTimeFormatted(dateTime) }}</v-tooltip>
+    <v-tooltip activator="parent" open-on-click location="top">{{ getDateTimeFormatted(dateTime) }}</v-tooltip>
   </v-chip>
 </template>
 


### PR DESCRIPTION
### What
- added possibility to show on click tooltips for "discount" and "date" for price cards since there is hovering is not feasible on touchscreen
