### PR TITLE
feat: add price filter

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -10,10 +10,17 @@ export default {
   PRODUCT_FILTER_LIST: [
     { key: 'hide_price_count_gte_1', value: 'Hide products with prices' },
   ],
+  PRICE_FILTER_LIST: [
+    { key: 'show_last_month', value: 'Show Prices from Last 30 Days' },
+  ],
   ORDER_BY_PARAM: 'order_by',
   PRODUCT_ORDER_BY_LIST: [
     { key: '-unique_scans_n', value: 'Number of scans', icon: 'mdi-barcode-scan' },
     { key: '-price_count', value: 'Number of prices', icon: 'mdi-tag-multiple-outline' },
+  ],
+  PRICE_ORDER_BY_LIST: [
+    { key: '-created', value: 'Last created', icon: 'mdi-calendar-plus' },
+    { key: '-date', value: 'Date (Newest First)', icon: 'mdi-calendar' },
   ],
   // https://wiki.openstreetmap.org/wiki/Key:place
   // https://wiki.openstreetmap.org/wiki/Key:highway

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export default {
     { key: 'hide_price_count_gte_1', value: 'Hide products with prices' },
   ],
   PRICE_FILTER_LIST: [
-    { key: 'show_last_month', value: 'Show Prices from Last 30 Days' },
+    { key: 'only_last_30d', value: 'Only prices for the last 30 days' },
   ],
   ORDER_BY_PARAM: 'order_by',
   PRODUCT_ORDER_BY_LIST: [
@@ -19,8 +19,8 @@ export default {
     { key: '-price_count', value: 'Number of prices', icon: 'mdi-tag-multiple-outline' },
   ],
   PRICE_ORDER_BY_LIST: [
-    { key: '-created', value: 'Last created', icon: 'mdi-calendar-plus' },
-    { key: '-date', value: 'Date (Newest First)', icon: 'mdi-calendar' },
+    { key: '-created', value: 'Addition date', icon: 'mdi-clock-outline' },
+    { key: '-date', value: 'Price Date', icon: 'mdi-calendar' },
   ],
   // https://wiki.openstreetmap.org/wiki/Key:place
   // https://wiki.openstreetmap.org/wiki/Key:highway

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -95,11 +95,11 @@
 	"BrandDetail": {
 		"LoadMore": "Load more",
 		"TopProducts": "Top products",
-		"BrandProductTotal": "{count} products",
-		"Filter": "Filter",
-		"Order": "Order"
+		"BrandProductTotal": "{count} products"
 	},
 	"Common": {
+		"Filter": "Filter",
+		"Order": "Order",
 		"SignInOFFAccount": "Sign in with your {url} account"
 	},
 	"Footer": {
@@ -188,10 +188,8 @@
 		"ProductNotFound": "Product not found in Open Food Facts... Don't hesitate to add it :)"
 	},
 	"ProductList": {
-		"Filter": "Filter",
 		"HideProductsWithPrices": "Hide products with prices",
 		"LoadMore": "Load more",
-		"Order": "Order",
 		"PriceNumber": "Number of prices added",
 		"ScanNumber": "Number of scans added",
 		"Title": "Top products"

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -32,7 +32,7 @@
     <v-col>
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!productFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!productFilter">{{ $t('Common.Filter') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="filter in productFilterList" :key="filter.key" :prepend-icon="(productFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="productFilter === filter.key" @click="toggleProductFilter(filter.key)">
@@ -43,7 +43,7 @@
 
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentProductOrderIcon"  :active="!!productOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentProductOrderIcon"  :active="!!productOrder">{{ $t('Common.Order') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in productOrderList" :key="order.key" :prepend-icon="order.icon" :active="productOrder === order.key" @click="selectProductOrder(order.key)">

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -35,7 +35,7 @@
     <v-col>
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('Common.Filter') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="filter in priceFilterList" :key="filter.key" :prepend-icon="(priceFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="priceFilter === filter.key" @click="togglePriceFilter(filter.key)">
@@ -46,7 +46,7 @@
 
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon" :active="!!priceOrder">{{ $t('Common.Order') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
@@ -111,7 +111,7 @@ export default {
       return currentPriceOrder ? currentPriceOrder.icon : ''
     },
     getPricesParams() {
-      let defaultParams = { location_id: this.locationId, order_by: `${this.priceOrder}`, page: this.locationPricePage }
+      let defaultParams = { location_id: this.locationId, order_by: this.priceOrder, page: this.locationPricePage }
       if (this.priceFilter === 'show_last_month') {
         let oneMonthAgo = new Date()
         oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
@@ -171,6 +171,19 @@ export default {
       if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
         this.initLocationPrices()
       }
+      let date = new Date().toISOString();
+
+      console.time('split');
+      for (let i = 0; i < 1000000; i++) {
+        let result = date.split('T')[0];
+      }
+      console.timeEnd('split');
+
+      console.time('substring');
+      for (let i = 0; i < 1000000; i++) {
+        let result = date.substring(0, 10);
+      }
+      console.timeEnd('substring');
     }
   }
 }

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -115,7 +115,7 @@ export default {
       if (this.priceFilter === 'show_last_month') {
         let oneMonthAgo = new Date()
         oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-        defaultParams['date__gte'] = oneMonthAgo.toISOString().split('T')[0]
+        defaultParams['date__gte'] = oneMonthAgo.toISOString().substring(0, 10)
       }
       return defaultParams
     },

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -31,6 +31,32 @@
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
+  <v-row v-if="!loading">
+    <v-col>
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+        </template>
+        <v-list>
+          <v-list-item :slim="true" v-for="filter in priceFilterList" :key="filter.key" :prepend-icon="(priceFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="priceFilter === filter.key" @click="togglePriceFilter(filter.key)">
+            {{ filter.value }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+        </template>
+        <v-list>
+          <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
+            {{ order.value }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </v-col>
+  </v-row>
+
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in locationPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" :hidePriceLocation="true" elevation="1" height="100%"></PriceCard>
@@ -48,6 +74,7 @@
 import api from '../services/api'
 import utils from '../utils.js'
 import { defineAsyncComponent } from 'vue'
+import constants from '../constants'
 
 export default {
   components: {
@@ -62,13 +89,43 @@ export default {
       locationPriceTotal: null,
       locationPricePage: 0,
       loading: false,
+      // filter & order
+      priceFilter: '',
+      priceFilterList: constants.PRICE_FILTER_LIST,
+      priceOrder: constants.PRICE_ORDER_BY_LIST[1].key,
+      priceOrderList: constants.PRICE_ORDER_BY_LIST,
     }
   },
   mounted() {
+    this.priceFilter = this.$route.query[constants.FILTER_PARAM] || this.priceFilter
+    this.priceOrder = this.$route.query[constants.ORDER_BY_PARAM] || this.priceOrder
     this.getLocation(),
     this.getLocationPrices()
   },
+  computed: {
+    locationId() {
+      return this.$route.params.id
+    },
+    getCurrentPriceOrderIcon() {
+      let currentPriceOrder = this.priceOrderList.find(o => o.key === this.priceOrder)
+      return currentPriceOrder ? currentPriceOrder.icon : ''
+    },
+    getPricesParams() {
+      let defaultParams = { location_id: this.locationId, order_by: `${this.priceOrder}`, page: this.locationPricePage }
+      if (this.priceFilter === 'show_last_month') {
+        let oneMonthAgo = new Date()
+        oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
+        defaultParams['date__gte'] = oneMonthAgo.toISOString().split('T')[0]
+      }
+      return defaultParams
+    },
+  },
   methods: {
+    initLocationPrices() {
+      this.locationPriceList = []
+      this.locationPricePage = 0
+      this.getLocationPrices()
+    },
     getLocation() {
       return api.getLocationById(this.$route.params.id)
         .then((data) => {
@@ -80,7 +137,7 @@ export default {
     getLocationPrices() {
       this.loading = true
       this.locationPricePage += 1
-      return api.getPrices({ location_id: this.$route.params.id, page: this.locationPricePage })
+      return api.getPrices(this.getPricesParams)
         .then((data) => {
           this.locationPriceList.push(...data.items)
           this.locationPriceTotal = data.total
@@ -95,6 +152,25 @@ export default {
     },
     getLocationOSMUrl(location) {
       return `https://www.openstreetmap.org/${location.osm_type.toLowerCase()}/${location.osm_id}`
+    },
+    togglePriceFilter(filterKey) {
+      this.priceFilter = this.priceFilter ? '' : filterKey
+      this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.priceFilter } })
+      // this.initLocationPrices() will be called in watch $route
+    },
+    selectPriceOrder(orderKey) {
+      if (this.priceOrder !== orderKey) {
+        this.priceOrder = orderKey
+        this.$router.push({ query: { ...this.$route.query, [constants.ORDER_BY_PARAM]: this.priceOrder } })
+        // this.initLocationPrices() will be called in watch $route
+      }
+    }
+  },
+  watch: {
+    $route (newRoute, oldRoute) {  // only called when query changes to avoid having an API call when the path changes
+      if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
+        this.initLocationPrices()
+      }
     }
   }
 }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -36,6 +36,31 @@
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
+  <v-row v-if="!loading">
+    <v-col>
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+        </template>
+        <v-list>
+          <v-list-item :slim="true" v-for="filter in priceFilterList" :key="filter.key" :prepend-icon="(priceFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="priceFilter === filter.key" @click="togglePriceFilter(filter.key)">
+            {{ filter.value }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+        </template>
+        <v-list>
+          <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
+            {{ order.value }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </v-col>
+  </v-row>
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in productPriceList" :key="price">
       <PriceCard :price="price" :product="product" :hideProductImage="true" :hideProductTitle="true" :hideProductDetails="productIsCategory ? false : true" elevation="1" height="100%"></PriceCard>
@@ -73,9 +98,16 @@ export default {
       loading: false,
       // share
       shareLinkCopySuccessMessage: false,
+      // filter & order
+      priceFilter: '',
+      priceFilterList: constants.PRICE_FILTER_LIST,
+      priceOrder: constants.PRICE_ORDER_BY_LIST[1].key,
+      priceOrderList: constants.PRICE_ORDER_BY_LIST,
     }
   },
   mounted() {
+    this.priceFilter = this.$route.query[constants.FILTER_PARAM] || this.priceFilter
+    this.priceOrder = this.$route.query[constants.ORDER_BY_PARAM] || this.priceOrder
     this.getProduct(),
     this.getProductPrices()
   },
@@ -94,9 +126,27 @@ export default {
     },
     productOrCategoryNotFound() {
       return !this.loading && (this.productNotFound || this.categoryNotFound)
-    }
+    },
+    getCurrentPriceOrderIcon() {
+      let currentPriceOrder = this.priceOrderList.find(o => o.key === this.priceOrder)
+      return currentPriceOrder ? currentPriceOrder.icon : ''
+    },
+    getPricesParams() {
+      let defaultParams = { [this.productIsCategory ? 'category_tag' : 'product_code']: this.productId, order_by: `${this.priceOrder}`, page: this.productPricePage }
+      if (this.priceFilter === 'show_last_month') {
+        let oneMonthAgo = new Date()
+        oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
+        defaultParams['date__gte'] = oneMonthAgo.toISOString().split('T')[0]
+      }
+      return defaultParams
+    },
   },
   methods: {
+    initProductPrices() {
+      this.productPriceList = []
+      this.productPricePage = 0
+      this.getProductPrices()
+    },
     getProduct() {
       if (!this.productIsCategory) {
         return api.getProductByCode(this.productId)
@@ -110,13 +160,32 @@ export default {
     getProductPrices() {
       this.loading = true
       this.productPricePage += 1
-      return api.getPrices({ [this.productIsCategory ? 'category_tag' : 'product_code']: this.productId, page: this.productPricePage })
+      return api.getPrices(this.getPricesParams)
         .then((data) => {
           this.productPriceList.push(...data.items)
           this.productPriceTotal = data.total
           this.loading = false
         })
     },
+    togglePriceFilter(filterKey) {
+      this.priceFilter = this.priceFilter ? '' : filterKey
+      this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.priceFilter } })
+      // this.initProductPrices() will be called in watch $route
+    },
+    selectPriceOrder(orderKey) {
+      if (this.priceOrder !== orderKey) {
+        this.priceOrder = orderKey
+        this.$router.push({ query: { ...this.$route.query, [constants.ORDER_BY_PARAM]: this.priceOrder } })
+        // this.initProductPrices() will be called in watch $route
+      }
+    }
+  },
+  watch: {
+    $route (newRoute, oldRoute) {  // only called when query changes to avoid having an API call when the path changes
+      if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
+        this.initProductPrices()
+      }
+    }
   }
 }
 </script>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -136,7 +136,7 @@ export default {
       if (this.priceFilter === 'show_last_month') {
         let oneMonthAgo = new Date()
         oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-        defaultParams['date__gte'] = oneMonthAgo.toISOString().split('T')[0]
+        defaultParams['date__gte'] = oneMonthAgo.toISOString().substring(0, 10)
       }
       return defaultParams
     },

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -40,7 +40,7 @@
     <v-col>
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('Common.Filter') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="filter in priceFilterList" :key="filter.key" :prepend-icon="(priceFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="priceFilter === filter.key" @click="togglePriceFilter(filter.key)">
@@ -51,7 +51,7 @@
 
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('Common.Order') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -11,7 +11,7 @@
       </v-chip>
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!productFilter">{{ $t('ProductList.Filter') }}</v-btn>
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!productFilter">{{ $t('Common.Filter') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="filter in productFilterList" :key="filter.key" :prepend-icon="(productFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="productFilter === filter.key" @click="toggleProductFilter(filter.key)">
@@ -22,7 +22,7 @@
 
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentProductOrderIcon"  :active="!!productOrder">{{ $t('ProductList.Order') }}</v-btn>
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentProductOrderIcon"  :active="!!productOrder">{{ $t('Common.Order') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in productOrderList" :key="order.key" :prepend-icon="order.icon" :active="productOrder === order.key" @click="selectProductOrder(order.key)">

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -117,8 +117,8 @@ export default {
     }
   },
   watch: {
-    $route (newRoute, oldRoute) {
-      if (oldRoute.fullPath !== newRoute.fullPath) {
+    $route (newRoute, oldRoute) { // only called when query changes to avoid having an API call when the path changes
+      if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
         this.initProductList()
       }
     }

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -103,7 +103,7 @@ export default {
       if (this.priceFilter === 'show_last_month') {
         let oneMonthAgo = new Date()
         oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
-        defaultParams['date__gte'] = oneMonthAgo.toISOString().split('T')[0]
+        defaultParams['date__gte'] = oneMonthAgo.toISOString().substring(0, 10)
       }
       return defaultParams
     },

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -27,7 +27,7 @@
     <v-col>
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('Common.Filter') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="filter in priceFilterList" :key="filter.key" :prepend-icon="(priceFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="priceFilter === filter.key" @click="togglePriceFilter(filter.key)">
@@ -38,7 +38,7 @@
 
       <v-menu>
         <template v-slot:activator="{ props }">
-          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('Common.Order') }}</v-btn>
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -23,6 +23,32 @@
     <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
   </h2>
 
+  <v-row v-if="!loading">
+    <v-col>
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props" size="small" class="mr-2" prepend-icon="mdi-filter-variant" :active="!!priceFilter">{{ $t('BrandDetail.Filter') }}</v-btn>
+        </template>
+        <v-list>
+          <v-list-item :slim="true" v-for="filter in priceFilterList" :key="filter.key" :prepend-icon="(priceFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="priceFilter === filter.key" @click="togglePriceFilter(filter.key)">
+            {{ filter.value }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <v-menu>
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props" size="small" prepend-icon="mdi-arrow-down" :append-icon="getCurrentPriceOrderIcon"  :active="!!priceOrder">{{ $t('BrandDetail.Order') }}</v-btn>
+        </template>
+        <v-list>
+          <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
+            {{ order.value }}
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </v-col>
+  </v-row>
+
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
@@ -41,6 +67,7 @@ import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
 import { defineAsyncComponent } from 'vue'
+import constants from '../constants'
 
 export default {
   components: {
@@ -55,6 +82,11 @@ export default {
       userPriceTotal: null,
       userPricePage: 0,
       loading: false,
+      // filter & order
+      priceFilter: '',
+      priceFilterList: constants.PRICE_FILTER_LIST,
+      priceOrder: constants.PRICE_ORDER_BY_LIST[1].key,
+      priceOrderList: constants.PRICE_ORDER_BY_LIST,
     }
   },
   computed: {
@@ -62,21 +94,60 @@ export default {
     username() {
       return this.$route.params.username
     },
+    getCurrentPriceOrderIcon() {
+      let currentPriceOrder = this.priceOrderList.find(o => o.key === this.priceOrder)
+      return currentPriceOrder ? currentPriceOrder.icon : ''
+    },
+    getPricesParams() {
+      let defaultParams = { owner: this.username, order_by: `${this.priceOrder}`, page: this.userPricePage }
+      if (this.priceFilter === 'show_last_month') {
+        let oneMonthAgo = new Date()
+        oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1)
+        defaultParams['date__gte'] = oneMonthAgo.toISOString().split('T')[0]
+      }
+      return defaultParams
+    },
   },
   mounted() {
+    this.priceFilter = this.$route.query[constants.FILTER_PARAM] || this.priceFilter
+    this.priceOrder = this.$route.query[constants.ORDER_BY_PARAM] || this.priceOrder
     this.getUserPrices()
   },
   methods: {
+    initUserPrices() {
+      this.userPriceList = []
+      this.userPricePage = 0
+      this.getUserPrices()
+    },
     getUserPrices() {
       this.loading = true
       this.userPricePage += 1
-      return api.getPrices({ owner: this.username, page: this.userPricePage })
+      return api.getPrices(this.getPricesParams)
         .then((data) => {
           this.userPriceList.push(...data.items)
           this.userPriceTotal = data.total
           this.loading = false
         })
     },
+    togglePriceFilter(filterKey) {
+      this.priceFilter = this.priceFilter ? '' : filterKey
+      this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.priceFilter } })
+      // this.initUserPrices() will be called in watch $route
+    },
+    selectPriceOrder(orderKey) {
+      if (this.priceOrder !== orderKey) {
+        this.priceOrder = orderKey
+        this.$router.push({ query: { ...this.$route.query, [constants.ORDER_BY_PARAM]: this.priceOrder } })
+        // this.initUserPrices() will be called in watch $route
+      }
+    }
+  },
+  watch: {
+    $route (newRoute, oldRoute) {  // only called when query changes to avoid having an API call when the path changes
+      if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
+        this.initUserPrices()
+      }
+    }
   }
 }
 </script>


### PR DESCRIPTION
### What
- With our database of prices growing and huge GDPR import, we need to have different filters to display prices
- Added price ordering by "last created" descending and "date"
- Added price filtering for the last 30 days (can be further improved/reworked)
- Pages concerned: ProductDetail, LocationDetail, UserDetail

### Screenshot
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/37ace12f-cc20-4e68-9aa5-25ac0479dc38)
### Fixes bug

- Added a small fix to ProductList to avoid doing an API call when going from ProductList page to any other

Closes #343 
