### PR TITLE
feat: Dark mode implemented

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,11 +2,14 @@
   <v-app>
     <Header />
 
-    <v-main class="d-flex justify-center">
-      <v-container>
-        <router-view />
-      </v-container>
-    </v-main>
+    <body
+    :style="{width: '100vw', height:'100%', backgroundColor: isDark ? '#393939' : '#e4e4e4', color: isDark ? '#fff' : '#000' }">
+      <v-main class="d-flex justify-center">
+        <v-container>
+          <router-view />
+        </v-container>
+      </v-main>
+    </body>
 
     <Footer />
   </v-app>
@@ -16,11 +19,22 @@
 import { defineComponent } from 'vue'
 import Header from './components/Header.vue'
 import Footer from './components/Footer.vue'
+import { useAppStore } from './store'
+import { mapStores } from 'pinia'
 
 export default defineComponent({
   components: {
     Header,
     Footer,
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    formFilled() {
+      return Object.values(this.userSettingsForm).every(x => !!x)
+    },
+    isDark() {
+      return this.appStore.getDarkMode;
+    },
   },
 })
 </script>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer class="bg-grey-lighten-1" style="max-height: 20%">
+  <v-footer class="bg-grey-lighten-1" style="position: static; width: 100%;height: 120px; bottom: 0;">
     <v-row>
       <v-col cols="12" md="6" align="center">
         <i18n-t keypath="Footer.TagLine" tag="span">
@@ -10,9 +10,11 @@
         </i18n-t>
       </v-col>
       <v-col cols="12" md="6" align="center">
-        <v-btn class="mx-2" variant="text" href="https://prices.openfoodfacts.org" target="_blank">{{ $t('Footer.About') }}</v-btn>
+        <v-btn class="mx-2" variant="text" href="https://prices.openfoodfacts.org" target="_blank">{{ $t('Footer.About')
+        }}</v-btn>
         <v-btn class="mx-2" variant="text" to="/stats">{{ $t('Footer.Stats') }}</v-btn>
-        <v-btn class="mx-2" variant="text" href="https://github.com/openfoodfacts/open-prices-frontend" target="_blank">Github</v-btn>
+        <v-btn class="mx-2" variant="text" href="https://github.com/openfoodfacts/open-prices-frontend"
+          target="_blank">Github</v-btn>
       </v-col>
     </v-row>
   </v-footer>

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia'
 import utils from './utils.js'
 
+const getDefaultDarkModeValue = () => {
+  const prefersDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return prefersDarkMode;
+};
+
 export const useAppStore = defineStore('app', {
   state: () => ({
     user: {
@@ -11,6 +16,7 @@ export const useAppStore = defineStore('app', {
       recent_locations: [],
       language: localStorage.getItem('user-locale') || import.meta.env.VITE_DEFAULT_LOCALE,  // 'en'
       country: import.meta.env.VITE_DEFAULT_COUNTRY,  // 'FR',
+      darkMode: getDefaultDarkModeValue(),
     },
   }),
   getters: {
@@ -31,7 +37,10 @@ export const useAppStore = defineStore('app', {
     },
     getUserCountry: (state) => {
       return state.user.country
-    }
+    },
+    getDarkMode: (state) => {
+      return state.user.darkMode;
+    },
   },
   actions: {
     signIn(username, token) {
@@ -59,6 +68,9 @@ export const useAppStore = defineStore('app', {
     },
     setCountry(country) {
       this.user.country = country
+    },
+    setDarkMode(isDark) {
+      this.user.darkMode = isDark;
     }
   },
   // pinia-plugin-persistedstate

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -56,6 +56,19 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-row>
+    <v-col cols="12" sm="6">
+        <v-card :title="$t('Change Mode')" prepend-icon="mdi-brightness-4">
+          <v-divider></v-divider>
+          <v-card-text>
+            <v-radio-group v-model="userSettingsForm.darkMode">
+              <v-radio label="Dark Mode" value="dark"></v-radio>
+              <v-radio label="Light Mode" value="light"></v-radio>
+            </v-radio-group>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
 
     <v-row>
       <v-col>
@@ -81,6 +94,7 @@ export default {
         selectedCountry: null, // see initUserSettingsForm
         selectedLanguage: null, // see initUserSettingsForm
         currency: null,  // see initUserSettingsForm
+        darkMode: null,
       },
       currencyList: constants.CURRENCY_LIST,
       languageList: [],
@@ -92,6 +106,18 @@ export default {
     'userSettingsForm.selectedLanguage': async function () {
       if (this.userSettingsForm.selectedLanguage !== null) {
         this.languageTranslationCompletion = await localeManager.calculateTranslationCompletion(this.userSettingsForm.selectedLanguage.code)
+      }
+    },
+    'userSettingsForm.darkMode': function (newDarkMode, oldDarkMode) {
+      if (newDarkMode !== oldDarkMode) {
+        if (newDarkMode === 'dark') {
+          this.appStore.setDarkMode(true);
+        } else if (newDarkMode === 'light') {
+          this.appStore.setDarkMode(false);
+        } else {
+          const systemDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          this.appStore.setDarkMode(systemDarkMode);
+        }
       }
     },
 
@@ -115,6 +141,7 @@ export default {
       this.userSettingsForm.currency = this.appStore.user.last_currency_used
       this.userSettingsForm.selectedLanguage = this.languageList.find(lang => lang.code === localeManager.guessDefaultLocale()) || this.languageList.find(lang => lang.code === 'en')
       this.userSettingsForm.selectedCountry = countryData.find(country => country.code === this.appStore.user.country).code  
+      this.userSettingsForm.darkMode = 'system'
     },
     async updateSettings() {
       await localeManager.changeLanguage(this.userSettingsForm.selectedLanguage.code)


### PR DESCRIPTION
What

I added a dark mode to the user settings file, resolved the footer issue from the previous [pull request](https://github.com/openfoodfacts/open-prices-frontend/pull/339), eliminated the "Follow System Settings" option, and aligned the dark mode with the system default value.

Screenshot

Dark mode:

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/84843461/4fc025b5-14be-4326-a597-0814ed6b821b)

Light mode:

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/84843461/0c39bcb3-d1a7-4376-9e8d-e08d60254a69)

System mode:

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/84843461/4ed8ed4d-a877-4aa3-9b02-b465dd802ec5)

Part of
https://github.com/openfoodfacts/open-prices-frontend/issues/274