### PR TITLE
feat(products): display categories & labels count

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -21,9 +21,15 @@
             <span v-if="hasProductQuantity">
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
+            <br />
             <span>
-              <br />
-              <v-chip label size="small" density="comfortable" class="mr-1">{{ product.code }}</v-chip>
+              <v-chip label size="small" density="comfortable" class="mr-1">
+                {{ $t('ProductCard.CategoryTotal', { count: product ? product.categories_tags.length : 0 }) }}
+              </v-chip>
+            </span>
+            <br />
+            <span>
+              <v-chip label size="small" density="comfortable">{{ product.code }}</v-chip>
             </span>
           </p>
         </v-col>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -26,6 +26,9 @@
               <v-chip label size="small" density="comfortable" class="mr-1">
                 {{ $t('ProductCard.CategoryTotal', { count: product ? product.categories_tags.length : 0 }) }}
               </v-chip>
+              <v-chip label size="small" density="comfortable">
+                {{ $t('ProductCard.LabelTotal', { count: product ? product.labels_tags.length : 0 }) }}
+              </v-chip>
             </span>
             <br />
             <span>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -174,6 +174,7 @@
 	},
 	"ProductCard": {
 		"CategoryTotal": "{count} categories",
+		"LabelTotal": "{count} labels",
 		"LatestPrice": "Latest price",
 		"ProductQuantityGram": "{0} g",
 		"ProductQuantityKilogram": "{0} kg",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -173,6 +173,7 @@
 		"Title": "Latest prices"
 	},
 	"ProductCard": {
+		"CategoryTotal": "{count} categories",
 		"LatestPrice": "Latest price",
 		"ProductQuantityGram": "{0} g",
 		"ProductQuantityKilogram": "{0} kg",


### PR DESCRIPTION
### What

Thanks to the new fields in the backend, we can start displaying a badge with the count
- `Product.categories_tags` : https://github.com/openfoodfacts/open-prices/issues/154
- `Product.labels_tags` : https://github.com/openfoodfacts/open-prices/issues/216

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/ea7794b2-a259-4e5d-b7d7-a96db2aec219)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/2eee9b3c-426c-41b2-888e-0c0c053bd31b)|
