### PR TITLE
feat(products): display popup with product categories

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -23,11 +23,11 @@
             </span>
             <br />
             <span>
-              <v-chip label size="small" density="comfortable" class="mr-1">
-                {{ $t('ProductCard.CategoryTotal', { count: product ? product.categories_tags.length : 0 }) }}
+              <v-chip label size="small" density="comfortable" class="mr-1" @click="showProductCategoriesDialog">
+                {{ $t('ProductCard.CategoryTotal', { count: (product && product.categories_tags) ? product.categories_tags.length : 0 }) }}
               </v-chip>
               <v-chip label size="small" density="comfortable">
-                {{ $t('ProductCard.LabelTotal', { count: product ? product.labels_tags.length : 0 }) }}
+                {{ $t('ProductCard.LabelTotal', { count: (product && product.labels_tags) ? product.labels_tags.length : 0 }) }}
               </v-chip>
             </span>
             <br />
@@ -46,6 +46,13 @@
       </v-sheet>
     </v-container>
   </v-card>
+
+  <ProductCategoriesDialog
+    v-if="product && product.categories_tags && productCategoriesDialog"
+    :categories="product.categories_tags"
+    v-model="productCategoriesDialog"
+    @close="productCategoriesDialog = false"
+  ></ProductCategoriesDialog>
 </template>
 
 <script>
@@ -56,7 +63,8 @@ export default {
     'PriceCountChip': defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
     'ProductQuantityChip': defineAsyncComponent(() => import('../components/ProductQuantityChip.vue')),
     'PricePrice': defineAsyncComponent(() => import('../components/PricePrice.vue')),
-    'PriceFooter': defineAsyncComponent(() => import('../components/PriceFooter.vue'))
+    'PriceFooter': defineAsyncComponent(() => import('../components/PriceFooter.vue')),
+    'ProductCategoriesDialog': defineAsyncComponent(() => import('../components/ProductCategoriesDialog.vue')),
   },
   props: {
     'product': null,
@@ -66,6 +74,7 @@ export default {
   data() {
     return {
       productImageDefault: 'https://world.openfoodfacts.org/images/icons/dist/packaging.svg',
+      productCategoriesDialog: false,
     }
   },
   mounted() {
@@ -86,6 +95,9 @@ export default {
   methods: {
     getProductTitle() {
       return this.product.product_name || this.$t('ProductCard.UnknownProduct')
+    },
+    showProductCategoriesDialog() {
+      this.productCategoriesDialog = true
     },
     goToProduct() {
       if (this.readonly) {

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -14,7 +14,7 @@
               <PriceCountChip :count="product.price_count" @click="goToProduct()"></PriceCountChip>
             </span>
             <span v-if="hasProductBrands">
-              <v-chip v-for="brand in getProductBrandsList" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
+              <v-chip v-for="brand in getProductBrandsList" :key="brand" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
                 {{ brand }}
               </v-chip>
             </span>

--- a/src/components/ProductCategoriesDialog.vue
+++ b/src/components/ProductCategoriesDialog.vue
@@ -8,7 +8,7 @@
       <v-divider></v-divider>
 
       <v-card-text v-if="categories.length">
-        <v-chip v-for="category in categories" label class="mr-2 mb-2">
+        <v-chip v-for="category in categories" :key="category" label class="mr-2 mb-2">
           {{ category }}
         </v-chip>
       </v-card-text>

--- a/src/components/ProductCategoriesDialog.vue
+++ b/src/components/ProductCategoriesDialog.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-dialog>
+    <v-card>
+      <v-card-title>
+        {{ $t('ProductCategories.Title') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+      </v-card-title>
+
+      <v-divider></v-divider>
+
+      <v-card-text v-if="categories.length">
+        <v-chip v-for="category in categories" label class="mr-2 mb-2">
+          {{ category }}
+        </v-chip>
+      </v-card-text>
+      <v-card-text v-if="!categories.length">
+        <span class="text-red">{{ $t('ProductCategories.Empty') }}</span>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  props: {
+    'categories': Array,
+  },
+  data() {
+    return {
+    }
+  },
+  computed: {
+  },
+  mounted() {
+  },
+  methods: {
+    close() {
+      this.$emit('close')
+    },
+  }
+}
+</script>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -184,7 +184,7 @@
 	},
 	"ProductCategories": {
 		"Title": "Categories",
-		"Empty": "This product does not have any categories yet."
+		"Empty": "No categories have been added to this product yet."
 	},
 	"ProductDetail": {
 		"AddPrice": "Add a price",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -182,6 +182,10 @@
 		"ProductQuantityLitre": "{0} L",
 		"UnknownProduct": "Unknown product name"
 	},
+	"ProductCategories": {
+		"Title": "Categories",
+		"Empty": "This product does not have any categories yet."
+	},
 	"ProductDetail": {
 		"AddPrice": "Add a price",
 		"CategoryNotFound": "Category not found...",


### PR DESCRIPTION
### What

Following #367

When the user clicks on the new "product categories count chip", a popup opens with the list of the categories.

### Screenshot

|Product without categories|Product with categories|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/95b729d5-6434-4f27-af7c-cec06dfa70c2)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/1c3fb181-69d2-4b92-b1ea-86c668ca4c79)|