### PR TITLE
feat(price create form): allow user to select a recent proof

### DIFF
--- a/src/components/ExistingProofDialog.vue
+++ b/src/components/ExistingProofDialog.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-dialog>
+  <v-dialog max-height="80%" width="80%">
     <v-card>
       <v-card-title>
         {{ $t('ExistingProofDialog.ChooseLatestProofs') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text>
+      <v-card-text style="overflow-y:scroll;">
         <v-row>
           <v-col cols="12" sm="6" md="3" v-for="proof in userProofList" :key="proof">
-            <ProofCard :proof="proof" :hideProofDelete="true" :isSelectable="true" :isSelected="selectedProof === proof" @proofSelected="selectProof"></ProofCard>
+            <ProofCard :proof="proof" :hideProofDelete="true" :isSelectable="true" @proofSelected="selectProof"></ProofCard>
           </v-col>
         </v-row>
     </v-card-text>

--- a/src/components/ExistingProofDialog.vue
+++ b/src/components/ExistingProofDialog.vue
@@ -7,25 +7,12 @@
       <v-divider></v-divider>
       <v-card-text>
         <v-row>
-          <v-col cols="6" sm="6" md="3" v-for="proof in userProofList" :key="proof">
-            <ProofCard :proof="proof" :reducedProofFooter="true" :isSelectable="true" :isSelected="selectedProof === proof" @proofSelected="selectProof"></ProofCard>
+          <v-col cols="12" sm="6" md="3" v-for="proof in userProofList" :key="proof">
+            <ProofCard :proof="proof" :hideProofDelete="true" :isSelectable="true" :isSelected="selectedProof === proof" @proofSelected="selectProof"></ProofCard>
           </v-col>
         </v-row>
     </v-card-text>
     </v-card>
-    <v-bottom-sheet v-model="showConfirmationPopup">
-      <v-card>
-        <v-card-text class="d-flex align-center">
-          {{ $t('ExistingProofDialog.SelectThis') }}
-          <v-btn class="mb-2 ml-2" size="small" prepend-icon="mdi-check-circle" @click="confirmSelection">
-            <span class="d-sm-inline-flex">{{ $t('Common.Yes') }}</span>
-          </v-btn>
-          <v-btn class="mb-2 ml-2" size="small" prepend-icon="mdi-close-circle-outline" @click="cancelSelection">
-            <span class="d-sm-inline-flex">{{ $t('Common.No') }}</span>
-          </v-btn>
-        </v-card-text>
-      </v-card>
-    </v-bottom-sheet>
   </v-dialog>
 </template>
 
@@ -46,7 +33,6 @@ export default {
       userProofPage: 1,
       loading: false,
       selectedProof: null,
-      showConfirmationPopup: false,
     }
   },
   computed: {
@@ -74,16 +60,8 @@ export default {
     },
     selectProof(proof) {
       this.selectedProof = proof
-      this.showConfirmationPopup = true
-    },
-    confirmSelection() {
-      this.showConfirmationPopup = false
-      this.$emit('proofConfirmed', this.selectedProof);
+      this.$emit('proofConfirmed', this.selectedProof)
       this.close()
-    },
-    cancelSelection() {
-      this.selectedProof = null;
-      this.showConfirmationPopup = false
     },
     close() {
       this.$emit('close')
@@ -91,9 +69,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-.d-flex {
-  display: flex;
-}
-</style>

--- a/src/components/ExistingProofDialog.vue
+++ b/src/components/ExistingProofDialog.vue
@@ -1,0 +1,102 @@
+<template>
+  <v-dialog>
+    <v-card>
+      <v-card-title>
+        {{ $t('UserDashboard.LatestProofs') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text>
+        <v-row>
+          <v-col cols="6" sm="6" md="3" v-for="proof in userProofList" :key="proof">
+            <ProofCard :proof="proof" :showProofFooter="false" :isSelectable="true" :isSelected="selectedProof === proof" @proofSelected="selectProof"></ProofCard>
+          </v-col>
+        </v-row>
+    </v-card-text>
+    </v-card>
+    <v-dialog v-model="showConfirmationPopup">
+      <v-card>
+        <v-card-title>Confirmation</v-card-title>
+        <v-card-text>Are you sure you want to select this proof?</v-card-text>
+        <v-card-actions>
+          <v-btn text @click="confirmSelection">Yes</v-btn>
+          <v-btn text @click="cancelSelection">No</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-dialog>
+</template>
+
+<script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import api from '../services/api'
+import ProofCard from '../components/ProofCard.vue'
+
+export default {
+  components: {
+    ProofCard,
+  },
+  data() {
+    return {
+      userProofList: [],
+      userProofTotal: null,
+      userProofPage: 1,
+      loading: false,
+      selectedProof: null,
+      showConfirmationPopup: false,
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    username() {
+      return this.appStore.user.username
+    },
+  },
+  mounted() {
+    this.getUserProofs()
+  },
+  methods: {
+    getUserProofs() {
+      this.loading = true
+      return api.getProofs({ owner: this.username, page: this.userProofPage })
+        .then((data) => {
+          this.userProofList.push(...data.items)
+          this.userProofTotal = data.total
+          this.loading = false
+        })
+        .catch((error) => {
+          console.error(error)
+          this.loading = false
+    })
+    },
+    selectProof(proof) {
+      this.selectedProof = proof
+      this.showConfirmationPopup = true
+    },
+    confirmSelection() {
+      this.showConfirmationPopup = false
+      this.$emit('proofConfirmed', this.selectedProof);
+      this.close()
+    },
+    cancelSelection() {
+      this.selectedProof = null;
+      this.showConfirmationPopup = false
+    },
+    close() {
+      this.$emit('close')
+    },
+  }
+}
+</script>
+
+<style scoped>
+.d-inline-block {
+  display: inline-block;
+}
+.align-start {
+  align-items: start;
+}
+.d-flex {
+  display: flex;
+}
+</style>

--- a/src/components/ExistingProofDialog.vue
+++ b/src/components/ExistingProofDialog.vue
@@ -2,27 +2,30 @@
   <v-dialog>
     <v-card>
       <v-card-title>
-        {{ $t('UserDashboard.LatestProofs') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+        {{ $t('ExistingProofDialog.ChooseLatestProofs') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
       </v-card-title>
       <v-divider></v-divider>
       <v-card-text>
         <v-row>
           <v-col cols="6" sm="6" md="3" v-for="proof in userProofList" :key="proof">
-            <ProofCard :proof="proof" :showProofFooter="false" :isSelectable="true" :isSelected="selectedProof === proof" @proofSelected="selectProof"></ProofCard>
+            <ProofCard :proof="proof" :reducedProofFooter="true" :isSelectable="true" :isSelected="selectedProof === proof" @proofSelected="selectProof"></ProofCard>
           </v-col>
         </v-row>
     </v-card-text>
     </v-card>
-    <v-dialog v-model="showConfirmationPopup">
+    <v-bottom-sheet v-model="showConfirmationPopup">
       <v-card>
-        <v-card-title>Confirmation</v-card-title>
-        <v-card-text>Are you sure you want to select this proof?</v-card-text>
-        <v-card-actions>
-          <v-btn text @click="confirmSelection">Yes</v-btn>
-          <v-btn text @click="cancelSelection">No</v-btn>
-        </v-card-actions>
+        <v-card-text class="d-flex align-center">
+          {{ $t('ExistingProofDialog.SelectThis') }}
+          <v-btn class="mb-2 ml-2" size="small" prepend-icon="mdi-check-circle" @click="confirmSelection">
+            <span class="d-sm-inline-flex">{{ $t('Common.Yes') }}</span>
+          </v-btn>
+          <v-btn class="mb-2 ml-2" size="small" prepend-icon="mdi-close-circle-outline" @click="cancelSelection">
+            <span class="d-sm-inline-flex">{{ $t('Common.No') }}</span>
+          </v-btn>
+        </v-card-text>
       </v-card>
-    </v-dialog>
+    </v-bottom-sheet>
   </v-dialog>
 </template>
 
@@ -90,12 +93,6 @@ export default {
 </script>
 
 <style scoped>
-.d-inline-block {
-  display: inline-block;
-}
-.align-start {
-  align-items: start;
-}
 .d-flex {
   display: flex;
 }

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-card :id="'proof_' + proof.id" :class="{ 'full-screen-proof-card': isSelected }" @click="selectProof">
+  <v-card :id="'proof_' + proof.id" @click="selectProof">
     <v-card-text>
       <v-img :src="getProofUrl(proof)"></v-img>
     </v-card-text>
     <v-divider v-if="!isSelected"></v-divider>
     <v-card-text v-if="!isSelected">
-      <ProofFooter :proof="proof" :reducedProofFooter="reducedProofFooter"></ProofFooter>
+      <ProofFooter :proof="proof" :hideProofDelete="hideProofDelete"></ProofFooter>
     </v-card-text>
   </v-card>
 </template>
@@ -19,7 +19,7 @@ export default {
   },
   props: {
     'proof': null,
-    reducedProofFooter: {
+    hideProofDelete: {
       type: Boolean,
       default: false,
     },
@@ -50,20 +50,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-.highlighted {
-  background-color: rgb(0, 255, 64);
-}
-.full-screen-proof-card {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1000;
-  object-fit: cover;
-}
-</style>

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-card :id="'proof_' + proof.id">
+  <v-card :id="'proof_' + proof.id" :class="{ 'highlighted': isSelected }" @click="selectProof">
     <v-card-text>
       <v-img :src="getProofUrl(proof)"></v-img>
     </v-card-text>
     <v-divider></v-divider>
-    <v-card-text>
+    <v-card-text v-if="showProofFooter">
       <ProofFooter :proof="proof"></ProofFooter>
     </v-card-text>
   </v-card>
@@ -19,11 +19,29 @@ export default {
   },
   props: {
     'proof': null,
+    showProofFooter: {
+      type: Boolean,
+      default: true,
+    },
+    isSelectable: {
+      type: Boolean,
+      default: false,
+    },
+    isSelected: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
-    return {}
+    return {
+    }
   },
   methods: {
+    selectProof() {
+      if (this.isSelectable) {
+        this.$emit('proofSelected', this.proof)
+      }
+    },
     getProofUrl(proof) {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'
@@ -32,3 +50,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.highlighted {
+  background-color: rgb(0, 255, 64);
+}
+</style>

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -3,8 +3,8 @@
     <v-card-text>
       <v-img :src="getProofUrl(proof)"></v-img>
     </v-card-text>
-    <v-divider v-if="!isSelected"></v-divider>
-    <v-card-text v-if="!isSelected">
+    <v-divider></v-divider>
+    <v-card-text>
       <ProofFooter :proof="proof" :hideProofDelete="hideProofDelete"></ProofFooter>
     </v-card-text>
   </v-card>
@@ -24,10 +24,6 @@ export default {
       default: false,
     },
     isSelectable: {
-      type: Boolean,
-      default: false,
-    },
-    isSelected: {
       type: Boolean,
       default: false,
     },

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-card :id="'proof_' + proof.id" :class="{ 'highlighted': isSelected }" @click="selectProof">
+  <v-card :id="'proof_' + proof.id" :class="{ 'full-screen-proof-card': isSelected }" @click="selectProof">
     <v-card-text>
       <v-img :src="getProofUrl(proof)"></v-img>
     </v-card-text>
-    <v-divider></v-divider>
-    <v-card-text v-if="showProofFooter">
-      <ProofFooter :proof="proof"></ProofFooter>
+    <v-divider v-if="!isSelected"></v-divider>
+    <v-card-text v-if="!isSelected">
+      <ProofFooter :proof="proof" :reducedProofFooter="reducedProofFooter"></ProofFooter>
     </v-card-text>
   </v-card>
 </template>
@@ -19,9 +19,9 @@ export default {
   },
   props: {
     'proof': null,
-    showProofFooter: {
+    reducedProofFooter: {
       type: Boolean,
-      default: true,
+      default: false,
     },
     isSelectable: {
       type: Boolean,
@@ -54,5 +54,16 @@ export default {
 <style scoped>
 .highlighted {
   background-color: rgb(0, 255, 64);
+}
+.full-screen-proof-card {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  object-fit: cover;
 }
 </style>

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex flex-wrap ga-1">
-    <v-chip label size="small" density="comfortable">
+    <v-chip v-if="!reducedProofFooter" label size="small" density="comfortable">
       <v-icon start icon="mdi-paperclip"></v-icon>
       <span v-if="proof.type === 'GDPR_REQUEST'">
         <a :href="OFF_WIKI_GDPR_REQUEST_URL" target="_blank">
@@ -13,9 +13,9 @@
       </span>
       
     </v-chip>
-    <PriceCountChip :count="proof.price_count" :withLabel="true"></PriceCountChip>
+    <PriceCountChip v-if="!reducedProofFooter" :count="proof.price_count" :withLabel="true"></PriceCountChip>
     <RelativeDateTimeChip :dateTime="proof.created"></RelativeDateTimeChip>
-    <ProofDeleteChip v-if="userCanDeleteProof" :proof="proof"></ProofDeleteChip>
+    <ProofDeleteChip v-if="!reducedProofFooter && userCanDeleteProof" :proof="proof"></ProofDeleteChip>
   </div>
 </template>
 
@@ -33,6 +33,10 @@ export default {
   },
   props: {
     'proof': null,
+    reducedProofFooter: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex flex-wrap ga-1">
-    <v-chip v-if="!reducedProofFooter" label size="small" density="comfortable">
+    <v-chip label size="small" density="comfortable">
       <v-icon start icon="mdi-paperclip"></v-icon>
       <span v-if="proof.type === 'GDPR_REQUEST'">
         <a :href="OFF_WIKI_GDPR_REQUEST_URL" target="_blank">
@@ -13,9 +13,9 @@
       </span>
       
     </v-chip>
-    <PriceCountChip v-if="!reducedProofFooter" :count="proof.price_count" :withLabel="true"></PriceCountChip>
+    <PriceCountChip :count="proof.price_count" :withLabel="true"></PriceCountChip>
     <RelativeDateTimeChip :dateTime="proof.created"></RelativeDateTimeChip>
-    <ProofDeleteChip v-if="!reducedProofFooter && userCanDeleteProof" :proof="proof"></ProofDeleteChip>
+    <ProofDeleteChip v-if="!hideProofDelete && userCanDeleteProof" :proof="proof"></ProofDeleteChip>
   </div>
 </template>
 
@@ -33,7 +33,7 @@ export default {
   },
   props: {
     'proof': null,
-    reducedProofFooter: {
+    hideProofDelete: {
       type: Boolean,
       default: false,
     },

--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -2,7 +2,7 @@
   <v-dialog max-height="80%" width="80%">
     <v-card>
       <v-card-title>
-        {{ $t('ExistingProofDialog.ChooseLatestProofs') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+        {{ $t('UserRecentProofsDialog.SelectRecentProof') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
       </v-card-title>
       <v-divider></v-divider>
       <v-card-text style="overflow-y:scroll;">
@@ -11,7 +11,7 @@
             <ProofCard :proof="proof" :hideProofDelete="true" :isSelectable="true" @proofSelected="selectProof"></ProofCard>
           </v-col>
         </v-row>
-    </v-card-text>
+      </v-card-text>
     </v-card>
   </v-dialog>
 </template>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -44,6 +44,7 @@
 			"LabelFull": "Full price",
 			"Proof": "Proof",
 			"ProofDateChanged": "Date updated!",
+			"ProofSelected": "Proof selected!",
 			"ProofUploaded": "Proof uploaded!",
 			"Title": "Price details",
 			"UploadProof": "Upload a proof",
@@ -102,7 +103,13 @@
 	"Common": {
 		"Filter": "Filter",
 		"Order": "Order",
-		"SignInOFFAccount": "Sign in with your {url} account"
+		"SignInOFFAccount": "Sign in with your {url} account",
+		"Yes": "Yes",
+		"No": "No"
+	},
+	"ExistingProofDialog": {
+		"ChooseLatestProofs": "Choose from latest proofs",
+		"SelectThis": "Select this proof?"
 	},
 	"Footer": {
 		"About": "About",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -50,7 +50,9 @@
 			"Picture": "Picture",
 			"TakePicture": "Take a picture",
 			"Gallery": "Device gallery",
-			"SelectFromGallery": "Select from device gallery"
+			"SelectFromGallery": "Select from device gallery",
+			"ExistingProof": "Existing proof",
+			"SelectExistingProof": "Select an existing proof"
 		},
 		"ProductInfo": {
 			"CategoryLabel": "Category",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -52,8 +52,8 @@
 			"TakePicture": "Take a picture",
 			"Gallery": "Device gallery",
 			"SelectFromGallery": "Select from device gallery",
-			"ExistingProof": "Existing proof",
-			"SelectExistingProof": "Select an existing proof"
+			"RecentProof": "Recent proof",
+			"SelectRecentProof": "Select a recent proof"
 		},
 		"ProductInfo": {
 			"CategoryLabel": "Category",
@@ -107,9 +107,8 @@
 		"Yes": "Yes",
 		"No": "No"
 	},
-	"ExistingProofDialog": {
-		"ChooseLatestProofs": "Choose from latest proofs",
-		"SelectThis": "Select this proof?"
+	"UserRecentProofsDialog": {
+		"SelectRecentProof": "Select one of your recent proofs"
 	},
 	"Footer": {
 		"About": "About",

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -20,9 +20,9 @@
             <v-col>
               <v-btn class="mb-2 mr-2" size="small" prepend-icon="mdi-camera" @click.prevent="$refs.proofCamera.click()" :loading="createProofLoading" :disabled="createProofLoading">{{ $t('AddPriceSingle.PriceDetails.TakePicture') }}</v-btn>
               <a href="#" @click.prevent="$refs.proofGallery.click()">{{ $t('AddPriceSingle.PriceDetails.SelectFromGallery') }}</a>
-              <v-btn class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showExistingProofs">
-                  <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.ExistingProof') }}</span>
-                  <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectExistingProof') }}</span>
+              <v-btn class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showUserRecentProofs">
+                  <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.RecentProof') }}</span>
+                  <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectRecentProof') }}</span>
                 </v-btn>
               <v-file-input
                 class="d-none overflow-hidden"
@@ -317,12 +317,12 @@
     @barcode="setProductCode($event)"
     @close="barcodeManualInput = false"
   ></BarcodeManualInput>
-  <ExistingProofDialog
-    v-if="existingProofDialog"
-    v-model="existingProofDialog"
+  <UserRecentProofsDialog
+    v-if="userRecentProofsDialog"
+    v-model="userRecentProofsDialog"
     @proofConfirmed="handleProofConfirmed"
-    @close="existingProofDialog = false"
-  ></ExistingProofDialog>
+    @close="userRecentProofsDialog = false"
+  ></UserRecentProofsDialog>
 </template>
 
 <script>
@@ -348,7 +348,7 @@ export default {
     'ProductCard': defineAsyncComponent(() => import('../components/ProductCard.vue')),
     'BarcodeScanner': defineAsyncComponent(() => import('../components/BarcodeScanner.vue')),
     'BarcodeManualInput': defineAsyncComponent(() => import('../components/BarcodeManualInput.vue')),
-    'ExistingProofDialog': defineAsyncComponent(() => import('../components/ExistingProofDialog.vue'))
+    'UserRecentProofsDialog': defineAsyncComponent(() => import('../components/UserRecentProofsDialog.vue'))
   },
   data() {
     return {
@@ -370,7 +370,7 @@ export default {
       createProofLoading: false,
       proofDateSuccessMessage: false,
       proofSuccessMessage: false,
-      existingProofDialog: false,
+      userRecentProofsDialog: false,
       proofSelectedSuccessMessage: false,
       proofSelectedMessage: false,
       // location data
@@ -478,8 +478,8 @@ export default {
     addPriceToUploadedList(price) {
       this.productPriceUploadedList.push(price)
     },
-    showExistingProofs() {
-      this.existingProofDialog = true
+    showUserRecentProofs() {
+      this.userRecentProofsDialog = true
     },
     handleProofConfirmed(selectedProof) {
       this.addPriceMultipleForm.proof_id = selectedProof.id

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -43,15 +43,13 @@
                 @click:clear="clearProof"
                 :loading="createProofLoading">
               </v-file-input>
-              <p v-if="proofFormFilled && !createProofLoading && !proofSelectedMessage" class="text-green mt-2 mb-2">
-                <i>{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
-              </p>
+              <p v-if="proofFormFilled && !createProofLoading" class="text-green mt-2 mb-2">
+                  <i v-if="!proofSelectedMessage">{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
+                  <i v-if="proofSelectedMessage">{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
+                </p>
               <p v-if="!proofFormFilled && !createProofLoading" class="text-red mt-2 mb-2">
                 <i>{{ $t('AddPriceSingle.PriceDetails.UploadProof') }}</i>
               </p>
-              <p v-if="proofFormFilled && proofSelectedMessage" class="text-green mt-2 mb-2">
-                  <i>{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
-                </p>
               <p v-if="proofType === 'RECEIPT'" class="text-warning">
                 <i>{{ $t('AddPriceMultiple.ProofDetails.ReceiptWarning') }}</i>
               </p>

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -173,14 +173,12 @@
                   @click:clear="clearProof"
                   :loading="createProofLoading">
                 </v-file-input>
-                <p v-if="proofFormFilled && !createProofLoading && !proofSelectedMessage" class="text-green mt-2 mb-2">
-                  <i>{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
+                <p v-if="proofFormFilled && !createProofLoading" class="text-green mt-2 mb-2">
+                  <i v-if="!proofSelectedMessage">{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
+                  <i v-if="proofSelectedMessage">{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
                 </p>
                 <p v-if="!proofFormFilled && !createProofLoading" class="text-red mt-2 mb-2">
                   <i>{{ $t('AddPriceSingle.PriceDetails.UploadProof') }}</i>
-                </p>
-                <p v-if="proofFormFilled && proofSelectedMessage" class="text-green mt-2 mb-2">
-                  <i>{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
                 </p>
               </v-col>
               <v-col v-if="proofFormFilled">

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -150,6 +150,10 @@
                   <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Gallery') }}</span>
                   <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectFromGallery') }}</span>
                 </v-btn>
+                <v-btn class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showExistingProofs">
+                  <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.ExistingProof') }}</span>
+                  <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectExistingProof') }}</span>
+                </v-btn>
                 <v-file-input
                   class="d-none overflow-hidden"
                   ref="proofCamera"
@@ -265,6 +269,12 @@
     @location="setLocationData($event)"
     @close="closeLocationSelector($event)"
   ></LocationSelector>
+  <ExistingProofDialog
+    v-if="existingProofDialog"
+    v-model="existingProofDialog"
+    @proofConfirmed="handleProofConfirmed"
+    @close="existingProofDialog = false"
+  ></ExistingProofDialog>
 </template>
 
 <script>
@@ -290,7 +300,8 @@ export default {
     'ProductCard': defineAsyncComponent(() => import('../components/ProductCard.vue')),
     'BarcodeScanner': defineAsyncComponent(() => import('../components/BarcodeScanner.vue')),
     'BarcodeManualInput': defineAsyncComponent(() => import('../components/BarcodeManualInput.vue')),
-    'LocationSelector': defineAsyncComponent(() => import('../components/LocationSelector.vue'))
+    'LocationSelector': defineAsyncComponent(() => import('../components/LocationSelector.vue')),
+    'ExistingProofDialog': defineAsyncComponent(() => import('../components/ExistingProofDialog.vue')),
   },
   data() {
     return {
@@ -328,6 +339,7 @@ export default {
       locationSelector: false,
       locationSelectedDisplayName: '',
       // proof data
+      existingProofDialog: false,
       proofImage: null,
       proofImagePreview: null,
       createProofLoading: false,
@@ -405,6 +417,17 @@ export default {
       }
       this.addPriceSingleForm.price_per = this.categoryPricePerList[0].key // init to 'KILOGRAM' because it's the most common use-case
       this.addPriceSingleForm.currency = this.appStore.user.last_currency_used
+    },
+    showExistingProofs() {
+      this.existingProofDialog = true
+    },
+    handleProofConfirmed(selectedProof) {
+      this.addPriceSingleForm.proof_id = selectedProof.id
+      this.proofImagePreview = this.getProofUrl(selectedProof)
+      this.proofSuccessMessage = true
+    },
+    getProofUrl(proof) {
+      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
     },
     newProof(source) {
       if (source === 'gallery') {

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -150,9 +150,9 @@
                   <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Gallery') }}</span>
                   <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectFromGallery') }}</span>
                 </v-btn>
-                <v-btn class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showExistingProofs">
-                  <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.ExistingProof') }}</span>
-                  <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectExistingProof') }}</span>
+                <v-btn class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showUserRecentProofs">
+                  <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.RecentProof') }}</span>
+                  <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectRecentProof') }}</span>
                 </v-btn>
                 <v-file-input
                   class="d-none overflow-hidden"
@@ -273,14 +273,14 @@
     v-if="locationSelector"
     v-model="locationSelector"
     @location="setLocationData($event)"
-    @close="closeLocationSelector($event)"
+    @close="locationSelector = false"
   ></LocationSelector>
-  <ExistingProofDialog
-    v-if="existingProofDialog"
-    v-model="existingProofDialog"
+  <UserRecentProofsDialog
+    v-if="userRecentProofsDialog"
+    v-model="userRecentProofsDialog"
     @proofConfirmed="handleProofConfirmed"
-    @close="existingProofDialog = false"
-  ></ExistingProofDialog>
+    @close="userRecentProofsDialog = false"
+  ></UserRecentProofsDialog>
 </template>
 
 <script>
@@ -307,7 +307,7 @@ export default {
     'BarcodeScanner': defineAsyncComponent(() => import('../components/BarcodeScanner.vue')),
     'BarcodeManualInput': defineAsyncComponent(() => import('../components/BarcodeManualInput.vue')),
     'LocationSelector': defineAsyncComponent(() => import('../components/LocationSelector.vue')),
-    'ExistingProofDialog': defineAsyncComponent(() => import('../components/ExistingProofDialog.vue')),
+    'UserRecentProofsDialog': defineAsyncComponent(() => import('../components/UserRecentProofsDialog.vue')),
   },
   data() {
     return {
@@ -345,7 +345,7 @@ export default {
       locationSelector: false,
       locationSelectedDisplayName: '',
       // proof data
-      existingProofDialog: false,
+      userRecentProofsDialog: false,
       proofImage: null,
       proofImagePreview: null,
       createProofLoading: false,
@@ -426,8 +426,8 @@ export default {
       this.addPriceSingleForm.price_per = this.categoryPricePerList[0].key // init to 'KILOGRAM' because it's the most common use-case
       this.addPriceSingleForm.currency = this.appStore.user.last_currency_used
     },
-    showExistingProofs() {
-      this.existingProofDialog = true
+    showUserRecentProofs() {
+      this.userRecentProofsDialog = true
     },
     handleProofConfirmed(selectedProof) {
       this.addPriceSingleForm.proof_id = selectedProof.id
@@ -515,9 +515,6 @@ export default {
     },
     showLocationSelector() {
       this.locationSelector = true
-    },
-    closeLocationSelector(event) {
-      this.locationSelector = false
     },
     getNominatimLocationTitle(location, withName=true, withRoad=false, withCity=true) {
       return utils.getLocationTitle(location, withName, withRoad, withCity)

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -173,11 +173,14 @@
                   @click:clear="clearProof"
                   :loading="createProofLoading">
                 </v-file-input>
-                <p v-if="proofFormFilled && !createProofLoading" class="text-green mt-2 mb-2">
+                <p v-if="proofFormFilled && !createProofLoading && !proofSelectedMessage" class="text-green mt-2 mb-2">
                   <i>{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
                 </p>
                 <p v-if="!proofFormFilled && !createProofLoading" class="text-red mt-2 mb-2">
                   <i>{{ $t('AddPriceSingle.PriceDetails.UploadProof') }}</i>
+                </p>
+                <p v-if="proofFormFilled && proofSelectedMessage" class="text-green mt-2 mb-2">
+                  <i>{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
                 </p>
               </v-col>
               <v-col v-if="proofFormFilled">
@@ -250,6 +253,11 @@
     color="success"
     :timeout="2000"
   >{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</v-snackbar>
+  <v-snackbar
+    v-model="proofSelectedSuccessMessage"
+    color="success"
+    :timeout="2000"
+  >{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</v-snackbar>
 
   <BarcodeScanner
     v-if="barcodeScanner"
@@ -345,6 +353,8 @@ export default {
       createProofLoading: false,
       proofDateSuccessMessage: false,
       proofSuccessMessage: false,
+      proofSelectedSuccessMessage: false,
+      proofSelectedMessage: false,
       categoryPricePerList: [
         {key: 'KILOGRAM', value: this.$t('AddPriceSingle.CategoryPricePer.PerKg'), icon: 'mdi-weight-kilogram'},
         {key: 'UNIT', value: this.$t('AddPriceSingle.CategoryPricePer.PerUnit'), icon: 'mdi-numeric-1-circle'}
@@ -424,7 +434,8 @@ export default {
     handleProofConfirmed(selectedProof) {
       this.addPriceSingleForm.proof_id = selectedProof.id
       this.proofImagePreview = this.getProofUrl(selectedProof)
-      this.proofSuccessMessage = true
+      this.proofSelectedSuccessMessage = true
+      this.proofSelectedMessage = true
     },
     getProofUrl(proof) {
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`


### PR DESCRIPTION
### What

Allow user to select an existing proof when adding a price.

This is a WIP and only implemented for addSinglePrice. Please add your feedback to this PR on design and code and I will change / implement further.


### How
A new button allows to open a dialog with the last (max 10) proofs.
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/b2965b49-84c5-43c4-ab85-71897ebf41a8)
They will be displayed in a 5x2 grid.
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/e3650951-71fa-4b8d-86dc-05482c508fb2)
Selecting one will highlight it and show a confirmation dialog
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/a5a2cd4c-bd3e-4cc9-9bde-463a1b8f8f65)
If "No" is selected, user goes back to choosing the proof.
If "Yes", it closes both dialogs and displays the selected proof as is done for "Camera" or "Gallery" modes
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/dbe5ccf2-0be6-48fc-8054-542ee0dc30d1)

<hr>

PR simplified, no more confirmation dialog, works for both single & multiple price forms, rename "existing" to "recent"
