### PR TITLE
refactor: use ProofCard everywhere

### DIFF
--- a/src/components/PriceProof.vue
+++ b/src/components/PriceProof.vue
@@ -10,43 +10,23 @@
   </v-chip>
 
   <v-dialog scrollable v-model="dialog" max-height="80%" width="80%">
-    <v-card>
-      <v-card-title>
-        {{ $t('PriceCard.Proof') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="closeDialog"></v-btn>
-      </v-card-title>
-      <v-divider></v-divider>
-      <v-card-text>
-        <v-img :src="proofUrl"></v-img>
-      </v-card-text>
-      <v-divider></v-divider>
-      <v-card-text>
-        <ProofFooter :proof="proof"></ProofFooter>
-      </v-card-text>
-    </v-card>
+    <ProofCard :proof="proof" @close="closeDialog"></ProofCard>
   </v-dialog>
 </template>
 
 <script>
-import ProofFooter from '../components/ProofFooter.vue'
+import ProofCard from '../components/ProofCard.vue'
 
 export default {
   components: {
-    ProofFooter,
+    ProofCard,
   },
   props: {
     'proof': null,
-    'readonly': false
   },
   data() {
     return {
       dialog: false
-    }
-  },
-  computed: {
-    proofUrl() {
-      // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
-      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'
-      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.file_path}`
     }
   },
   methods: {

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -1,12 +1,20 @@
 <template>
   <v-card :id="'proof_' + proof.id" @click="selectProof">
+    <v-card-title v-if="!hideProofHeader">
+      {{ $t('ProofCard.Proof') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+    </v-card-title>
+
+    <v-divider v-if="!hideProofHeader"></v-divider>
+
     <v-card-text>
       <v-img :src="getProofUrl(proof)"></v-img>
     </v-card-text>
+
     <v-divider></v-divider>
-    <v-card-text>
+
+    <v-card-actions>
       <ProofFooter :proof="proof" :hideProofDelete="hideProofDelete" :readonly="readonly"></ProofFooter>
-    </v-card-text>
+    </v-card-actions>
   </v-card>
 </template>
 
@@ -19,6 +27,10 @@ export default {
   },
   props: {
     'proof': null,
+    hideProofHeader: {
+      type: Boolean,
+      default: false,
+    },
     hideProofDelete: {
       type: Boolean,
       default: false,
@@ -46,6 +58,9 @@ export default {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
+    },
+    close() {
+      this.$emit('close')
     }
   }
 }

--- a/src/components/ProofDeleteChip.vue
+++ b/src/components/ProofDeleteChip.vue
@@ -18,11 +18,8 @@
       <v-divider></v-divider>
       <v-card-text>
         <p class="mb-1">{{ $t('ProofDeleteChip.Confirmation') }}</p>
-        <v-row>
-          <v-col cols="12" md="6">
-            <v-img :src="proofUrl" max-height="150px"></v-img>
-          </v-col>
-        </v-row>
+        <ProofCard :proof="proof" :hideProofHeader="true" :hideProofDelete="true" :readonly="true"></ProofCard>
+        <br />
         <v-row>
           <v-col>
             <v-btn
@@ -48,8 +45,12 @@
 <script>
 import api from '../services/api'
 import { useAppStore } from '../store'
+import ProofCard from '../components/ProofCard.vue'
 
 export default {
+  components: {
+    ProofCard
+  },
   props: {
     'proof': null,
   },
@@ -61,11 +62,6 @@ export default {
     }
   },
   computed: {
-    proofUrl() {
-      // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
-      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'
-      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.file_path}`
-    }
   },
   methods: {
     deleteProof() {

--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -8,7 +8,7 @@
       <v-card-text>
         <v-row>
           <v-col cols="12" sm="6" md="3" v-for="proof in userProofList" :key="proof">
-            <ProofCard :proof="proof" :hideProofDelete="true" :isSelectable="true" :readonly="true" @proofSelected="selectProof"></ProofCard>
+            <ProofCard :proof="proof" :hideProofHeader="true" :hideProofDelete="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof"></ProofCard>
           </v-col>
         </v-row>
       </v-card-text>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -210,6 +210,7 @@
 		"Title": "Top products"
 	},
 	"ProofCard": {
+		"Proof": "Proof",
 		"PRICE_TAG": "Price tag",
 		"RECEIPT": "Receipt",
 		"GDPR_REQUEST": "GDPR request"

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <ProofCard v-if="proof" :proof="proof" :readonly="true"></ProofCard>
+      <ProofCard v-if="proof" :proof="proof" :hideProofHeader="true" :hideProofDelete="true" :readonly="true"></ProofCard>
       <p v-if="!loading && !proof" class="text-red">{{ $t('ProofDetail.ProofNotFound') }}</p>
     </v-col>
   </v-row>

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -23,7 +23,7 @@
 
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="proof in appStore.user.proofs" :key="proof">
-      <ProofCard :proof="proof" height="100%"></ProofCard>
+      <ProofCard :proof="proof" :hideProofHeader="true" height="100%"></ProofCard>
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

We have duplicated code between ProofCard, PriceProof & ProofDeleteChip.

Added a new prop `hideProofHeader`, so that the ProofCard can be used everywhere !