### PR TITLE
feat: add update PATCH proof in api

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -73,7 +73,7 @@ export default {
     .then((response) => response.json())
   },
 
-  updateProof(proofId) {
+  updateProof(proofId, params = {}) {
     const store = useAppStore()
     return fetch(`${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/${proofId}`, {
       method: 'PATCH',
@@ -81,10 +81,7 @@ export default {
         'Authorization': `Bearer ${store.user.token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        "is_public": "true", 
-        "type": "PRICE_TAG"
-      }),
+      body: JSON.stringify(params),
     })
     .then((response) => response.json())
   },

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -73,6 +73,22 @@ export default {
     .then((response) => response.json())
   },
 
+  updateProof(proofId) {
+    const store = useAppStore()
+    return fetch(`${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/${proofId}`, {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${store.user.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        "is_public": "true", 
+        "type": "PRICE_TAG"
+      }),
+    })
+    .then((response) => response.json())
+  },
+
   deleteProof(proofId) {
     const store = useAppStore()
     return fetch(`${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/${proofId}`, {


### PR DESCRIPTION
### What
Thanks to https://github.com/openfoodfacts/open-prices/issues/236, it is now possible to update a proof fields (`type` and `is_public`)
Created the endpoint on the frontend side

Part of  #363 