### PR TITLE
feat: clickable proof chip to set RECEIPT as private

### DIFF
--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -15,7 +15,9 @@
     </v-chip>
     <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()"></PriceCountChip>
     <RelativeDateTimeChip :dateTime="proof.created"></RelativeDateTimeChip>
+    <ProofIsPublicChip v-if="proof.type === 'RECEIPT'" :proof="proof"></ProofIsPublicChip>
     <ProofDeleteChip v-if="!hideProofDelete && userCanDeleteProof" :proof="proof"></ProofDeleteChip>
+
   </div>
 </template>
 
@@ -29,7 +31,9 @@ export default {
   components: {
     'PriceCountChip': defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
     'RelativeDateTimeChip': defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
-    'ProofDeleteChip': defineAsyncComponent(() => import('../components/ProofDeleteChip.vue'))
+    'ProofDeleteChip': defineAsyncComponent(() => import('../components/ProofDeleteChip.vue')),
+    'ProofIsPublicChip': defineAsyncComponent(() => import('../components/ProofisPublicChip.vue'))
+
   },
   props: {
     'proof': null,

--- a/src/components/ProofIsPublicChip.vue
+++ b/src/components/ProofIsPublicChip.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-chip label size="small" density="comfortable" :color="getColor()" class="mr-1" @click="updateIsPublicProof">
+    <v-icon start :icon="proof.is_public ? 'mdi-lock-open-check' : 'mdi-lock-alert'"></v-icon>
+    <span>{{ proof.is_public ? $t('ProofIsPublicChip.Public') : $t('ProofIsPublicChip.Private') }}</span>
+  </v-chip>
+
+  <v-snackbar
+    v-model="isPublicChangeSuccessMessage"
+    color="success"
+    :timeout="2000"
+  >{{ $t('ProofIsPublicChip.Success') }}</v-snackbar>
+</template>
+
+<script>
+import api from '../services/api'
+import { useAppStore } from '../store'
+import ProofCard from '../components/ProofCard.vue'
+
+export default {
+  components: {
+    ProofCard
+  },
+  props: {
+    'proof': null,
+  },
+  data() {
+    return {
+      isPublicChangeSuccessMessage: false
+    }
+  },
+  computed: {
+  },
+  methods: {
+    updateIsPublicProof() {
+      const params = {
+        is_public: !this.proof.is_public
+      }
+      api
+        .updateProof(this.proof.id, params)
+        .then((response) => {
+          // if response.status == 204
+          this.deleteSuccessMessage = true
+          const store = useAppStore()
+          store.updateProof(this.proof.id, params)
+          this.isPublicChangeSuccessMessage = true
+        })
+        .catch((error) => {
+          console.log(error)
+        })
+    },
+    getColor() {
+      if (this.proof.is_public) {
+        return 'success'
+      }
+      else {
+        return 'error'
+      }
+    },
+  }
+}
+</script>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -230,6 +230,11 @@
 		"Prices": "Prices",
 		"ProofNotFound": "Proof not found (or not the owner)"
 	},
+	"ProofIsPublicChip": {
+		"Public": "Public",
+		"Private": "Private",
+		"Success": "Proof updated!"
+	},
 	"Router": {
 		"AddPrice": {
 			"Title": "Add a price"

--- a/src/store.js
+++ b/src/store.js
@@ -73,6 +73,10 @@ export const useAppStore = defineStore('app', {
         this.user.proofs.push(proof)
       }
     },
+    updateProof(proofId, params) {
+      const proof = this.user.proofs.find(proof => proof.id === proofId)
+      Object.assign(proof, params)
+    },
     removeProof(proofId) {
       this.user.proofs = this.user.proofs.filter(proof => proof.id !== proofId)
       this.user.proofTotal -= 1


### PR DESCRIPTION
### What
Thanks to #401 there is an API endpoint to update some proof fields. User can now see in Proof page a chip for RECEIPT type proofs.

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/80daf764-ad87-4da1-a538-622a4b43e923)

This chip is clickable and will toggle between "Public" and "Private"

Part of #363 