### PR TITLE
refactor(l10n): allow translation of price ordering options

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,9 +20,9 @@ export default {
     { key: '-price_count', value: 'Number of prices', icon: 'mdi-tag-multiple-outline' },
   ],
   PRICE_ORDER_BY_LIST: [
-    { key: 'price', value: 'Price', icon: 'mdi-order-numeric-ascending' },
-    { key: '-date', value: 'Price Date', icon: 'mdi-calendar' },
-    { key: '-created', value: 'Addition date', icon: 'mdi-clock-outline' },
+    { key: 'price', value: 'OrderPriceASC', icon: 'mdi-order-numeric-ascending' },
+    { key: '-date', value: 'OrderPriceDateDESC', icon: 'mdi-calendar' },
+    { key: '-created', value: 'OrderPriceCreatedDESC', icon: 'mdi-clock-outline' },
   ],
   // https://wiki.openstreetmap.org/wiki/Key:place
   // https://wiki.openstreetmap.org/wiki/Key:highway

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -109,6 +109,9 @@
 		"AddToOFF": "Add to {name}",
 		"Filter": "Filter",
 		"Order": "Order",
+		"OrderPriceASC": "Price",
+		"OrderPriceCreatedDESC": "Addition date",
+		"OrderPriceDateDESC": "Price date",
 		"SignInOFFAccount": "Sign in with your {url} account",
 		"Yes": "Yes",
 		"No": "No"

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -50,7 +50,7 @@
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
-            {{ order.value }}
+            {{ $t('Common.' + order.value) }}
           </v-list-item>
         </v-list>
       </v-menu>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -56,7 +56,7 @@
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
-            {{ order.value }}
+            {{ $t('Common.' + order.value) }}
           </v-list-item>
         </v-list>
       </v-menu>

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -42,7 +42,7 @@
         </template>
         <v-list>
           <v-list-item :slim="true" v-for="order in priceOrderList" :key="order.key" :prepend-icon="order.icon" :active="priceOrder === order.key" @click="selectPriceOrder(order.key)">
-            {{ order.value }}
+            {{ $t('Common.' + order.value) }}
           </v-list-item>
         </v-list>
       </v-menu>


### PR DESCRIPTION
### What

Currently the price ordering values are hardcoded in `constants.js`

Refactored to allow translations 