### PR TITLE
feat(product): if quantity missing, show warning color & tooltip

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -15,7 +15,7 @@
                 {{ brand }}
               </v-chip>
             </span>
-            <span v-if="hasProductQuantity">
+            <span v-if="hasProductName">
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
             <span v-if="hasPriceOrigin && priceOrigin">
@@ -87,6 +87,9 @@ export default {
     hasCategoryTag() {
       return !!this.categoryTag
     },
+    hasProductName() {
+      return this.hasProduct && !!this.product.product_name
+    },
     hasProductQuantity() {
       return this.hasProduct && !!this.product.product_quantity
     },
@@ -116,7 +119,7 @@ export default {
       this.priceLabels = this.getPriceLabelsTagsList()
     },
     getPriceProductTitle() {
-      if (this.hasProduct && this.product.product_name) {
+      if (this.hasProductName) {
         return this.product.product_name
       } else if (this.hasPrice && this.price.product_code) {
         return this.price.product_code

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -18,7 +18,7 @@
                 {{ brand }}
               </v-chip>
             </span>
-            <span v-if="hasProductQuantity">
+            <span v-if="hasProductName">
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
             <br />
@@ -69,6 +69,9 @@ export default {
   mounted() {
   },
   computed: {
+    hasProductName() {
+      return !!this.product.product_name
+    },
     hasProductSource() {
       return !!this.product.source
     },

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -3,7 +3,8 @@
     {{ productQuantityWithUnitDisplay }}
   </v-chip>
   <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning">
-    g
+    <span>{{ productQuantityUnitDisplay }}</span>
+    <v-tooltip activator="parent" open-on-click location="top">{{ $t('ProductCard.ProductQuantityMissing') }}</v-tooltip>
   </v-chip>
 </template>
 
@@ -12,16 +13,20 @@ import constants from '../constants'
 
 export default {
   props: {
-    productQuantity: null,
-    productQuantityUnit: constants.PRODUCT_QUANTITY_UNIT_G
+    productQuantity: Number,
+    productQuantityUnit: String,
   },
   computed: {
+    productQuantityUnitDisplay() {
+      // to manage case where productQuantityUnit is null
+      return this.productQuantityUnit || constants.PRODUCT_QUANTITY_UNIT_G
+    },
     productQuantityWithUnitDisplay() {
-      if (this.productQuantityUnit === constants.PRODUCT_QUANTITY_UNIT_ML) {
+      if (this.productQuantityUnitDisplay === constants.PRODUCT_QUANTITY_UNIT_ML) {
         return this.$t('ProductCard.ProductQuantityMililitre', [this.productQuantity])
       }
       return this.$t('ProductCard.ProductQuantityGram', [this.productQuantity])
-    }
+    },
   }
 }
 </script>

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -1,6 +1,9 @@
 <template>
-  <v-chip label size="small" density="comfortable">
+  <v-chip v-if="productQuantity" label size="small" density="comfortable">
     {{ productQuantityWithUnitDisplay }}
+  </v-chip>
+  <v-chip v-else label size="small" density="comfortable" color="warning">
+    ??? g
   </v-chip>
 </template>
 

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -2,8 +2,8 @@
   <v-chip v-if="productQuantity" label size="small" density="comfortable">
     {{ productQuantityWithUnitDisplay }}
   </v-chip>
-  <v-chip v-else label size="small" density="comfortable" color="warning">
-    ??? g
+  <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning">
+    g
   </v-chip>
 </template>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -199,8 +199,9 @@
 		"LatestPrice": "Latest price",
 		"ProductQuantityGram": "{0} g",
 		"ProductQuantityKilogram": "{0} kg",
-		"ProductQuantityMililitre": "{0} mL",
 		"ProductQuantityLitre": "{0} L",
+		"ProductQuantityMililitre": "{0} mL",
+		"ProductQuantityMissing": "Product quantity missing",
 		"UnknownProduct": "Unknown product name"
 	},
 	"ProductCategories": {


### PR DESCRIPTION
### What

Currently, if the product quantity info is missing, we simply hide the `ProductQuantityChip` chip + don't calculate the price per kg/L.

But we could also show a "warning" message to nudge users to edit the info in OFF :)

Add a tooltip on hover

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/ee84293c-ea81-4c81-9e0e-923a6398d6e0)
