### PR TITLE
fix: improve page display when the user changes the price or product order

### DIFF
--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -115,6 +115,7 @@ export default {
     initBrand() {
       this.brand = this.$route.params.id
       this.brandProductList = []
+      this.brandProductTotal = null
       this.brandProductPage = 0
       this.getBrandProducts()
     },

--- a/src/views/CategoryDetail.vue
+++ b/src/views/CategoryDetail.vue
@@ -115,6 +115,7 @@ export default {
     initCategory() {
       this.category = this.$route.params.id
       this.categoryProductList = []
+      this.categoryProductTotal = null
       this.categoryProductPage = 0
       this.getCategoryProducts()
     },

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -123,6 +123,7 @@ export default {
   methods: {
     initLocationPrices() {
       this.locationPriceList = []
+      this.locationPriceTotal = null
       this.locationPricePage = 0
       this.getLocationPrices()
     },

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -1,8 +1,8 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <ProductCard v-if="!loading && !productIsCategory" :product="product"></ProductCard>
-      <v-card v-if="!loading && productIsCategory" :title="getCategoryName" prepend-icon="mdi-fruit-watermelon" elevation="1"></v-card>
+      <ProductCard v-if="!productIsCategory" :product="product"></ProductCard>
+      <v-card v-else :title="getCategoryName" prepend-icon="mdi-fruit-watermelon" elevation="1"></v-card>
     </v-col>
   </v-row>
 
@@ -110,7 +110,7 @@ export default {
     this.priceFilter = this.$route.query[constants.FILTER_PARAM] || this.priceFilter
     this.priceOrder = this.$route.query[constants.ORDER_BY_PARAM] || this.priceOrder
     this.getProduct(),
-    this.getProductPrices()
+    this.initProductPrices()
   },
   computed: {
     productIsCategory() {
@@ -145,6 +145,7 @@ export default {
   methods: {
     initProductPrices() {
       this.productPriceList = []
+      this.productPriceTotal = null
       this.productPricePage = 0
       this.getProductPrices()
     },

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -90,6 +90,7 @@ export default {
   methods: {
     initProductList() {
       this.productList = []
+      this.productTotal = null
       this.productPage = 0
       this.getProducts()
     },

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -116,6 +116,7 @@ export default {
   methods: {
     initUserPrices() {
       this.userPriceList = []
+      this.userPriceTotal = null
       this.userPricePage = 0
       this.getUserPrices()
     },


### PR DESCRIPTION
### What

We are starting to have many pages where the user can order the data (price or product).

But it sometimes shows many useless "loading" buttons, even though the underlying data doesn't change.

Cleaned up to avoid having : 
- the top section go into loading mode
- the bottom "load more" showing up