### PR TITLE
feat(product): if categories missing, show warning color & tooltip

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -22,8 +22,10 @@
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
             <br />
-            <span>
+            <span class="mr-1">
               <ProductCategoriesChip :productCategories="product.categories_tags"></ProductCategoriesChip>
+            </span>
+            <span>
               <ProductLabelsChip :productLabels="product.labels_tags"></ProductLabelsChip>
             </span>
             <br />

--- a/src/components/ProductCategoriesChip.vue
+++ b/src/components/ProductCategoriesChip.vue
@@ -33,8 +33,6 @@ export default {
       productCategoriesDialog: false
     }
   },
-  computed: {
-  },
   methods: {
     showProductCategoriesDialog() {
       this.productCategoriesDialog = true

--- a/src/components/ProductCategoriesChip.vue
+++ b/src/components/ProductCategoriesChip.vue
@@ -1,10 +1,14 @@
 <template>
-  <v-chip label size="small" density="comfortable" class="mr-1" @click="showProductCategoriesDialog">
-    {{ $t('ProductCard.CategoryTotal', { count: productCategories ? productCategories.length : 0 }) }}
+  <v-chip v-if="productCategories.length" label size="small" density="comfortable" @click="showProductCategoriesDialog">
+    {{ $t('ProductCard.CategoryTotal', { count: productCategories.length }) }}
+  </v-chip>
+  <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning">
+    {{ $t('ProductCard.CategoriesLower') }}
+    <v-tooltip activator="parent" open-on-click location="top">{{ $t('ProductCard.ProductCategoriesMissing') }}</v-tooltip>
   </v-chip>
 
   <ProductCategoriesDialog
-    v-if="productCategories && productCategoriesDialog"
+    v-if="productCategories.length && productCategoriesDialog"
     :categories="productCategories"
     v-model="productCategoriesDialog"
     @close="productCategoriesDialog = false"
@@ -19,7 +23,10 @@ export default {
     'ProductCategoriesDialog': defineAsyncComponent(() => import('../components/ProductCategoriesDialog.vue')),
   },
   props: {
-    productCategories: null,
+    productCategories: {
+      type: Array,
+      default: []
+    }
   },
   data() {
     return {

--- a/src/components/ProductCategoriesDialog.vue
+++ b/src/components/ProductCategoriesDialog.vue
@@ -21,14 +21,6 @@ export default {
   props: {
     categories: Array,
   },
-  data() {
-    return {
-    }
-  },
-  computed: {
-  },
-  mounted() {
-  },
   methods: {
     goToCategory(category) {
       this.$router.push({ path: `/categories/${category}` })

--- a/src/components/ProductCategoriesDialog.vue
+++ b/src/components/ProductCategoriesDialog.vue
@@ -2,18 +2,15 @@
   <v-dialog>
     <v-card>
       <v-card-title>
-        {{ $t('ProductCategories.Title') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+        {{ $t('ProductCard.Categories') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
       </v-card-title>
 
       <v-divider></v-divider>
 
-      <v-card-text v-if="categories.length">
+      <v-card-text>
         <v-chip v-for="category in categories" :key="category" label class="mr-2 mb-2" @click="goToCategory(category)">
           {{ category }}
         </v-chip>
-      </v-card-text>
-      <v-card-text v-if="!categories.length">
-        <span class="text-red">{{ $t('ProductCategories.Empty') }}</span>
       </v-card-text>
     </v-card>
   </v-dialog>
@@ -22,7 +19,7 @@
 <script>
 export default {
   props: {
-    'categories': Array,
+    categories: Array,
   },
   data() {
     return {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -194,19 +194,19 @@
 		"Title": "Latest prices"
 	},
 	"ProductCard": {
+		"Categories": "Categories",
+		"CategoriesLower": "categories",
 		"CategoryTotal": "{count} categories",
 		"LabelTotal": "{count} labels",
 		"LatestPrice": "Latest price",
+		"ProductCategoriesMissing": "Product categories missing",
+		"ProductLabelsMissing": "Product labels missing",
 		"ProductQuantityGram": "{0} g",
 		"ProductQuantityKilogram": "{0} kg",
 		"ProductQuantityLitre": "{0} L",
 		"ProductQuantityMililitre": "{0} mL",
 		"ProductQuantityMissing": "Product quantity missing",
 		"UnknownProduct": "Unknown product name"
-	},
-	"ProductCategories": {
-		"Title": "Categories",
-		"Empty": "No categories have been added to this product yet."
 	},
 	"ProductDetail": {
 		"AddPrice": "Add a price",


### PR DESCRIPTION
### What

In the ProductCard (displayed in the ProductDetail page for instance), we display the CategoriesChip in orange if it's empty (+ tooltip), to nudge users to edit the product.

### Screenshots

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/0b0193a1-6223-41c4-b01a-6a63fd8ca4bd)