### PR TITLE
fix(i10n): language dropdown and locale load at mount

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import App from './App.vue'
 import router from './router.js'
 import { vuetify } from './plugins/vuetify.js'
 import i18n from './i18n'
-
+import localeManager from './i18n/localeManager.js'
 const app = createApp(App)
 
 const pinia = createPinia()
@@ -21,7 +21,8 @@ app.use(VueMatomo, {
   host: 'https://analytics.openfoodfacts.org',
   siteId: 13,
 })
-
+const locale = localeManager.guessDefaultLocale()
+localeManager.changeLanguage(locale)
 app.mount('#app')
 
 // Matomo

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -141,8 +141,6 @@ export default {
       this.userSettingsForm.currency = this.appStore.user.last_currency_used
       this.userSettingsForm.selectedLanguage = this.languageList.find(lang => lang.code === localeManager.guessDefaultLocale()).code
       this.userSettingsForm.selectedCountry = countryData.find(country => country.code === this.appStore.user.country).code
-      const store = useAppStore()
-      console.log(store.user)
     },
     async updateSettings() {
       await localeManager.changeLanguage(this.userSettingsForm.selectedLanguage)
@@ -150,8 +148,6 @@ export default {
       this.appStore.setCountry(this.userSettingsForm.selectedCountry)
       this.appStore.setLastCurrencyUsed(this.userSettingsForm.currency)
       this.$router.push({ path: '/', query: { settingsSuccess: 'true' } })
-      const store = useAppStore()
-      console.log(store.user)
     }
   }
 }

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -100,16 +100,17 @@ export default {
         // Update the language list to show the previously selected language first then the selected country languages and the rest of the languages
         let newLanguageList = this.languageList.slice()
         if (selectedCountry) {
+          const currentLanguage = this.languageList.find(lang => lang.code === this.userSettingsForm.selectedLanguage)
           // get the languages of the selected country minus the selected language (if it exists in the country languages list)
           const countryLanguagesList = selectedCountry.languages.map(code => {
             const language = languageData.find(lang => lang.code === code || lang.code === `${code}_${selectedCountry.code}`)
             return language ? language : null
-          }).filter(language => language !== null && language.code !== this.userSettingsForm.selectedLanguage.code)
+          }).filter(language => language !== null && language.code !== currentLanguage.code)
           // Update the language list to show the current selected language first then the selected country languages and the rest of the languages
           newLanguageList = [
-            ...[this.userSettingsForm.selectedLanguage],
+            ...[currentLanguage],
             ...countryLanguagesList,
-            ...newLanguageList.filter(language => !selectedCountry.languages.includes(language.code) && language.code !== this.userSettingsForm.selectedLanguage.code &&
+            ...newLanguageList.filter(language => !selectedCountry.languages.includes(language.code) && language.code !== currentLanguage.code &&
               !countryLanguagesList.includes(language))
           ].filter(Boolean); // Remove any null or undefined values 
           this.languageList = newLanguageList
@@ -139,7 +140,9 @@ export default {
     initUserSettingsForm() {
       this.userSettingsForm.currency = this.appStore.user.last_currency_used
       this.userSettingsForm.selectedLanguage = this.languageList.find(lang => lang.code === localeManager.guessDefaultLocale()).code
-      this.userSettingsForm.selectedCountry = countryData.find(country => country.code === this.appStore.user.country).code  
+      this.userSettingsForm.selectedCountry = countryData.find(country => country.code === this.appStore.user.country).code
+      const store = useAppStore()
+      console.log(store.user)
     },
     async updateSettings() {
       await localeManager.changeLanguage(this.userSettingsForm.selectedLanguage)
@@ -147,6 +150,8 @@ export default {
       this.appStore.setCountry(this.userSettingsForm.selectedCountry)
       this.appStore.setLastCurrencyUsed(this.userSettingsForm.currency)
       this.$router.push({ path: '/', query: { settingsSuccess: 'true' } })
+      const store = useAppStore()
+      console.log(store.user)
     }
   }
 }


### PR DESCRIPTION
### What
Due to recent language cleanup PR #337 some issues were raised
- UserSettings language dropdown was not showing the current locale name but code
![image](https://github.com/openfoodfacts/open-prices-frontend/assets/21193194/3e3ff3af-411f-412b-81f8-afa53601bebf)
- Refresh or direct URL would default text to English

### Changes
- Small fix in UserSettings
- Added call of `changeLanguage` before App mount