### PR TITLE
feat(product): if brand missing, show warning color & tooltip

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -10,10 +10,8 @@
           <h3 v-if="!hideProductTitle" @click="goToProduct()">{{ getPriceProductTitle() }}</h3>
 
           <p v-if="!hideProductDetails" class="mb-2">
-            <span v-if="hasProductBrands">
-              <v-chip v-for="brand in getProductBrandsList" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
-                {{ brand }}
-              </v-chip>
+            <span v-if="hasProductSource">
+              <ProductBrands :productBrands="product.brands" :readonly="readonly"></ProductBrands>
             </span>
             <span v-if="hasProductName">
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
@@ -48,6 +46,7 @@ import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    'ProductBrands': defineAsyncComponent(() => import('../components/ProductBrands.vue')),
     'ProductQuantityChip': defineAsyncComponent(() => import('../components/ProductQuantityChip.vue')),
     'PricePrice': defineAsyncComponent(() => import('../components/PricePrice.vue')),
     'PriceFooter': defineAsyncComponent(() => import('../components/PriceFooter.vue'))
@@ -90,11 +89,11 @@ export default {
     hasProductName() {
       return this.hasProduct && !!this.product.product_name
     },
+    hasProductSource() {
+      return this.hasProduct && !!this.product.source
+    },
     hasProductQuantity() {
       return this.hasProduct && !!this.product.product_quantity
-    },
-    hasProductBrands() {
-      return this.hasProduct && !!this.product.brands
     },
     hasPriceOrigin() {
       return this.hasPrice && !!this.price.origins_tags && this.price.origins_tags.length
@@ -105,11 +104,6 @@ export default {
     getPriceCategoryName() {
       if (this.price && this.hasCategoryTag) {
         return utils.getCategoryName(this.price.category_tag)
-      }
-    },
-    getProductBrandsList() {
-      if (this.hasProductBrands) {
-        return this.product.brands.split(',')
       }
     },
   },
@@ -153,12 +147,6 @@ export default {
         return
       }
       this.$router.push({ path: `/products/${this.getPriceProductCode()}` })
-    },
-    goToBrand(brand) {
-      if (this.readonly) {
-        return
-      }
-      this.$router.push({ path: `/brands/${brand}` })
     },
   },
 }

--- a/src/components/ProductBrands.vue
+++ b/src/components/ProductBrands.vue
@@ -1,0 +1,31 @@
+<template>
+    <span v-if="productBrands.length">
+        <v-chip v-for="brand in getProductBrandsList" :key="brand" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
+        {{ brand }}
+        </v-chip>
+    </span>
+</template>
+
+<script>
+export default {
+  props: {
+    productBrands: {
+        type: String,
+        default: ''
+    },
+  },
+  computed: {
+    getProductBrandsList() {
+      return this.productBrands.split(',')
+    }
+  },
+  methods: {
+    goToBrand(brand) {
+      if (this.readonly) {
+        return
+      }
+      this.$router.push({ path: `/brands/${brand}` })
+    },
+  }
+}
+</script>

--- a/src/components/ProductBrands.vue
+++ b/src/components/ProductBrands.vue
@@ -1,18 +1,23 @@
 <template>
-    <span v-if="productBrands.length">
+    <span v-if="productBrands && productBrands.length">
         <v-chip v-for="brand in getProductBrandsList" :key="brand" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
-        {{ brand }}
+            {{ brand }}
         </v-chip>
     </span>
+    <v-chip v-if="!productBrands" label size="small" density="comfortable" prepend-icon="mdi-help" color="warning" class="mr-1">
+        {{ $t('ProductCard.BrandLower') }}
+        <v-tooltip activator="parent" open-on-click location="top">{{ $t('ProductCard.ProductBrandMissing') }}</v-tooltip>
+  </v-chip>
 </template>
 
 <script>
 export default {
   props: {
-    productBrands: {
-        type: String,
-        default: ''
-    },
+    productBrands: String,
+    readonly: {
+      type: Boolean,
+      default: false
+    }
   },
   computed: {
     getProductBrandsList() {

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -13,7 +13,9 @@
             <span>
               <PriceCountChip :count="product.price_count" @click="goToProduct()"></PriceCountChip>
             </span>
-            <ProductBrands v-if="hasProductSource" :productBrands="product.brands"></ProductBrands>
+            <span v-if="hasProductSource">
+              <ProductBrands :productBrands="product.brands" :readonly="readonly"></ProductBrands>
+            </span>
             <span v-if="hasProductSource">
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -13,12 +13,8 @@
             <span>
               <PriceCountChip :count="product.price_count" @click="goToProduct()"></PriceCountChip>
             </span>
-            <span v-if="hasProductBrands">
-              <v-chip v-for="brand in getProductBrandsList" :key="brand" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
-                {{ brand }}
-              </v-chip>
-            </span>
-            <span v-if="hasProductName">
+            <ProductBrands v-if="hasProductSource" :productBrands="product.brands"></ProductBrands>
+            <span v-if="hasProductSource">
               <ProductQuantityChip class="mr-1" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit"></ProductQuantityChip>
             </span>
             <br />
@@ -52,6 +48,7 @@ import { defineAsyncComponent } from 'vue'
 export default {
   components: {
     'PriceCountChip': defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
+    'ProductBrands': defineAsyncComponent(() => import('../components/ProductBrands.vue')),
     'ProductQuantityChip': defineAsyncComponent(() => import('../components/ProductQuantityChip.vue')),
     'ProductCategoriesChip': defineAsyncComponent(() => import('../components/ProductCategoriesChip.vue')),
     'ProductLabelsChip': defineAsyncComponent(() => import('../components/ProductLabelsChip.vue')),
@@ -83,11 +80,6 @@ export default {
     hasProductQuantity() {
       return !!this.product.product_quantity
     },
-    getProductBrandsList() {
-      if (this.hasProductBrands) {
-        return this.product.brands.split(',')
-      }
-    }
   },
   methods: {
     getProductTitle() {
@@ -98,12 +90,6 @@ export default {
         return
       }
       this.$router.push({ path: `/products/${this.product.code}` })
-    },
-    goToBrand(brand) {
-      if (this.readonly) {
-        return
-      }
-      this.$router.push({ path: `/brands/${brand}` })
     },
   }
 }

--- a/src/components/ProductQuantityChip.vue
+++ b/src/components/ProductQuantityChip.vue
@@ -3,7 +3,7 @@
     {{ productQuantityWithUnitDisplay }}
   </v-chip>
   <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning">
-    <span>{{ productQuantityUnitDisplay }}</span>
+    {{ productQuantityUnitDisplay }}
     <v-tooltip activator="parent" open-on-click location="top">{{ $t('ProductCard.ProductQuantityMissing') }}</v-tooltip>
   </v-chip>
 </template>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -194,6 +194,7 @@
 		"Title": "Latest prices"
 	},
 	"ProductCard": {
+		"BrandLower": "brand",
 		"Categories": "Categories",
 		"CategoriesLower": "categories",
 		"CategoryTotal": "{count} categories",
@@ -201,6 +202,7 @@
 		"LabelsLower": "labels",
 		"LabelTotal": "{count} labels",
 		"LatestPrice": "Latest price",
+		"ProductBrandMissing": "Product brand missing",
 		"ProductCategoriesMissing": "Product categories missing",
 		"ProductQuantityGram": "{0} g",
 		"ProductQuantityKilogram": "{0} kg",


### PR DESCRIPTION
### What

If the ProductCard (or PriceCard) has no brands, show the chip with a warning color (and a tooltip on hover), instead of hiding it

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/70e11be6-6029-49b1-b949-44ff35fbd581)
