### PR TITLE
refactor(product): hide product code

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -26,10 +26,6 @@
             <span>
               <ProductLabelsChip :productLabels="product.labels_tags"></ProductLabelsChip>
             </span>
-            <br />
-            <span>
-              <v-chip label size="small" density="comfortable">{{ product.code }}</v-chip>
-            </span>
           </p>
         </v-col>
       </v-row>


### PR DESCRIPTION
### What

Hide product code to gain some space
- possible to retrieve it via the OFF / share links
- if asked to be put again by power users, we can add a toggle in the settings in the future

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/1800631f-820a-4f56-a88e-79cd9d473f0f)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/dda4b075-290c-401b-8c73-42c7956d0e7b)|