### PR TITLE
feat(product): if too many brands, show count & dialog

### DIFF
--- a/src/components/ProductBrands.vue
+++ b/src/components/ProductBrands.vue
@@ -1,22 +1,44 @@
 <template>
-    <span v-if="productBrands && productBrands.length">
-        <v-chip v-for="brand in getProductBrandsList" :key="brand" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
-            {{ brand }}
-        </v-chip>
+  <span v-if="productBrands">
+    <span v-if="getProductBrandsList.length <= 2">
+      <v-chip v-for="brand in getProductBrandsList" :key="brand" label size="small" density="comfortable" class="mr-1" @click="goToBrand(brand)">
+        {{ brand }}
+      </v-chip>
     </span>
-    <v-chip v-if="!productBrands" label size="small" density="comfortable" prepend-icon="mdi-help" color="warning" class="mr-1">
-        {{ $t('ProductCard.BrandLower') }}
-        <v-tooltip activator="parent" open-on-click location="top">{{ $t('ProductCard.ProductBrandMissing') }}</v-tooltip>
+    <v-chip v-else label size="small" density="comfortable" class="mr-1" @click="showProductBrandsDialog">
+      {{ $t('ProductCard.BrandTotal', { count: getProductBrandsList.length }) }}
+    </v-chip>
+  </span>
+  <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning" class="mr-1">
+    {{ $t('ProductCard.BrandLower') }}
+    <v-tooltip activator="parent" open-on-click location="top">{{ $t('ProductCard.ProductBrandMissing') }}</v-tooltip>
   </v-chip>
+
+  <ProductBrandsDialog
+    v-if="productBrands && productBrands.length && productBrandsDialog"
+    :brands="getProductBrandsList"
+    v-model="productBrandsDialog"
+    @close="productBrandsDialog = false"
+  ></ProductBrandsDialog>
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
+
 export default {
+  components: {
+    'ProductBrandsDialog': defineAsyncComponent(() => import('../components/ProductBrandsDialog.vue')),
+  },
   props: {
     productBrands: String,
     readonly: {
       type: Boolean,
       default: false
+    }
+  },
+  data() {
+    return {
+      productBrandsDialog: false
     }
   },
   computed: {
@@ -30,6 +52,9 @@ export default {
         return
       }
       this.$router.push({ path: `/brands/${brand}` })
+    },
+    showProductBrandsDialog() {
+      this.productBrandsDialog = true
     },
   }
 }

--- a/src/components/ProductBrandsDialog.vue
+++ b/src/components/ProductBrandsDialog.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-dialog>
+    <v-card>
+      <v-card-title>
+        {{ $t('ProductCard.Brands') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close"></v-btn>
+      </v-card-title>
+
+      <v-divider></v-divider>
+
+      <v-card-text>
+        <v-chip v-for="brand in brands" :key="brand" label class="mr-2 mb-2" @click="goToBrand(brand)">
+          {{ brand }}
+        </v-chip>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  props: {
+    brands: Array,
+  },
+  methods: {
+    goToBrand(brand) {
+      this.$router.push({ path: `/brands/${brand}` })
+    },
+    close() {
+      this.$emit('close')
+    },
+  }
+}
+</script>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -194,7 +194,9 @@
 		"Title": "Latest prices"
 	},
 	"ProductCard": {
+		"Brands": "Brands",
 		"BrandLower": "brand",
+		"BrandTotal": "{count} brands",
 		"Categories": "Categories",
 		"CategoriesLower": "categories",
 		"CategoryTotal": "{count} categories",


### PR DESCRIPTION
### What

Some products, have (too) many brands, that clog the ProductCard.

Now, if the brand count is greater than 2, the brands are replaced with a count chip + dialog (like categories & labels)

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/67883263-6a42-43b0-8c9f-136b44286bea)|![Screenshot from 2024-03-09 10-56-38](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/64baad0b-63d9-4346-b132-315210f8c4cb)|
