### PR TITLE
feat: add column limits on the main pages and change the color scheme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,15 @@
   </v-app>
 </template>
 
+<style>
+.v-main{
+  background-color: #FFFCF2;
+}
+a {
+  color: #309191;
+}
+</style>
+
 <script>
 import { defineComponent } from 'vue'
 import Header from './components/Header.vue'

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer class="bg-grey-lighten-1" style="max-height: 20%">
+  <v-footer>
     <v-row>
       <v-col cols="12" md="6" align="center">
         <i18n-t keypath="Footer.TagLine" tag="span">
@@ -17,6 +17,14 @@
     </v-row>
   </v-footer>
 </template>
+
+<style scoped>
+.v-footer{
+  max-height: 20%;
+  background-color: #1E1E24;
+  color: #fff
+}
+</style>
 
 <script>
 import constants from '../constants'

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar :elevation="1" style="background-color: rgb(242, 233, 228);">
+  <v-app-bar :elevation="1" >
     <v-app-bar-nav-icon @click.stop="showDrawerMenu = !showDrawerMenu"></v-app-bar-nav-icon>
     <v-app-bar-title style="cursor:pointer" @click="$router.push('/')">
       <img src="/favicon.svg" height="28" width="28" style="vertical-align:bottom">
@@ -26,6 +26,12 @@
     <v-list :items="getDrawerMenuItems"></v-list>
   </v-navigation-drawer>
 </template>
+
+<style scoped>
+.v-app-bar {
+  background-color: #ff8e00;
+}
+</style>
 
 <script>
 import { mapStores } from 'pinia'

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,47 +1,62 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    <i18n-t keypath="Home.Welcome.Title" tag="span">
-      <template #name>{{ APP_NAME }}</template>
-    </i18n-t>
-  </h1>
-  <p>{{ $t('Home.Welcome.Subtitle') }}</p>
-  
-  <br />
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        <i18n-t keypath="Home.Welcome.Title" tag="span">
+          <template #name>{{ APP_NAME }}</template>
+        </i18n-t>
+      </h1>
+      <p>{{ $t('Home.Welcome.Subtitle') }}</p>
 
-  <v-row>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Home.SearchProduct')"
-        prepend-icon="mdi-magnify"
-        height="100%"
-        to="/search">
-      </v-card>
     </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Home.AddPrice')"
-        prepend-icon="mdi-plus"
-        color="primary"
-        variant="outlined"
-        elevation="1"
-        to="/add">
-        <template v-slot:subtitle v-if="!username">
-          <i18n-t keypath="Common.SignInOFFAccount" tag="span">
-            <template #url>
-              <a href="https://world.openfoodfacts.org" target="_blank">Open Food Facts</a>
-            </template>
-          </i18n-t>
-        </template>
+  </v-row>
+  <br /><br />
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <v-btn
+          block
+          height="52"
+          variant="elevated"
+          to="/search"
+          prepend-icon="mdi-magnify">
+        {{ $t('Home.SearchProduct') }}
+      </v-btn>
+    </v-col>
+  </v-row>
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <v-card>
+          <template v-slot:subtitle v-if="!username" >
+            <i18n-t keypath="Common.SignInOFFAccount" tag="span">
+              <template #url>
+                <a href="https://world.openfoodfacts.org" target="_blank">Open Food Facts</a>
+              </template>
+            </i18n-t>
+          </template>
+        <v-btn
+            block
+            height="52"
+            prepend-icon="mdi-plus"
+            color="primary"
+            variant="tonal"
+            elevation="1"
+            to="/add">
+          {{$t('Home.AddPrice')}}
+        </v-btn>
       </v-card>
     </v-col>
   </v-row>
-
-  <v-row>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Home.LatestPrices')"
-        prepend-icon="mdi-tag-multiple-outline"
-        to="/prices">
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <v-card>
+        <v-btn
+            block
+            height="52"
+            variant="elevated"
+            prepend-icon="mdi-tag-multiple-outline"
+            to="/prices">
+          {{$t('Home.LatestPrices')}}
+        </v-btn>
         <template v-slot:subtitle v-if="!loading">
           <i18n-t keypath="Home.TodayPriceStat" :plural="todayPriceCount" tag="span">
             <template v-slot:todayPriceNumber>

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-row>
-    <v-col cols="12" sm="6">
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-card
         :title="getLocationTitle(location)"
         :subtitle="location ? location.osm_display_name : ''"

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -1,11 +1,14 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    {{ $t('LocationList.Title') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h1>
-
-  <v-row v-if="!loading">
-    <v-col>
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        {{ $t('LocationList.Title') }}
+        <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      </h1>
+    </v-col>
+  </v-row>
+  <v-row v-if="!loading" align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-chip class="mr-2" label variant="text" prepend-icon="mdi-map-marker-outline">
         {{ $t('LocationList.LocationTotal', { count: locationTotal }) }}
       </v-chip>

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -1,9 +1,13 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    {{ $t('PriceList.Title') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h1>
-
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        {{ $t('PriceList.Title') }}
+        <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      </h1>
+    </v-col>
+  </v-row>
+  <br/>
   <v-row>
     <v-col cols="12" sm="6" md="4" v-for="price in priceList" :key="price">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -1,11 +1,15 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    {{ $t('ProductList.Title') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h1>
-
-  <v-row v-if="!loading">
-    <v-col>
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        {{ $t('ProductList.Title') }}
+        <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      </h1>
+    </v-col>
+  </v-row>
+  <br/>
+  <v-row v-if="!loading" align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-chip class="mr-2" label variant="text" prepend-icon="mdi-food-outline">
         {{ productTotal }}<span class="d-none d-sm-inline">&nbsp;products</span>
       </v-chip>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -1,45 +1,54 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    {{ $t('Search.Title') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h1>
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        {{ $t('Search.Title') }}
+        <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      </h1>
+      <br/>
+      <v-row>
+        <v-col>
+          <v-form @submit.prevent="search">
+            <v-text-field
+                v-model="productSearchForm.q"
+                :label="$t('Search.ProductBarcode')"
+                type="number"
+                inputmode="numeric"
+                :prepend-inner-icon="formFilled ? 'mdi-barcode' : 'mdi-barcode-scan'"
+                append-inner-icon="mdi-magnify"
+                @click:prepend-inner="showBarcodeScanner"
+                @click:append-inner="search"
+                :rules="[fieldRequired]"
+                :loading="loading"
+                required>
+            </v-text-field>
+          </v-form>
+        </v-col>
+      </v-row>
 
-  <v-row>
-    <v-col>
-      <v-form @submit.prevent="search">
-        <v-text-field
-          v-model="productSearchForm.q"
-          :label="$t('Search.ProductBarcode')"
-          type="number"
-          inputmode="numeric"
-          :prepend-inner-icon="formFilled ? 'mdi-barcode' : 'mdi-barcode-scan'"
-          append-inner-icon="mdi-magnify"
-          @click:prepend-inner="showBarcodeScanner"
-          @click:append-inner="search"
-          :rules="[fieldRequired]"
-          :loading="loading"
-          required>
-        </v-text-field>
-      </v-form>
+      <p v-if="productTotal === 0" class="text-red">
+        <i>{{ $t('ProductDetail.ProductNotFound') }}</i>
+      </p>
+
+      <v-row v-if="productTotal > 0" class="mt-0">
+        <v-col cols="12" sm="6" md="4" v-for="product in productList" :key="product">
+          <ProductCard
+              :product="product"
+              :latestPrice="product.latest_price"
+              elevation="1"
+              height="100%"
+          ></ProductCard>
+        </v-col>
+      </v-row>
+
+      <BarcodeScanner
+          v-if="barcodeScanner"
+          v-model="barcodeScanner"
+          @barcode="setProductCode($event)"
+          @close="barcodeScanner = false"
+      ></BarcodeScanner>
     </v-col>
   </v-row>
-
-  <p v-if="productTotal === 0" class="text-red">
-    <i>{{ $t('ProductDetail.ProductNotFound') }}</i>
-  </p>
-
-  <v-row v-if="productTotal > 0" class="mt-0">
-    <v-col cols="12" sm="6" md="4" v-for="product in productList" :key="product">
-      <ProductCard :product="product" :latestPrice="product.latest_price" elevation="1" height="100%"></ProductCard>
-    </v-col>
-  </v-row>
-
-  <BarcodeScanner
-    v-if="barcodeScanner"
-    v-model="barcodeScanner"
-    @barcode="setProductCode($event)"
-    @close="barcodeScanner = false"
-  ></BarcodeScanner>
 </template>
 
 <script>

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -1,37 +1,42 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    {{ $t('SignIn.Title') }}
-  </h1>
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        {{ $t('SignIn.Title') }}
+      </h1>
+      <br />
+      <v-alert
+          class="mb-2"
+          type="info"
+          variant="outlined">
+        <i18n-t keypath="Common.SignInOFFAccount" tag="span">
+          <template #url>
+            <a href="https://world.openfoodfacts.org" target="_blank">Open Food Facts</a>
+          </template>
+        </i18n-t>
+      </v-alert>
 
-  <v-alert
-    class="mb-2"
-    type="info"
-    variant="outlined">
-    <i18n-t keypath="Common.SignInOFFAccount" tag="span">
-      <template #url>
-        <a href="https://world.openfoodfacts.org" target="_blank">Open Food Facts</a>
-      </template>
-    </i18n-t>
-  </v-alert>
-
-  <v-form @submit.prevent="signIn">
-    <v-text-field
-      v-model="signinForm.username"
-      :label="$t('SignIn.UsernameLabel')"
-      type="text"
-    ></v-text-field>
-    <v-text-field
-      v-model="signinForm.password"
-      :label="$t('SignIn.Password')"
-      type="password"
-    ></v-text-field>
-    <v-btn
-      type="submit"
-      class="mt-2"
-      :loading="loading"
-      :disabled="!formFilled"
-    >{{ $t('SignIn.Button') }}</v-btn>
-  </v-form>
+      <v-form @submit.prevent="signIn">
+        <v-text-field
+            v-model="signinForm.username"
+            :label="$t('SignIn.UsernameLabel')"
+            type="text"
+        ></v-text-field>
+        <v-text-field
+            v-model="signinForm.password"
+            :label="$t('SignIn.Password')"
+            type="password"
+        ></v-text-field>
+        <v-btn
+            type="submit"
+            class="mt-2"
+            variant="elevated"
+            :loading="loading"
+            :disabled="!formFilled"
+        >{{ $t('SignIn.Button') }}</v-btn>
+      </v-form>
+    </v-col>
+  </v-row>
 </template>
 
 <script>

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -4,7 +4,7 @@
   </h1>
 
   <v-row>
-    <v-col>
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-chip class="mr-2" label variant="text" prepend-icon="mdi-account">
         {{ username }}
       </v-chip>
@@ -15,7 +15,7 @@
   </v-row>
 
   <v-row>
-    <v-col cols="12" sm="6" lg="4">
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-card
         :title="$t('UserDashboard.MyPrices')"
         :subtitle="userPriceTotal"
@@ -24,7 +24,7 @@
         to="/dashboard/prices">
       </v-card>
     </v-col>
-    <v-col cols="12" sm="6" lg="4">
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-card
         :title="$t('UserDashboard.MyProofs')"
         :subtitle="userProofTotal"

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -1,11 +1,15 @@
 <template>
-  <h1 class="text-h5 mb-1">
-    {{ $t('UserList.Title') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h1>
-
+  <v-row align="center" justify="center">
+    <v-col cols="12" sm="10" md="8" lg="6">
+      <h1 class="text-h5 mb-1">
+        {{ $t('UserList.Title') }}
+        <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      </h1>
+    </v-col>
+  </v-row>
+  <br/>
   <v-row v-if="!loading">
-    <v-col>
+    <v-col cols="12" sm="10" md="8" lg="6">
       <v-chip class="mr-2" label variant="text" prepend-icon="mdi-account-badge-outline">
         {{ $t('UserList.UserTotal', { count: userTotal }) }}
       </v-chip>


### PR DESCRIPTION
### What
Added column limits for lg, md and sm screens on the principal sites home, sign in, search, user dashboard, user list, prices, products and locations
Changed the card buttons into actual v-btn buttons 
Changed some colors using the vue's style tags on the header, app.js and footer

### Screenshots
**Large screen**
![Captura desde 2024-03-14 23-50-35](https://github.com/openfoodfacts/open-prices-frontend/assets/29210382/a1c39e99-8143-4e24-90aa-d18f7b930981)
**Medium screen**
![Captura desde 2024-03-14 23-50-57](https://github.com/openfoodfacts/open-prices-frontend/assets/29210382/732ea80b-ba30-4e61-9682-b33a1070211f)
**Small screen**
![Captura desde 2024-03-14 23-51-12](https://github.com/openfoodfacts/open-prices-frontend/assets/29210382/69f09638-7e33-49dc-bff6-2c87737b713c)

Notes

Colors used:
header #ff8e00
footer #1E1E24
links #309191
background #FFFCF2

Some of the changes look big but are just automatic indention, like in search and sign in