### PR TITLE
fix(proofs): cleanup post proof privacy recent changes

### DIFF
--- a/src/components/PriceFooter.vue
+++ b/src/components/PriceFooter.vue
@@ -4,7 +4,7 @@
       <PriceLocationChip v-if="!hidePriceLocation" class="mr-1" :price="price" :readonly="readonly"></PriceLocationChip>
       <PriceOwnerChip class="mr-1" :price="price" :readonly="readonly"></PriceOwnerChip>
       <RelativeDateTimeChip class="mr-1" :dateTime="price.created"></RelativeDateTimeChip>
-      <PriceProof v-if="price.proof && price.proof.is_public && !hidePriceProof" :proof="price.proof"></PriceProof>
+      <PriceProof v-if="price.proof && !hidePriceProof" :proof="price.proof"></PriceProof>
     </v-col>
   </v-row>
 

--- a/src/components/PriceProof.vue
+++ b/src/components/PriceProof.vue
@@ -10,7 +10,7 @@
   </v-chip>
 
   <v-dialog scrollable v-model="dialog" max-height="80%" width="80%">
-    <ProofCard :proof="proof" @close="closeDialog"></ProofCard>
+    <ProofCard :proof="proof" :hideProofActions="true" @close="closeDialog"></ProofCard>
   </v-dialog>
 </template>
 

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -7,25 +7,24 @@
     <v-divider v-if="!hideProofHeader"></v-divider>
 
     <v-card-text>
-      <v-img :src="getProofUrl(proof)"></v-img>
+      <v-img v-if="proof.file_path" :src="getProofUrl(proof)"></v-img>
     </v-card-text>
 
     <v-divider></v-divider>
 
-    <v-card-actions>
-      <ProofFooter :proof="proof" :hideProofDelete="hideProofDelete" :readonly="readonly"></ProofFooter>
+    <v-card-actions style="padding-bottom: 0;">
+      <ProofFooter :proof="proof" :hideProofActions="hideProofActions" :readonly="readonly"></ProofFooter>
     </v-card-actions>
   </v-card>
 </template>
 
 <script>
-import ProofFooter from '../components/ProofFooter.vue'
 import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
-    ProofFooter,
     'ProofEditDialog': defineAsyncComponent(() => import('../components/ProofEditDialog.vue')),
+    'ProofFooter': defineAsyncComponent(() => import('../components/ProofFooter.vue')),
   },
   props: {
     'proof': null,
@@ -33,7 +32,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    hideProofDelete: {
+    hideProofActions: {
       type: Boolean,
       default: false,
     },
@@ -67,12 +66,9 @@ export default {
       }
     },
     getProofUrl(proof) {
-      return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
+      // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
-    },
-    showProofEditDialog(proof) {
-      this.proofEditDialog = true
     },
     close() {
       this.$emit('close')

--- a/src/components/ProofDeleteConfirmationDialog.vue
+++ b/src/components/ProofDeleteConfirmationDialog.vue
@@ -9,7 +9,7 @@
 
       <v-card-text>
         <p class="mb-1">{{ $t('ProofDelete.Confirmation') }}</p>
-        <ProofCard :proof="proof" :hideProofHeader="true" :hideProofDelete="true" :readonly="true"></ProofCard>
+        <ProofCard :proof="proof" :hideProofHeader="true" :hideProofActions="true" :readonly="true"></ProofCard>
       </v-card-text>
 
       <v-divider></v-divider>

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -8,12 +8,13 @@
       <v-divider></v-divider>
 
       <v-card-text v-if="proof.type === 'RECEIPT'">
+        <h3>{{ $t('ProofEdit.PrivateWarning') }}</h3>
         <v-switch
           v-model="isPublic"
           color="green"
           density="compact"
           inset
-          :label="isPublic ? $t('ProofEdit.Public') : $t('ProofEdit.Private')"
+          :label="isPublic ? $t('ProofDetail.Public') : $t('ProofDetail.Private')"
           hide-details
         ></v-switch>
         <p class="text-caption text-warning">

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row style="margin-top:0;">
+  <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof"></ProofTypeChip>
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()"></PriceCountChip>
@@ -7,14 +7,13 @@
     </v-col>
   </v-row>
 
-  <ProofActionMenuButton v-if="!readonly && userIsProofOwner" :proof="proof"></ProofActionMenuButton>
+  <ProofActionMenuButton v-if="!readonly && !hideProofActions && userIsProofOwner" :proof="proof"></ProofActionMenuButton>
 </template>
 
 <script>
 import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
-import constants from '../constants'
 
 export default {
   components: {
@@ -25,7 +24,7 @@ export default {
   },
   props: {
     'proof': null,
-    hideProofDelete: {
+    hideProofActions: {
       type: Boolean,
       default: false,
     },

--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -10,7 +10,7 @@
       <v-card-text>
         <v-row>
           <v-col cols="12" sm="6" md="3" v-for="proof in userProofList" :key="proof">
-            <ProofCard :proof="proof" :hideProofHeader="true" :hideProofDelete="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof"></ProofCard>
+            <ProofCard :proof="proof" :hideProofHeader="true" :hideProofActions="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof"></ProofCard>
           </v-col>
         </v-row>
       </v-card-text>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -32,11 +32,7 @@
 		"ProofDetails": {
 			"ReceiptWarning": "Receipts may contain personal information, we recommend to hide them (redact, fold...) before taking the picture.",
 			"PrivateWarning": "You can also set the receipt to Private. Private proofs will only be visible to you and to moderators.",
-			"Title": "Proof details",
-			"ProofStatus": "Proof status",
-			"Public": "Public",
-			"Private": "Private",
-			"Privacy": "Privacy"
+			"Title": "Proof details"
 		},
 		"Title": "Add multiple prices"
 	},
@@ -263,12 +259,13 @@
 	"ProofDetail": {
 		"LoadMore": "Load more",
 		"Prices": "Prices",
-		"ProofNotFound": "Proof not found (or not the owner)"
+		"ProofNotFound": "Proof not found (or not the owner)",
+		"Public": "Public",
+		"Private": "Private",
+		"Privacy": "Privacy"
 	},
 	"ProofEdit": {
 		"Title": "Edit a proof",
-		"Public": "Public",
-		"Private": "Private",
 		"PrivateWarning": "When setting your proof to Private, it will be hidden from public view. We recommend hiding any personal information by redacting or folding the document, if possible.",
 		"Save": "Save",
 		"Success": "Proof edited!"

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -78,7 +78,6 @@
                   @change="updateIsPublicProof">
                   <template v-slot:label>
                     <v-icon start size="small" :icon="proofIsPublic ? 'mdi-lock-open-check' : 'mdi-lock-alert'" :color="proofIsPublic ? 'green' : 'red'"></v-icon>
-                    <strong>{{ $t('AddPriceMultiple.ProofDetails.ProofStatus') }}&nbsp;</strong>
                     <span :style="{ color: proofIsPublic ? 'green' : 'red' }">
                       {{ proofIsPublic ? $t('AddPriceMultiple.ProofDetails.Public') : $t('AddPriceMultiple.ProofDetails.Private') }}
                     </span>

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <ProofCard v-if="proof" :proof="proof" :hideProofHeader="true" :hideProofDelete="true" :readonly="true"></ProofCard>
+      <ProofCard v-if="proof" :proof="proof" :hideProofHeader="true" :readonly="true"></ProofCard>
       <p v-if="!loading && !proof" class="text-red">{{ $t('ProofDetail.ProofNotFound') }}</p>
     </v-col>
   </v-row>


### PR DESCRIPTION
### What

Cleanup & fixes following recent Proof privacy changes (especially #462)
- rename hideProofDelete to hideProofActions
- show proof actions only on dashboard & detail page
- translations