### PR TITLE
feat(user): add share button on dashboard

### DIFF
--- a/src/components/ShareButton.vue
+++ b/src/components/ShareButton.vue
@@ -19,6 +19,9 @@
 import constants from '../constants'
 
 export default {
+  props: {
+    'overrideUrl': null,
+  },
   data () {
     return {
       APP_NAME: constants.APP_NAME,
@@ -27,7 +30,7 @@ export default {
   },
   methods: {
     shareViaWebShare() {
-      let URL = `${import.meta.env.VITE_OPEN_PRICES_APP_URL}${this.$route.href}`
+      let URL = `${import.meta.env.VITE_OPEN_PRICES_APP_URL}${this.overrideUrl ? this.overrideUrl : this.$route.href}`
       if (navigator.share) {
         navigator.share({
           title: this.APP_NAME,

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -11,6 +11,7 @@
       <v-btn size="small" prepend-icon="mdi-arrow-left" to="/dashboard">
         {{ $t('UserDashboard.Title') }}
       </v-btn>
+      <ShareButton :overrideUrl="'/users/' + username"></ShareButton>
     </v-col>
   </v-row>
 
@@ -35,13 +36,14 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
-import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    'ShareButton': defineAsyncComponent(() => import('../components/ShareButton.vue')),
     'PriceCard': defineAsyncComponent(() => import('../components/PriceCard.vue'))
   },
   data() {

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -63,10 +63,10 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
-import { defineAsyncComponent } from 'vue'
 import constants from '../constants'
 
 export default {


### PR DESCRIPTION
### What

On the logged-in user's dashboard, add the `ShareButton`, to link to the public user price list

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/c60d5bb7-9182-4501-be88-99c4655c9448)
