### PR TITLE
refactor: move FilterMenu & OrderMenu on the same line

### DIFF
--- a/src/components/FilterMenu.vue
+++ b/src/components/FilterMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu scroll-strategy="close">
     <template v-slot:activator="{ props }">
-      <v-btn v-bind="props" size="small" class="mr-2" rounded="xl" prepend-icon="mdi-filter-variant" :active="!!currentFilter">{{ $t('Common.Filter') }}</v-btn>
+      <v-btn v-bind="props" size="x-small" class="mr-2" rounded="xl" prepend-icon="mdi-filter-variant" :active="!!currentFilter">{{ $t('Common.Filter') }}</v-btn>
     </template>
     <v-list>
       <v-list-item :slim="true" v-for="filter in filterList" :key="filter.key" :prepend-icon="(currentFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="currentFilter === filter.key" @click="selectFilter(filter.key)">

--- a/src/components/OrderMenu.vue
+++ b/src/components/OrderMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <v-menu scroll-strategy="close">
     <template v-slot:activator="{ props }">
-      <v-btn v-bind="props" size="small" rounded="xl" prepend-icon="mdi-arrow-down" :append-icon="getCurrentOrderIcon" :active="!!currentOrder">{{ $t('Common.Order') }}</v-btn>
+      <v-btn v-bind="props" size="x-small" rounded="xl" prepend-icon="mdi-arrow-down" :append-icon="getCurrentOrderIcon" :active="!!currentOrder">{{ $t('Common.Order') }}</v-btn>
     </template>
     <v-list>
       <v-list-item :slim="true" v-for="order in orderList" :key="order.key" :prepend-icon="order.icon" :active="currentOrder === order.key" @click="selectOrder(order.key)">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -245,7 +245,8 @@
 		"LoadMore": "Load more",
 		"PriceNumber": "Number of prices added",
 		"ScanNumber": "Number of scans added",
-		"Title": "Top products"
+		"Title": "Top products",
+		"ProductTotal": "{count} products"
 	},
 	"ProofCard": {
 		"Proof": "Proof",

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -23,15 +23,12 @@
 
   <br />
 
-  <h2 class="text-h6 mb-1">
-    {{ $t('BrandDetail.TopProducts') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h2>
-
-  <v-row v-if="!loading">
+  <v-row>
     <v-col>
-      <FilterMenu kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
-      <OrderMenu kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
+      <h2 class="text-h6 d-inline mr-2">{{ $t('BrandDetail.TopProducts') }}</h2>
+      <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      <FilterMenu v-if="!loading" kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
+      <OrderMenu v-if="!loading" kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
     </v-col>
   </v-row>
 

--- a/src/views/CategoryDetail.vue
+++ b/src/views/CategoryDetail.vue
@@ -23,15 +23,12 @@
 
   <br />
 
-  <h2 class="text-h6 mb-1">
-    {{ $t('CategoryDetail.TopProducts') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h2>
-
-  <v-row v-if="!loading">
+  <v-row>
     <v-col>
-      <FilterMenu kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
-      <OrderMenu kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
+      <h2 class="text-h6 d-inline mr-2">{{ $t('CategoryDetail.TopProducts') }}</h2>
+      <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      <FilterMenu v-if="!loading" kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
+      <OrderMenu v-if="!loading" kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
     </v-col>
   </v-row>
 

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -26,19 +26,16 @@
 
   <br />
 
-  <h2 class="text-h6 mb-1">
-    {{ $t('LocationDetail.LatestPrices') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h2>
-
-  <v-row v-if="!loading">
+  <v-row>
     <v-col>
-      <FilterMenu kind="price" :currentFilter="currentFilter" @update:currentFilter="togglePriceFilter($event)"></FilterMenu>
-      <OrderMenu kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)"></OrderMenu>
+      <h2 class="text-h6 d-inline mr-2">{{ $t('LocationDetail.LatestPrices') }}</h2>
+      <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      <FilterMenu v-if="!loading" kind="price" :currentFilter="currentFilter" @update:currentFilter="togglePriceFilter($event)"></FilterMenu>
+      <OrderMenu v-if="!loading" kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)"></OrderMenu>
     </v-col>
   </v-row>
 
-  <v-row>
+  <v-row class="mt-0">
     <v-col cols="12" sm="6" md="4" v-for="price in locationPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" :hidePriceLocation="true" elevation="1" height="100%"></PriceCard>
     </v-col>

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -6,7 +6,7 @@
 
   <v-row v-if="!loading">
     <v-col>
-      <v-chip class="mr-2" label variant="text" prepend-icon="mdi-map-marker-outline">
+      <v-chip label variant="text" prepend-icon="mdi-map-marker-outline">
         {{ $t('LocationList.LocationTotal', { count: locationTotal }) }}
       </v-chip>
     </v-col>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -32,18 +32,16 @@
 
   <br />
 
-  <h2 class="text-h6 mb-1">
-    {{ $t('ProductDetail.LatestPrices') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h2>
-
-  <v-row v-if="!loading">
+  <v-row>
     <v-col>
-      <FilterMenu kind="price" :currentFilter="currentFilter" @update:currentFilter="togglePriceFilter($event)"></FilterMenu>
-      <OrderMenu kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)"></OrderMenu>
+      <h2 class="text-h6 d-inline mr-2">{{ $t('ProductDetail.LatestPrices') }}</h2>
+      <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      <FilterMenu v-if="!loading" kind="price" :currentFilter="currentFilter" @update:currentFilter="togglePriceFilter($event)"></FilterMenu>
+      <OrderMenu v-if="!loading" kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)"></OrderMenu>
     </v-col>
   </v-row>
-  <v-row>
+
+  <v-row class="mt-0">
     <v-col cols="12" sm="6" md="4" v-for="price in productPriceList" :key="price">
       <PriceCard :price="price" :product="product" :hideProductImage="true" :hideProductTitle="true" :hideProductDetails="productIsCategory ? false : true" elevation="1" height="100%"></PriceCard>
     </v-col>

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -6,8 +6,8 @@
 
   <v-row v-if="!loading">
     <v-col>
-      <v-chip class="mr-2" label variant="text" prepend-icon="mdi-food-outline">
-        {{ productTotal }}<span class="d-none d-sm-inline">&nbsp;products</span>
+      <v-chip label variant="text" prepend-icon="mdi-food-outline">
+        {{ $t('ProductList.ProductTotal', { count: productTotal }) }}
       </v-chip>
       <FilterMenu kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
       <OrderMenu kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -18,19 +18,16 @@
 
   <br />
 
-  <h2 class="text-h6 mb-1">
-    {{ $t('UserDetail.LatestPrices') }}
-    <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-  </h2>
-
-  <v-row v-if="!loading">
+  <v-row>
     <v-col>
-      <FilterMenu kind="price" :currentFilter="currentFilter" @update:currentFilter="togglePriceFilter($event)"></FilterMenu>
-      <OrderMenu kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)"></OrderMenu>
+      <h2 class="text-h6 d-inline mr-2">{{ $t('UserDetail.LatestPrices') }}</h2>
+      <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
+      <FilterMenu v-if="!loading" kind="price" :currentFilter="currentFilter" @update:currentFilter="togglePriceFilter($event)"></FilterMenu>
+      <OrderMenu v-if="!loading" kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)"></OrderMenu>
     </v-col>
   </v-row>
 
-  <v-row>
+  <v-row class="mt-0">
     <v-col cols="12" sm="6" md="4" v-for="price in userPriceList" :key="price">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%"></PriceCard>
     </v-col>

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -6,7 +6,7 @@
 
   <v-row v-if="!loading">
     <v-col>
-      <v-chip class="mr-2" label variant="text" prepend-icon="mdi-account-badge-outline">
+      <v-chip label variant="text" prepend-icon="mdi-account-badge-outline">
         {{ $t('UserList.UserTotal', { count: userTotal }) }}
       </v-chip>
     </v-col>


### PR DESCRIPTION
### What

- reduce the size of the Filter & Order menu buttons
- move to one line to reduce space

### Screenshot

||before|after|
|---|---|---|
|ProductList|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/bc94a9c1-3d92-452c-ac59-eab5e44c5078)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/6658a6a8-1e64-420a-8b3b-59177af0f678)|
|ProductDetail|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/661a96fd-c230-4dd1-950c-ce795b045e82)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/204c9cb3-7aa4-4bae-ac51-d0ce88ee7aa6)|
