### PR TITLE
refactor: disable allowing a user to set a receipt as private

### DIFF
--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -3,7 +3,7 @@
     <v-icon>mdi-dots-vertical</v-icon>
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
-        <v-list-item v-if="proofIsReceipt && !proof.is_public" :slim="true" prepend-icon="mdi-pencil" @click="openEditDialog" :disabled="!proofIsReceipt">{{ $t('Common.Edit') }}</v-list-item>
+        <v-list-item v-if="proofIsPrivateReceipt" :slim="true" prepend-icon="mdi-pencil" @click="openEditDialog" :disabled="!proofIsReceipt">{{ $t('Common.Edit') }}</v-list-item>
         <v-list-item :slim="true" prepend-icon="mdi-delete" @click="openDeleteConfirmationDialog" :disabled="!userCanDeleteProof">{{ $t('Common.Delete') }}</v-list-item>
       </v-list>
     </v-menu>
@@ -64,6 +64,9 @@ export default {
   computed: {
     proofIsReceipt() {
       return this.proof.type === 'RECEIPT'
+    },
+    proofIsPrivateReceipt() {
+      return this.proofIsReceipt && !this.proof.is_public
     },
     userCanDeleteProof() {
       // user must be proof owner

--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -3,7 +3,7 @@
     <v-icon>mdi-dots-vertical</v-icon>
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
-        <v-list-item :slim="true" prepend-icon="mdi-pencil" @click="openEditDialog" :disabled="!proofIsReceipt">{{ $t('Common.Edit') }}</v-list-item>
+        <v-list-item v-if="proofIsReceipt && !proof.is_public" :slim="true" prepend-icon="mdi-pencil" @click="openEditDialog" :disabled="!proofIsReceipt">{{ $t('Common.Edit') }}</v-list-item>
         <v-list-item :slim="true" prepend-icon="mdi-delete" @click="openDeleteConfirmationDialog" :disabled="!userCanDeleteProof">{{ $t('Common.Delete') }}</v-list-item>
       </v-list>
     </v-menu>

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -7,7 +7,7 @@
 
       <v-divider></v-divider>
 
-      <v-card-text v-if="proof.type === 'RECEIPT'">
+      <v-card-text v-if="proofIsReceipt">
         <h3>{{ $t('ProofDetail.Privacy') }}</h3>
         <v-switch
           v-model="isPublic"
@@ -51,6 +51,9 @@ export default {
   },
   emits: ['update', 'close'],
   computed: {
+    proofIsReceipt() {
+      return this.proof.type === 'RECEIPT'
+    },
   },
   mounted() {
     this.isPublic = this.proof.is_public

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -17,9 +17,6 @@
           :label="isPublic ? $t('ProofDetail.Public') : $t('ProofDetail.Private')"
           hide-details
         ></v-switch>
-        <p class="text-caption text-warning">
-          <i>{{ $t('ProofEdit.PrivateWarning') }}</i>
-        </p>
       </v-card-text>
 
       <v-divider></v-divider>

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -2,7 +2,7 @@
   <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof"></ProofTypeChip>
-      <ProofPrivateChip v-if="proof.type === 'RECEIPT'" class="mr-1" :proof="proof"></ProofPrivateChip>
+      <ProofPrivateChip v-if="proofIsPrivateReceipt" class="mr-1" :proof="proof"></ProofPrivateChip>
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()"></PriceCountChip>
       <RelativeDateTimeChip :dateTime="proof.created"></RelativeDateTimeChip>
     </v-col>
@@ -42,6 +42,12 @@ export default {
     },
     userIsProofOwner() {
       return this.username && (this.proof.owner === this.username)
+    },
+    proofIsReceipt() {
+      return this.proof.type === 'RECEIPT'
+    },
+    proofIsPrivateReceipt() {
+      return this.proofIsReceipt && !this.proof.is_public
     }
   },
   methods: {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -279,7 +279,6 @@
 	},
 	"ProofEdit": {
 		"Title": "Edit a proof",
-		"PrivateWarning": "When setting your proof to Private, it will be hidden from public view. We recommend hiding any personal information by redacting or folding the document, if possible.",
 		"Save": "Save",
 		"Success": "Proof edited!"
 	},

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -66,24 +66,7 @@
               <h3 class="mb-1">{{ $t('ProofDetail.Privacy') }}</h3>
               <p class="text-caption text-warning">
                 <i>{{ $t('AddPriceMultiple.ProofDetails.ReceiptWarning') }}</i>
-                <i>{{ $t('AddPriceMultiple.ProofDetails.PrivateWarning') }}</i>
               </p>
-              <div v-if="proofFormFilled">
-                <v-switch
-                  v-model="proofIsPublic"
-                  density="compact"
-                  color="green"
-                  inset
-                  hide-details
-                  @change="updateIsPublicProof">
-                  <template v-slot:label>
-                    <v-icon start size="small" :icon="proofIsPublic ? 'mdi-lock-open-check' : 'mdi-lock-alert'" :color="proofIsPublic ? 'green' : 'red'"></v-icon>
-                    <span :class="proofIsPublic ? 'text-green' : 'text-red'">
-                      {{ proofIsPublic ? $t('ProofDetail.Public') : $t('ProofDetail.Private') }}
-                    </span>
-                  </template>
-                </v-switch>
-              </div>
             </v-col>
           </v-row>
         </v-card-text>
@@ -376,7 +359,6 @@ export default {
       userRecentProofsDialog: false,
       proofSelectedSuccessMessage: false,
       proofisSelected: false,
-      proofIsPublic: true,
       // location data
       locationSelector: false,
       locationSelectedDisplayName: '',
@@ -490,7 +472,6 @@ export default {
       this.proofImagePreview = this.getProofUrl(selectedProof)
       this.proofSelectedSuccessMessage = true
       this.proofisSelected = true
-      this.proofIsPublic = selectedProof.is_public
     },
     getProofUrl(proof) {
       return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'
@@ -528,7 +509,6 @@ export default {
               const store = useAppStore()
               store.addProof(data)
               this.addPriceMultipleForm.proof_id = data['id']
-              this.proofIsPublic = data['is_public']
               this.proofImagePreview = URL.createObjectURL(proofImageCompressed)
               this.proofSuccessMessage = true
             } else {
@@ -549,21 +529,6 @@ export default {
       // .finally(() => {
       //   console.log('Compress complete')
       // })
-    },
-    updateIsPublicProof() {
-      const params = {
-        is_public: this.proofIsPublic
-      }
-      api
-        .updateProof(this.addPriceMultipleForm.proof_id, params)
-        .then((response) => {
-          // if response.status == 204
-          const store = useAppStore()
-          store.updateProof(this.addPriceMultipleForm.proof_id, params)
-        })
-        .catch((error) => {
-          console.log(error)
-        })
     },
     clearProof() {
       this.proofImage = null


### PR DESCRIPTION
### What

Revert changes in : 
- add price multiple
- edit proof
- proof privacy chip