### PR TITLE
feat(products): add new filter by source

### DIFF
--- a/src/components/FilterMenu.vue
+++ b/src/components/FilterMenu.vue
@@ -4,9 +4,16 @@
       <v-btn v-bind="props" size="x-small" class="mr-2" rounded="xl" prepend-icon="mdi-filter-variant" :active="!!currentFilter">{{ $t('Common.Filter') }}</v-btn>
     </template>
     <v-list>
-      <v-list-item :slim="true" v-for="filter in filterList" :key="filter.key" :prepend-icon="(currentFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="currentFilter === filter.key" @click="selectFilter(filter.key)">
+      <v-list-item v-for="filter in filterList" :key="filter.key" :slim="true" :prepend-icon="(currentFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="currentFilter === filter.key" @click="selectFilter(filter.key)">
         {{ $t('Common.' + filter.value) }}
       </v-list-item>
+      <v-sheet v-if="kind === 'product'">
+        <v-divider></v-divider>
+        <v-list-subheader class="text-uppercase">{{ $t('Common.Source') }}</v-list-subheader>
+        <v-list-item v-for="source in productSourceList" :key="source.key" :slim="true" :prepend-icon="(currentSource === source.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="currentSource === source.key" @click="selectSource(source.key)">
+          {{ source.value }}
+        </v-list-item>
+      </v-sheet>
     </v-list>
   </v-menu>
 </template>
@@ -17,13 +24,19 @@ import constants from '../constants'
 export default {
   props: {
     currentFilter: String,
+    currentSource: {
+      type: String,
+      default: null
+    },
     kind: {
+      // product, price
       type: String,
       default: 'product'
     }
   },
   data() {
     return {
+      productSourceList: constants.PRODUCT_SOURCE_LIST,
       productFilterList: constants.PRODUCT_FILTER_LIST,
       priceFilterList: constants.PRICE_FILTER_LIST,
     }
@@ -33,10 +46,13 @@ export default {
       return this.kind === 'product' ? this.productFilterList : this.priceFilterList
     }
   },
-  emits: ['update:currentFilter'],
+  emits: ['update:currentFilter', 'update:currentSource'],
   methods: {
     selectFilter(filter) {
       this.$emit('update:currentFilter', filter)
+    },
+    selectSource(source) {
+      this.$emit('update:currentSource', source)
     }
   }
 }

--- a/src/components/FilterMenu.vue
+++ b/src/components/FilterMenu.vue
@@ -1,16 +1,19 @@
 <template>
   <v-menu scroll-strategy="close">
     <template v-slot:activator="{ props }">
-      <v-btn v-bind="props" size="x-small" class="mr-2" rounded="xl" prepend-icon="mdi-filter-variant" :active="!!currentFilter">{{ $t('Common.Filter') }}</v-btn>
+      <v-btn v-bind="props" size="x-small" class="mr-2" rounded="xl" prepend-icon="mdi-filter-variant" :append-icon="getCurrentFilterIcon" :active="currentFilterOrSource">
+        {{ $t('Common.Filter') }}
+      </v-btn>
     </template>
     <v-list>
       <v-list-item v-for="filter in filterList" :key="filter.key" :slim="true" :prepend-icon="(currentFilter === filter.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="currentFilter === filter.key" @click="selectFilter(filter.key)">
         {{ $t('Common.' + filter.value) }}
       </v-list-item>
-      <v-sheet v-if="kind === 'product'">
+      <v-sheet v-if="showSource">
         <v-divider></v-divider>
         <v-list-subheader class="text-uppercase">{{ $t('Common.Source') }}</v-list-subheader>
-        <v-list-item v-for="source in productSourceList" :key="source.key" :slim="true" :prepend-icon="(currentSource === source.key) ? 'mdi-check-circle' : 'mdi-circle-outline'" :active="currentSource === source.key" @click="selectSource(source.key)">
+        <v-list-item v-for="source in productSourceList" :key="source.key" :slim="true" :active="currentSource === source.key" @click="selectSource(source.key)">
+          <v-icon>{{ source.icon }}</v-icon>
           {{ source.value }}
         </v-list-item>
       </v-sheet>
@@ -32,6 +35,10 @@ export default {
       // product, price
       type: String,
       default: 'product'
+    },
+    hideSource: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -42,9 +49,19 @@ export default {
     }
   },
   computed: {
+    showSource() {
+      return this.kind === 'product' && !this.hideSource
+    },
     filterList() {
       return this.kind === 'product' ? this.productFilterList : this.priceFilterList
-    }
+    },
+    currentFilterOrSource() {
+      return !!this.currentFilter || !!this.currentSource
+    },
+    getCurrentFilterIcon() {
+      let source = this.productSourceList.find(o => o.key === this.currentSource)
+      return source ? source.icon : ''
+    },
   },
   emits: ['update:currentFilter', 'update:currentSource'],
   methods: {

--- a/src/components/OrderMenu.vue
+++ b/src/components/OrderMenu.vue
@@ -1,10 +1,12 @@
 <template>
   <v-menu scroll-strategy="close">
     <template v-slot:activator="{ props }">
-      <v-btn v-bind="props" size="x-small" rounded="xl" prepend-icon="mdi-arrow-down" :append-icon="getCurrentOrderIcon" :active="!!currentOrder">{{ $t('Common.Order') }}</v-btn>
+      <v-btn v-bind="props" size="x-small" rounded="xl" prepend-icon="mdi-arrow-down" :append-icon="getCurrentOrderIcon" :active="!!currentOrder">
+        {{ $t('Common.Order') }}
+      </v-btn>
     </template>
     <v-list>
-      <v-list-item :slim="true" v-for="order in orderList" :key="order.key" :prepend-icon="order.icon" :active="currentOrder === order.key" @click="selectOrder(order.key)">
+      <v-list-item v-for="order in orderList" :key="order.key" :slim="true" :prepend-icon="order.icon" :active="currentOrder === order.key" @click="selectOrder(order.key)">
         {{ $t('Common.' + order.value) }}
       </v-list-item>
     </v-list>
@@ -33,8 +35,8 @@ export default {
       return this.kind === 'product' ? this.productOrderList : this.priceOrderList
     },
     getCurrentOrderIcon() {
-      let currentOrder = this.orderList.find(o => o.key === this.currentOrder)
-      return currentOrder ? currentOrder.icon : ''
+      let order = this.orderList.find(o => o.key === this.currentOrder)
+      return order ? order.icon : ''
     },
   },
   emits: ['update:currentOrder'],

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,22 +1,34 @@
+const OFF_NAME = 'Open Food Facts'
+const OBF_NAME = 'Open Beauty Facts'
+const OPFF_NAME = 'Open Pet Food Facts'
+const OPF_NAME = 'Open Products Facts'
+
 export default {
   APP_NAME: 'Open Prices',
-  OFF_NAME: 'Open Food Facts',
+  OFF_NAME: OFF_NAME,
   OFF_URL: 'https://world.openfoodfacts.org',
   OFF_ICON: 'mdi-food-apple-outline',
   OFF_WIKI_URL: 'https://wiki.openfoodfacts.org/Main_Page',
   OFF_WIKI_APP_URL: 'https://wiki.openfoodfacts.org/Project:Open-Prices',
   OFF_WIKI_GDPR_REQUEST_URL: 'https://wiki.openfoodfacts.org/GDPR_request',
-  OBF_NAME: 'Open Beauty Facts',
+  OBF_NAME: OBF_NAME,
   OBF_URL: 'https://world.openbeautyfacts.org',
   OBF_ICON: 'mdi-lotion-outline',
-  OPFF_NAME: 'Open Pet Food Facts',
+  OPFF_NAME: OPFF_NAME,
   OPFF_URL: 'https://world.openpetfoodfacts.org',
   OPFF_ICON: 'mdi-paw',
-  OPF_NAME: 'Open Products Facts',
+  OPF_NAME: OPF_NAME,
   OPF_URL: 'https://world.openproductsfacts.org',
   OPF_ICON: 'mdi-bookshelf',
   PRODUCT_QUANTITY_UNIT_G: 'g',
   PRODUCT_QUANTITY_UNIT_ML: 'ml',
+  SOURCE_PARAM: 'source',
+  PRODUCT_SOURCE_LIST: [
+    { key: 'off', value: OFF_NAME },
+    { key: 'obf', value: OBF_NAME },
+    { key: 'opf', value: OPF_NAME },
+    { key: 'opff', value: OPFF_NAME },
+  ],
   FILTER_PARAM: 'filter',
   PRODUCT_FILTER_LIST: [
     { key: 'hide_price_count_gte_1', value: 'FilterProductWithPriceCountHide' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,33 +1,37 @@
 const OFF_NAME = 'Open Food Facts'
+const OFF_ICON = 'mdi-food-apple-outline'
 const OBF_NAME = 'Open Beauty Facts'
+const OBF_ICON = 'mdi-lotion-outline'
 const OPFF_NAME = 'Open Pet Food Facts'
+const OPFF_ICON = 'mdi-paw'
 const OPF_NAME = 'Open Products Facts'
+const OPF_ICON = 'mdi-bookshelf'
 
 export default {
   APP_NAME: 'Open Prices',
   OFF_NAME: OFF_NAME,
   OFF_URL: 'https://world.openfoodfacts.org',
-  OFF_ICON: 'mdi-food-apple-outline',
+  OFF_ICON: OFF_ICON,
   OFF_WIKI_URL: 'https://wiki.openfoodfacts.org/Main_Page',
   OFF_WIKI_APP_URL: 'https://wiki.openfoodfacts.org/Project:Open-Prices',
   OFF_WIKI_GDPR_REQUEST_URL: 'https://wiki.openfoodfacts.org/GDPR_request',
   OBF_NAME: OBF_NAME,
   OBF_URL: 'https://world.openbeautyfacts.org',
-  OBF_ICON: 'mdi-lotion-outline',
+  OBF_ICON: OBF_ICON,
   OPFF_NAME: OPFF_NAME,
   OPFF_URL: 'https://world.openpetfoodfacts.org',
-  OPFF_ICON: 'mdi-paw',
+  OPFF_ICON: OPFF_ICON,
   OPF_NAME: OPF_NAME,
   OPF_URL: 'https://world.openproductsfacts.org',
-  OPF_ICON: 'mdi-bookshelf',
+  OPF_ICON: OPF_ICON,
   PRODUCT_QUANTITY_UNIT_G: 'g',
   PRODUCT_QUANTITY_UNIT_ML: 'ml',
   SOURCE_PARAM: 'source',
   PRODUCT_SOURCE_LIST: [
-    { key: 'off', value: OFF_NAME },
-    { key: 'obf', value: OBF_NAME },
-    { key: 'opf', value: OPF_NAME },
-    { key: 'opff', value: OPFF_NAME },
+    { key: 'off', value: OFF_NAME, icon: OFF_ICON },
+    { key: 'obf', value: OBF_NAME, icon: OBF_ICON },
+    { key: 'opf', value: OPF_NAME, icon: OPF_ICON },
+    { key: 'opff', value: OPFF_NAME, icon: OPFF_ICON },
   ],
   FILTER_PARAM: 'filter',
   PRODUCT_FILTER_LIST: [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -120,6 +120,7 @@
 		"OrderPriceCreatedDESC": "Addition date",
 		"OrderPriceDateDESC": "Price date",
 		"SignInOFFAccount": "Sign in with your {url} account",
+		"Source": "Source",
 		"Yes": "Yes",
 		"No": "No",
 		"Food": "Food",

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -27,7 +27,7 @@
     <v-col>
       <h2 class="text-h6 d-inline mr-2">{{ $t('BrandDetail.TopProducts') }}</h2>
       <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-      <FilterMenu v-if="!loading" kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
+      <FilterMenu v-if="!loading" kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)" :hideSource="true"></FilterMenu>
       <OrderMenu v-if="!loading" kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
     </v-col>
   </v-row>

--- a/src/views/CategoryDetail.vue
+++ b/src/views/CategoryDetail.vue
@@ -27,7 +27,7 @@
     <v-col>
       <h2 class="text-h6 d-inline mr-2">{{ $t('CategoryDetail.TopProducts') }}</h2>
       <v-progress-circular v-if="loading" indeterminate :size="30"></v-progress-circular>
-      <FilterMenu v-if="!loading" kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
+      <FilterMenu v-if="!loading" kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)" :hideSource="true"></FilterMenu>
       <OrderMenu v-if="!loading" kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
     </v-col>
   </v-row>

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -9,7 +9,7 @@
       <v-chip label variant="text" prepend-icon="mdi-database-outline">
         {{ $t('ProductList.ProductTotal', { count: productTotal }) }}
       </v-chip>
-      <FilterMenu kind="product" :currentFilter="currentFilter" @update:currentFilter="toggleProductFilter($event)"></FilterMenu>
+      <FilterMenu kind="product" :currentFilter="currentFilter" :currentSource="currentSource" @update:currentFilter="toggleProductFilter($event)" @update:currentSource="toggleProductSource($event)"></FilterMenu>
       <OrderMenu kind="product" :currentOrder="currentOrder" @update:currentOrder="selectProductOrder($event)"></OrderMenu>
     </v-col>
   </v-row>
@@ -42,6 +42,7 @@ export default {
     return {
       // filter & order
       currentFilter: '',
+      currentSource: '',
       currentOrder: constants.PRODUCT_ORDER_LIST[1].key,
       // data
       productList: [],
@@ -56,11 +57,15 @@ export default {
       if (this.currentFilter && this.currentFilter === 'hide_price_count_gte_1') {
         defaultParams['price_count'] = 0
       }
+      if (this.currentSource) {
+        defaultParams['source'] = this.currentSource
+      }
       return defaultParams
     },
   },
   mounted() {
     this.currentFilter = this.$route.query[constants.FILTER_PARAM] || this.currentFilter
+    this.currentSource = this.$route.query[constants.SOURCE_PARAM] || this.currentSource
     this.currentOrder = this.$route.query[constants.ORDER_PARAM] || this.currentOrder
     this.initProductList()
   },
@@ -85,6 +90,13 @@ export default {
       this.currentFilter = this.currentFilter ? '' : filterKey
       this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.currentFilter } })
       // this.initProductList() will be called in watch $route
+    },
+    toggleProductSource(sourceKey) {
+      if (this.currentSource !== sourceKey) {
+        this.currentSource = sourceKey
+        this.$router.push({ query: { ...this.$route.query, [constants.SOURCE_PARAM]: this.currentSource } })
+        // this.initProductList() will be called in watch $route
+      }
     },
     selectProductOrder(orderKey) {
       if (this.currentOrder !== orderKey) {


### PR DESCRIPTION
### What

Following #479, related issue #502

Extend the `FilterMenu`, and add a new filter by source
- source = OFF, OBF, OPFF or OPF
- updates the url
- only available in the `ProductList` page

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/48191061-e01f-475d-92aa-ad8d34e53e0f)

