### PR TITLE
fix(product detail): fix display and translation of price category name

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -82,13 +82,20 @@ function prettyRelativeDateTime(dateTimeString, size=null) {
   diff < 60 && "just now" || diff < 120 && "1 minute ago" || diff < 3600 && Math.floor(diff / 60) + " minutes ago" || diff < 7200 && "1 hour ago" || diff < 86400 && Math.floor(diff / 3600) + " hours ago") || day_diff == 1 && "Yesterday" || day_diff < 10 && day_diff + " days ago" || Math.ceil(day_diff / 7) + " weeks ago";
 }
 
+function getCategoryName(categoryId) {
+  let category = CategoryTags.find(ct => ct.id === categoryId)
+  return category ? category.name : categoryId
+}
+
 function getLocaleCategoryTags(locale) {
   return import(`./data/categories/${locale}.json`)
 }
 
-function getCategoryName(categoryId) {
-  let category = CategoryTags.find(ct => ct.id === categoryId)
-  return category ? category.name : categoryId
+function getLocaleCategoryTagName(locale, categoryId) {
+  return getLocaleCategoryTags(locale).then((module) => {
+    let category = module.default.find(ct => ct.id === categoryId)
+    return category ? category.name : categoryId
+  })
 }
 
 function getLocaleOriginTags(locale) {
@@ -223,8 +230,9 @@ export default {
   prettyDate,
   prettyDateTime,
   prettyRelativeDateTime,
-  getLocaleCategoryTags,
   getCategoryName,
+  getLocaleCategoryTags,
+  getLocaleCategoryTagName,
   getLocaleOriginTags,
   getCountryEmojiFromName,
   getLocationTitle,


### PR DESCRIPTION
### What

For prices with a `category_tag`, we were using the old categories, and not the new/translated ones