### PR TITLE
feat(price): allow editing price date

### DIFF
--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -18,7 +18,19 @@
       <v-divider></v-divider>
 
       <v-card-text>
+        <h3 class="mb-1">{{ $t('PriceForm.Label') }}</h3>
         <PriceInputRow :priceForm="updatePriceForm"></PriceInputRow>
+
+        <h3 class="mt-4 mb-1">{{ $t('Common.Date') }}</h3>
+        <v-row>
+          <v-col cols="12" sm="6">
+            <v-text-field
+              v-model="updatePriceForm.date"
+              :label="$t('Common.Date')"
+              type="date"
+            ></v-text-field>
+          </v-col>
+        </v-row>
       </v-card-text>
 
       <v-divider></v-divider>
@@ -54,6 +66,7 @@ export default {
         price_is_discounted: false,
         price_without_discount: null,
         currency: null,
+        date: null,
       },
       productMode: null,
       loading: false

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -108,6 +108,7 @@
 	},
 	"Common": {
 		"AddToOFF": "Add to {name}",
+		"Date": "Date",
 		"Delete": "Delete",
 		"Edit": "Edit",
 		"Filter": "Filter",


### PR DESCRIPTION
### What

following #446, closes #552

### Screenshot

![Screenshot from 2024-04-25 16-47-20](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/4581133d-04bf-40b7-aaa3-29022f317812)


