### PR TITLE
feat(Location): display osm_tag in a new chip

### DIFF
--- a/src/components/LocationCard.vue
+++ b/src/components/LocationCard.vue
@@ -6,6 +6,9 @@
     @click="goToLocation(location)">
     <v-card-text v-if="location">
       <PriceCountChip :count="location.price_count" :withLabel="true"></PriceCountChip>
+      <v-chip label size="small" density="comfortable" class="mr-1" title="OpenStreetMap tag">
+        {{ location.osm_tag_key }}:{{ location.osm_tag_value }}
+      </v-chip>
     </v-card-text>
   </v-card>
 </template>


### PR DESCRIPTION
### What

Thanks to https://github.com/openfoodfacts/open-prices/pull/294 we now have `Location.osm_tag_key` & `Location.osm_tag_value`.

We can display them in the `LocationCard` as a chip

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/8a5f3deb-d121-4525-9d1e-aadbf46df59c)
