### PR TITLE
feat(proof): fetch and insert proof data to 'add single price' page when using 'add the price' button

### DIFF
--- a/src/components/PriceAddButton.vue
+++ b/src/components/PriceAddButton.vue
@@ -28,7 +28,7 @@ export default {
   computed: {
     getAddUrl() {
       if (this.proofId) {
-        return `${this.ADD_PRICE_BASE_URL}?proof=${this.proofId}`
+        return `${this.ADD_PRICE_BASE_URL}?proof_id=${this.proofId}`
       }
       return `${this.ADD_PRICE_BASE_URL}?code=${this.productCode}`
     }

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -412,17 +412,27 @@ export default {
     showUserRecentProofs() {
       this.userRecentProofsDialog = true
     },
-    handleProofSelected(proofId) {
-      this.addPriceSingleForm.proof_id = proofId
+    handleProofSelected(proof) {
+      this.addPriceSingleForm.proof_id = proof.id
+      this.addPriceSingleForm.date = new Date(proof.created).toISOString().split('T')[0]
+      this.proofImagePreview = this.getProofUrl(proof)
       this.proofSelectedSuccessMessage = true
       this.proofSelectedMessage = true
     },
     handleRecentProofSelected(selectedProof) {
-      this.handleProofSelected(selectedProof.id)
+      this.handleProofSelected(selectedProof)
       this.proofImagePreview = this.getProofUrl(selectedProof)
     },
     getProofUrl(proof) {
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
+    },
+    getProofById(proofId) {
+      this.loading = true;
+      api.getProofById(proofId)
+        .then(proof => {
+          this.handleProofSelected(proof);
+          this.loading = false;
+        });
     },
     newProof(source) {
       if (source === 'gallery') {

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -383,7 +383,7 @@ export default {
         this.setProductCode(this.$route.query.code)
       }
     } else if (this.$route.query.proof) {
-      this.handleProofSelected(this.$route.query.proof)
+      this.getProofById(this.$route.query.proof);
     }
     this.initPriceSingleForm()
   },

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -382,8 +382,8 @@ export default {
       else {
         this.setProductCode(this.$route.query.code)
       }
-    } else if (this.$route.query.proof) {
-      this.getProofById(this.$route.query.proof);
+    } else if (this.$route.query.proof_id) {
+      this.getProofById(this.$route.query.proof_id)
     }
     this.initPriceSingleForm()
   },
@@ -415,6 +415,7 @@ export default {
     handleProofSelected(proof) {
       this.addPriceSingleForm.proof_id = proof.id
       this.addPriceSingleForm.date = new Date(proof.created).toISOString().split('T')[0]
+      // this.proofDateSuccessMessage = true
       this.proofImagePreview = this.getProofUrl(proof)
       this.proofSelectedSuccessMessage = true
       this.proofSelectedMessage = true
@@ -427,12 +428,12 @@ export default {
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
     },
     getProofById(proofId) {
-      this.loading = true;
+      this.loading = true
       api.getProofById(proofId)
         .then(proof => {
-          this.handleProofSelected(proof);
-          this.loading = false;
-        });
+          this.handleProofSelected(proof)
+          this.loading = false
+        })
     },
     newProof(source) {
       if (source === 'gallery') {


### PR DESCRIPTION
### What
- Solves the missing proof image from https://github.com/openfoodfacts/open-prices-frontend/pull/557 and also inserts the proof created date to the form.
 _It uses the date the proof was uploaded, so might not always be the correct date for when the picture was taken_

### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) -->

### Part of 
- <!-- #1, please use the most granular issue possible -->
