### PR TITLE
feat(proof): recent proof dialog: add load more button, filter list depending on receipt or price tag

### DIFF
--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -13,6 +13,11 @@
             <ProofCard :proof="proof" :hideProofHeader="true" :hideProofActions="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof" />
           </v-col>
         </v-row>
+        <v-row v-if="userProofList.length < userProofTotal" class="mb-2">
+          <v-col align="center">
+            <v-btn size="small" :loading="loading" @click="getUserProofs">{{ $t('ProofDetail.LoadMore') }}</v-btn>
+          </v-col>
+        </v-row>
       </v-card-text>
     </v-card>
   </v-dialog>
@@ -33,7 +38,8 @@ export default {
     return {
       userProofList: [],
       userProofTotal: null,
-      userProofPage: 1,
+      userProofPage: 0,
+      userProofType: this.$route.path.endsWith('/receipt') ? 'RECEIPT' : 'PRICE_TAG',
       loading: false,
       selectedProof: null,
     }
@@ -50,7 +56,8 @@ export default {
   methods: {
     getUserProofs() {
       this.loading = true
-      return api.getProofs({ owner: this.username, page: this.userProofPage })
+      this.userProofPage += 1
+      return api.getProofs({ owner: this.username, page: this.userProofPage, type: this.userProofType })
         .then((data) => {
           this.userProofList.push(...data.items)
           this.userProofTotal = data.total
@@ -59,7 +66,7 @@ export default {
         .catch((error) => {
           console.error(error)
           this.loading = false
-    })
+        })
     },
     selectProof(proof) {
       this.selectedProof = proof

--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -33,13 +33,18 @@ export default {
   components: {
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
   },
+  props: {
+    filterType: {
+      type: String,
+      default: null,
+    }
+  },
   emits: ['recentProofSelected', 'close'],
   data() {
     return {
       userProofList: [],
       userProofTotal: null,
       userProofPage: 0,
-      userProofType: this.$route.path.endsWith('/receipt') ? 'RECEIPT' : 'PRICE_TAG',
       loading: false,
       selectedProof: null,
     }
@@ -49,6 +54,13 @@ export default {
     username() {
       return this.appStore.user.username
     },
+    getProofParams() {
+      let defaultParams = { owner: this.username, page: this.userProofPage }
+      if (this.filterType) {
+        defaultParams['type'] = this.filterType
+      }
+      return defaultParams
+    }
   },
   mounted() {
     this.getUserProofs()
@@ -57,7 +69,7 @@ export default {
     getUserProofs() {
       this.loading = true
       this.userProofPage += 1
-      return api.getProofs({ owner: this.username, page: this.userProofPage, type: this.userProofType })
+      return api.getProofs(this.getProofParams)
         .then((data) => {
           this.userProofList.push(...data.items)
           this.userProofTotal = data.total

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -342,6 +342,7 @@
   <UserRecentProofsDialog
     v-if="userRecentProofsDialog"
     v-model="userRecentProofsDialog"
+    :filterType="proofType"
     @recentProofSelected="handleRecentProofSelected($event)"
     @close="userRecentProofsDialog = false"
   />


### PR DESCRIPTION
### What
- Adds a load more button at the bottom of the recent proofs list in the dialog box used when adding prices.
Also, filters the proof type when fetching proofs based on if you're adding receipts or regular price tags.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) -->

### Part of 
- <!-- #1, please use the most granular issue possible -->
