### PR TITLE
feat(settings): user setting to display raw product category tag

### DIFF
--- a/src/components/CategoryCard.vue
+++ b/src/components/CategoryCard.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-card v-if="category" :title="category.name" prepend-icon="mdi-fruit-watermelon" data-name="category-card">
+    <v-card-text>
+      <PriceCountChip :count="priceCount" />
+      <CategoryTagChip v-if="category && !category.status && showProductCategoryTag" :category="category" />
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import { defineAsyncComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+
+export default {
+  components: {
+    PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
+    CategoryTagChip: defineAsyncComponent(() => import('../components/CategoryTagChip.vue')),
+  },
+  props: {
+    category: {
+      type: Object,
+      default: null,
+      example: { 'id': 'en:croissants', 'name': 'Croissants' }
+    },
+    priceCount: {
+      type: Number,
+      default: 0
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    showProductCategoryTag() {
+      return this.appStore.user.username && this.appStore.user.product_display_category_tag
+    }
+  }
+}
+</script>

--- a/src/components/CategoryTagChip.vue
+++ b/src/components/CategoryTagChip.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-chip label size="small" density="comfortable">
+    {{ category.id }}
+  </v-chip>
+</template>
+
+<script>
+export default {
+  props: {
+    category: {
+      type: Object,
+      default: null,
+      example: { 'id': 'en:croissants', 'name': 'Croissants' }
+    }
+  }
+}
+</script>

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -140,8 +140,8 @@ export default {
       } else if (this.hasPrice && this.price.product_code) {
         this.productTitle = this.price.product_code
       } else if (this.hasPrice && this.hasCategoryTag) {
-        utils.getLocaleCategoryTagName(this.appStore.getUserLanguage, this.price.category_tag).then((categoryName) => {
-          this.productTitle = categoryName
+        utils.getLocaleCategoryTag(this.appStore.getUserLanguage, this.price.category_tag).then((category) => {
+          this.productTitle = category.name
         })
       } else {
         this.productTitle = this.$t('PriceCard.UnknownProduct')

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -382,6 +382,7 @@
 		"LanguageLabel": "Languages",
 		"LocationDisplayOSMID": "Display OSM ID",
 		"ProductDisplayBarcode": "Display barcode",
+		"ProductDisplayCategoryTag": "Display category tag",
 		"Save": "Save",
 		"Title": "Settings",
 		"TranslationCompletion": "Translation is {completion}% complete.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -376,7 +376,7 @@
 		"ChangeLanguage": "Change language",
 		"CountryLabel": "Country",
 		"CurrencyLabel": "Currency",
-		"Display": "Display",
+		"DisplayTitle": "Display",
 		"FavoriteCurrencies": "Favorite currencies",
 		"CurrencyRequired": "At least one currency is required",
 		"LanguageLabel": "Languages",

--- a/src/store.js
+++ b/src/store.js
@@ -15,6 +15,7 @@ export const useAppStore = defineStore('app', {
       proofs: [],
       proofTotal: null,
       product_display_barcode: false,
+      product_display_category_tag: false,
       location_display_osm_id: false,
     },
   }),

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,13 @@ function getLocaleCategoryTags(locale) {
   return import(`./data/categories/${locale}.json`)
 }
 
+function getLocaleCategoryTag(locale, categoryId) {
+  return getLocaleCategoryTags(locale).then((module) => {
+    let category = module.default.find(ct => ct.id === categoryId)
+    return category ? category : { 'id': categoryId, 'name': categoryId, 'status': 'unknown' }
+  })
+}
+
 function getLocaleCategoryTagName(locale, categoryId) {
   return getLocaleCategoryTags(locale).then((module) => {
     let category = module.default.find(ct => ct.id === categoryId)
@@ -242,6 +249,7 @@ export default {
   prettyRelativeDateTime,
   getCategoryName,
   getLocaleCategoryTags,
+  getLocaleCategoryTag,
   getLocaleCategoryTagName,
   getLocaleOriginTags,
   getCountryEmojiFromName,

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -2,11 +2,7 @@
   <v-row>
     <v-col cols="12" sm="6">
       <ProductCard v-if="!productIsCategory" :product="product" />
-      <v-card v-else :title="categoryName" prepend-icon="mdi-fruit-watermelon" elevation="1">
-        <v-card-text>
-          <PriceCountChip :count="productPriceTotal" />
-        </v-card-text>
-      </v-card>
+      <CategoryCard v-else :category="category" :priceCount="productPriceTotal" />
     </v-col>
   </v-row>
 
@@ -30,7 +26,7 @@
   <v-row v-if="!productOrCategoryNotFound" class="mt-0">
     <v-col cols="12">
       <PriceAddButton v-if="product && product.code" class="mr-2" :productCode="product.code" />
-      <PriceAddButton v-else class="mr-2" :productCode="categoryName" />
+      <PriceAddButton v-else-if="category" class="mr-2" :productCode="category.name" />
       <OpenFoodFactsLink v-if="product && product.code && product.source" display="button" :source="product.source" facet="product" :value="product.code" />
       <ShareButton />
     </v-col>
@@ -75,7 +71,7 @@ import api from '../services/api'
 export default {
   components: {
     ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
-    PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
+    CategoryCard: defineAsyncComponent(() => import('../components/CategoryCard.vue')),
     PriceAddButton: defineAsyncComponent(() => import('../components/PriceAddButton.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
@@ -89,7 +85,7 @@ export default {
       OFF_NAME: constants.OFF_NAME,
       productId: this.$route.params.id,  // product_code or product_category
       product: null,
-      categoryName: null,
+      category: null,
       productPriceList: [],
       productPriceTotal: 0,
       productPricePage: 0,
@@ -110,7 +106,7 @@ export default {
       return !this.productIsCategory && !this.product
     },
     categoryNotFound() {
-      return this.productIsCategory && !this.categoryName
+      return this.productIsCategory && this.category && this.category.status
     },
     productOrCategoryNotFound() {
       return !this.loading && (this.productNotFound || this.categoryNotFound)
@@ -147,8 +143,8 @@ export default {
     },
     getProduct() {
       if (this.productIsCategory) {
-        utils.getLocaleCategoryTagName(this.appStore.getUserLanguage, this.productId).then((categoryName) => {
-          this.categoryName = categoryName
+        utils.getLocaleCategoryTag(this.appStore.getUserLanguage, this.productId).then((category) => {
+          this.category = category
         })
       } else {
         return api.getProductByCode(this.productId)

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -6,7 +6,7 @@
   <v-form @submit.prevent="updateSettings">
     <v-row>
       <v-col cols="12" sm="6">
-        <v-card :title="$t('UserSettings.Display')" prepend-icon="mdi-laptop">
+        <v-card :title="$t('UserSettings.DisplayTitle')" prepend-icon="mdi-laptop">
           <v-divider />
           <!-- Country -->
           <v-card-text>

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -49,6 +49,7 @@
               {{ $t('Common.Products') }}
             </h3>
             <v-checkbox v-model="appStore.user.product_display_barcode" :label="$t('UserSettings.ProductDisplayBarcode')" hide-details="auto" />
+            <v-checkbox v-model="appStore.user.product_display_category_tag" :label="$t('UserSettings.ProductDisplayCategoryTag')" hide-details="auto" />
             <!-- Locations -->
             <h3 class="mt-4 mb-1">
               {{ $t('Common.Locations') }}


### PR DESCRIPTION
### What

Similar to #559

- new user setting to toggle the display of the product category in the Product Detail page
- new `CategoryCard` & `CategoryTagChip` components

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/1233aebf-2155-4a2a-a361-76fba2845194)
