### PR TITLE
refactor(price add): change the ui of the discount toggle (switch instead of checkbox)

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -31,7 +31,7 @@
     </v-col>
   </v-row>
   <div class="d-inline">
-    <v-checkbox v-model="priceForm.price_is_discounted" :label="$t('PriceForm.Discount')" hide-details="auto" />
+    <v-switch v-model="priceForm.price_is_discounted" :label="$t('Common.Discount')" color="success" hide-details="auto" />
   </div>
 
   <ChangeCurrencyDialog

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -114,6 +114,7 @@
 		"Locations": "Locations",
 		"Date": "Date",
 		"Delete": "Delete",
+		"Discount": "Discount",
 		"Edit": "Edit",
 		"Filter": "Filter",
 		"FilterProductWithPriceCountHide": "Hide products with prices",


### PR DESCRIPTION
### What

Replace the discount checkbox with a switch

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/f80df5b6-4a79-49dc-a20b-418315f77b89)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/6da2b3ef-1cad-4212-ac2d-96539650ad0d)|