### PR TITLE
refactor(price add): when coming from the proof detail page, direct users to multiple add form

### DIFF
--- a/src/components/PriceAddButton.vue
+++ b/src/components/PriceAddButton.vue
@@ -19,19 +19,29 @@ export default {
     proofId: {
       type: Number,
       default: null
+    },
+    proofType: {
+      type: String,
+      default: null,
+      examples: ['PRICE_TAG', 'RECEIPT']
     }
   },
   data() {
     return {
-      ADD_PRICE_BASE_URL: '/prices/add/single'
+      ADD_PRICE_SINGLE_BASE_URL: '/prices/add/single',
+      ADD_PRICE_MULTIPLE_RECEIPT_BASE_URL: '/prices/add/multiple/receipt',
+      ADD_PRICE_MULTIPLE_PRICE_TAG_BASE_URL: '/prices/add/multiple/price-tag',
     }
   },
   computed: {
     getAddUrl() {
       if (this.proofId) {
-        return `${this.ADD_PRICE_BASE_URL}?proof_id=${this.proofId}`
+        if (this.proofType === 'RECEIPT') {
+          return `${this.ADD_PRICE_MULTIPLE_RECEIPT_BASE_URL}?proof_id=${this.proofId}`
+        }
+        return `${this.ADD_PRICE_MULTIPLE_PRICE_TAG_BASE_URL}?proof_id=${this.proofId}`
       }
-      return `${this.ADD_PRICE_BASE_URL}?code=${this.productCode}`
+      return `${this.ADD_PRICE_SINGLE_BASE_URL}?code=${this.productCode}`
     }
   }
 }

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -17,7 +17,7 @@
         </template>
         <v-divider />
         <v-card-text>
-          <ProofInputRow :proofType="proofType" :proofForm="addPriceMultipleForm" />
+          <ProofInputRow :proofType="proofType" :proofForm="addPriceMultipleForm" @proof="proofObject = $event" />
         </v-card-text>
         <v-overlay v-model="disableProofForm" scrim="#E8F5E9" contained persistent />
       </v-card>
@@ -31,9 +31,9 @@
         style="border: 1px solid #4CAF50"
       >
         <template #title>
-          <i18n-t keypath="AddPriceMultiple.ProductPriceDetails.AlreadyUploaded" :plural="productPriceUploadedList.length" tag="span">
+          <i18n-t keypath="AddPriceMultiple.ProductPriceDetails.AlreadyUploaded" :plural="productPriceUploadedCount" tag="span">
             <template #priceAlreadyUploadedNumber>
-              <span>{{ productPriceUploadedList.length }}</span>
+              <span>{{ productPriceUploadedCount }}</span>
             </template>
           </i18n-t>
         </template>
@@ -121,13 +121,6 @@
   </v-row>
 
   <v-snackbar
-    v-model="proofDateSuccessMessage"
-    color="info"
-    :timeout="2000"
-  >
-    {{ $t('AddPriceSingle.PriceDetails.ProofDateChanged') }}
-  </v-snackbar>
-  <v-snackbar
     v-model="priceSuccessMessage"
     color="success"
     :timeout="2000"
@@ -167,7 +160,7 @@ export default {
       createPriceLoading: false,
       priceSuccessMessage: false,
       // proof data
-      proofDateSuccessMessage: false,
+      proofObject: null,
       // product price data
       productPriceUploadedList: [],
       productPriceNew: {
@@ -214,6 +207,9 @@ export default {
     disablePriceAlreadyUploadedCard() {
       // return !!this.productPriceUploadedList.length
       return true
+    },
+    productPriceUploadedCount() {
+      return (this.proofObject ? this.proofObject.price_count : 0) + this.productPriceUploadedList.length
     }
   },
   mounted() {

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -8,7 +8,7 @@
     </v-col>
   </v-row>
 
-  <v-row v-if="proof" class="mt-0">
+  <v-row v-if="allowPriceAdd" class="mt-0">
     <v-col cols="12">
       <PriceAddButton class="mr-2" :proofId="proof.id" :proofType="proof.type" />
     </v-col>
@@ -54,6 +54,11 @@ export default {
       proofPriceTotal: null,
       proofPricePage: 0,
       loading: false,
+    }
+  },
+  computed: {
+    allowPriceAdd() {
+      return this.proof && (this.proof.type === 'PRICE_TAG' || this.proof.type === 'RECEIPT')
     }
   },
   mounted() {

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -10,7 +10,7 @@
 
   <v-row v-if="proof" class="mt-0">
     <v-col cols="12">
-      <PriceAddButton class="mr-2" :proofId="proof.id" />
+      <PriceAddButton class="mr-2" :proofId="proof.id" :proofType="proof.type" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

Since #557 there is a "Add price" button in the proof detail page.
But it was directing users towards the "single price" workflow.

With this change users are now directed towards the "multiple price" workflow.

### Todo

- fetch existing proof prices and display them in the form ?