### PR TITLE
feat(proof card): display date & currency in the footer

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-chip label size="small" density="comfortable">
+    <v-icon start icon="mdi-cash" />
+    {{ proof.currency }}
+  </v-chip>
+</template>
+
+<script>
+export default {
+  props: {
+    proof: {
+      type: Object,
+      default: null
+    },
+  },
+}
+</script>

--- a/src/components/ProofDateChip.vue
+++ b/src/components/ProofDateChip.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-chip label size="small" density="comfortable">
+    <v-icon start icon="mdi-camera" />
+    {{ getDateFormatted(proof.date) }}
+  </v-chip>
+</template>
+
+<script>
+import utils from '../utils.js'
+
+export default {
+  props: {
+    proof: {
+      type: Object,
+      default: null
+    },
+  },
+  methods: {
+    getDateFormatted(dateString) {
+      return utils.prettyDate(dateString)
+    },
+  }
+}
+</script>

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -4,6 +4,7 @@
       <ProofTypeChip class="mr-1" :proof="proof" />
       <ProofPrivateChip v-if="proofIsPrivateReceipt" class="mr-1" :proof="proof" />
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()" />
+      <CurrencyChip v-if="proof.currency" class="mr-1" :proof="proof" />
       <RelativeDateTimeChip :dateTime="proof.created" />
     </v-col>
   </v-row>
@@ -21,6 +22,7 @@ export default {
     ProofTypeChip: defineAsyncComponent(() => import('../components/ProofTypeChip.vue')),
     ProofPrivateChip: defineAsyncComponent(() => import('../components/ProofPrivateChip.vue')),
     PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
+    CurrencyChip: defineAsyncComponent(() => import('../components/CurrencyChip.vue')),
     RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
     ProofActionMenuButton: defineAsyncComponent(() => import('../components/ProofActionMenuButton.vue'))
   },

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -3,6 +3,7 @@
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof" />
       <ProofPrivateChip v-if="proofIsPrivateReceipt" class="mr-1" :proof="proof" />
+      <ProofDateChip v-if="proof.date" class="mr-1" :proof="proof" />
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()" />
       <CurrencyChip v-if="proof.currency" class="mr-1" :proof="proof" />
       <RelativeDateTimeChip :dateTime="proof.created" />
@@ -22,6 +23,7 @@ export default {
     ProofTypeChip: defineAsyncComponent(() => import('../components/ProofTypeChip.vue')),
     ProofPrivateChip: defineAsyncComponent(() => import('../components/ProofPrivateChip.vue')),
     PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
+    ProofDateChip: defineAsyncComponent(() => import('../components/ProofDateChip.vue')),
     CurrencyChip: defineAsyncComponent(() => import('../components/CurrencyChip.vue')),
     RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
     ProofActionMenuButton: defineAsyncComponent(() => import('../components/ProofActionMenuButton.vue'))


### PR DESCRIPTION
### What

If available, show the proof date & proof currency in the proof card footer

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/1b4662d1-5a54-46ab-98f1-d87807c4baf5)
