### PR TITLE
feat(price add): move date & currency to the proof section

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -11,7 +11,7 @@
         :suffix="priceForm.currency"
         @update:model-value="newValue => priceForm.price = fixComma(newValue)"
       >
-        <template #prepend-inner>
+        <template v-if="!hideCurrencyChoice" #prepend-inner>
           <!-- image from https://www.svgrepo.com/svg/32717/currency-exchange -->
           <img src="/currency-exchange-svgrepo-com.svg" class="icon-info-currency" @click="changeCurrencyDialog = true">
         </template>
@@ -54,6 +54,10 @@ export default {
       type: Object,
       default: () => ({ price: null, currency: null, price_is_discounted: false, price_without_discount: null })
     },
+    hideCurrencyChoice: {
+      type: Boolean,
+      default: false
+    }
   },
   emits: ['filled'],
   data() {

--- a/src/components/ProofInputRow.vue
+++ b/src/components/ProofInputRow.vue
@@ -1,52 +1,73 @@
 <template>
   <v-row>
-    <v-col cols="8">
-      <v-btn
-        class="mb-2 mr-2" size="small" prepend-icon="mdi-camera" :loading="createProofLoading"
-        :disabled="createProofLoading" @click.prevent="$refs.proofCamera.click()"
-      >
-        <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Picture') }}</span>
-        <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.TakePicture') }}</span>
-      </v-btn>
-      <v-btn
-        class="mb-2 mr-2" size="small" prepend-icon="mdi-image-plus" :loading="createProofLoading"
-        :disabled="createProofLoading" @click.prevent="$refs.proofGallery.click()"
-      >
-        <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Gallery') }}</span>
-        <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectFromGallery') }}</span>
-      </v-btn>
-      <v-btn v-if="!hideRecentProofChoice" class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showUserRecentProofsDialog">
-        <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.RecentProof') }}</span>
-        <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectRecentProof') }}</span>
-      </v-btn>
-      <v-file-input
-        ref="proofCamera" v-model="proofImage" class="d-none overflow-hidden" capture="environment"
-        accept="image/*" :loading="createProofLoading" @change="newProof('camera')" @click:clear="clearProof"
-      />
-      <v-file-input
-        ref="proofGallery" v-model="proofImage" class="d-none overflow-hidden" accept="image/*, .heic"
-        :loading="createProofLoading" @change="newProof('gallery')" @click:clear="clearProof"
-      />
-      <p v-if="proofFormFilled && !createProofLoading" class="text-green mt-2 mb-2">
-        <i v-if="!proofisSelected">{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
-        <i v-if="proofisSelected">{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
-      </p>
-      <p v-if="!proofFormFilled && !createProofLoading" class="text-red mt-2 mb-2">
-        <i>{{ $t('AddPriceSingle.PriceDetails.UploadProof') }}</i>
-      </p>
+    <!-- proof image -->
+    <v-col cols="12">
+      <v-row>
+        <v-col cols="8">
+          <v-btn
+            class="mb-2 mr-2" size="small" prepend-icon="mdi-camera" :loading="loading"
+            :disabled="loading" @click.prevent="$refs.proofCamera.click()"
+          >
+            <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Picture') }}</span>
+            <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.TakePicture') }}</span>
+          </v-btn>
+          <v-btn
+            class="mb-2 mr-2" size="small" prepend-icon="mdi-image-plus" :loading="loading"
+            :disabled="loading" @click.prevent="$refs.proofGallery.click()"
+          >
+            <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Gallery') }}</span>
+            <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectFromGallery') }}</span>
+          </v-btn>
+          <v-btn v-if="!hideRecentProofChoice" class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="showUserRecentProofsDialog">
+            <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.RecentProof') }}</span>
+            <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectRecentProof') }}</span>
+          </v-btn>
+          <v-file-input
+            ref="proofCamera" v-model="proofImage" class="d-none overflow-hidden" capture="environment"
+            accept="image/*" :loading="loading" @change="newProof('camera')" @click:clear="clearProof"
+          />
+          <v-file-input
+            ref="proofGallery" v-model="proofImage" class="d-none overflow-hidden" accept="image/*, .heic"
+            :loading="loading" @change="newProof('gallery')" @click:clear="clearProof"
+          />
+          <p v-if="proofFormFilled && !loading" class="text-green mt-2 mb-2">
+            <i v-if="!existingProof">{{ $t('AddPriceSingle.PriceDetails.ProofUploaded') }}</i>
+            <i v-if="existingProof">{{ $t('AddPriceSingle.PriceDetails.ProofSelected') }}</i>
+          </p>
+          <p v-if="!proofFormFilled && !loading" class="text-red mt-2 mb-2">
+            <i>{{ $t('AddPriceSingle.PriceDetails.UploadProof') }}</i>
+          </p>
+        </v-col>
+        <v-col v-if="proofFormFilled" cols="4">
+          <v-img :src="proofImagePreview" style="max-height:200px" />
+        </v-col>
+      </v-row>
+      <v-row v-if="proofType === 'RECEIPT'" class="mt-0">
+        <v-col>
+          <h3 class="mb-1">
+            {{ $t('ProofDetail.Privacy') }}
+          </h3>
+          <p class="text-caption text-warning">
+            <i>{{ $t('AddPriceMultiple.ProofDetails.ReceiptWarning') }}</i>
+          </p>
+        </v-col>
+      </v-row>
     </v-col>
-    <v-col v-if="proofFormFilled" cols="4">
-      <v-img :src="proofImagePreview" style="max-height:200px" />
-    </v-col>
-  </v-row>
-  <v-row v-if="proofType === 'RECEIPT'" class="mt-0">
-    <v-col>
-      <h3 class="mb-1">
-        {{ $t('ProofDetail.Privacy') }}
+    <!-- proof date -->
+    <v-col cols="12">
+      <h3 class="mt-4 mb-1">
+        {{ $t('Common.Date') }}
       </h3>
-      <p class="text-caption text-warning">
-        <i>{{ $t('AddPriceMultiple.ProofDetails.ReceiptWarning') }}</i>
-      </p>
+      <v-row>
+        <v-col cols="12" sm="6">
+          <v-text-field
+            v-model="proofForm.date"
+            :label="$t('Common.Date')"
+            type="date"
+            :disabled="existingProof"
+          />
+        </v-col>
+      </v-row>
     </v-col>
   </v-row>
 
@@ -111,20 +132,20 @@ export default {
   },
   data() {
     return {
+      existingProof: false,
       proofImage: null,
       proofImagePreview: null,
-      createProofLoading: false,
       proofDateSuccessMessage: false,
       proofSuccessMessage: false,
       userRecentProofsDialog: false,
       proofSelectedSuccessMessage: false,
-      proofisSelected: false,
+      loading: false,
     }
   },
   computed: {
     ...mapStores(useAppStore),
     proofFormFilled() {
-      let keys = ['proof_id']
+      let keys = ['proof_id', 'date']
       return Object.keys(this.proofForm).filter(k => keys.includes(k)).every(k => !!this.proofForm[k])
     },
   },
@@ -138,6 +159,7 @@ export default {
       this.userRecentProofsDialog = true
     },
     handleRecentProofSelected(selectedProof) {
+      this.existingProof = true
       this.proofForm.proof_id = selectedProof.id
       this.proofImagePreview = this.getProofUrl(selectedProof)
       if (selectedProof.date) {
@@ -145,14 +167,13 @@ export default {
         this.proofDateSuccessMessage = true
       }
       this.proofSelectedSuccessMessage = true
-      this.proofisSelected = true
     },
     getProofById(proofId) {
-      this.createProofLoading = true
+      this.loading = true
       api.getProofById(proofId)
         .then(proof => {
           this.handleRecentProofSelected(proof)
-          this.createProofLoading = false
+          this.loading = false
         })
     },
     getProofUrl(proof) {
@@ -161,6 +182,7 @@ export default {
     },
     newProof(source) {
       if (source === 'gallery') {
+        // extract date from image exif
         ExifReader.load(this.proofImage[0]).then((tags) => {
           if (tags['DateTimeOriginal'] && tags['DateTimeOriginal'].description) {
             // exif DateTimeOriginal format: '2024:01:31 20:23:52'
@@ -175,7 +197,7 @@ export default {
       this.uploadProof()
     },
     uploadProof() {
-      this.createProofLoading = true
+      this.loading = true
       new Promise((resolve, reject) => {
         new Compressor(this.proofImage[0], {
           success: resolve,
@@ -184,9 +206,9 @@ export default {
       })
       .then((proofImageCompressed) => {
         api
-          .createProof(proofImageCompressed, this.proofType)  // this.proofForm.date
+          .createProof(proofImageCompressed, this.proofType, this.proofForm.date)
           .then((data) => {
-            this.createProofLoading = false
+            this.loading = false
             if (data.id) {
               const store = useAppStore()
               store.addProof(data)
@@ -201,7 +223,7 @@ export default {
           .catch((error) => {
             alert('Error: server error')
             console.log(error)
-            this.createProofLoading = false
+            this.loading = false
           })
       })
       .catch((error) => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -131,6 +131,7 @@
 		"SignInOFFAccount": "Sign in with your {url} account",
 		"Source": "Source",
 		"Type": "Type",
+		"Upload": "Upload",
 		"Yes": "Yes",
 		"No": "No",
 		"Food": "Food",
@@ -284,6 +285,8 @@
 		"GDPR_REQUEST": "GDPR request"
 	},
 	"ProofCreate": {
+		"SelectProof": "Select a proof",
+		"ProofSelected": "Proof selected!",
 		"Success": "Proof created!"
 	},
 	"ProofDelete": {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -55,8 +55,8 @@ export default {
     let formData = new FormData()
     formData.append('file', proofImage, proofImage.name)
     formData.append('type', type)
-    formData.append('date', date)
-    formData.append('currency', currency)
+    formData.append('date', date ? date : '')
+    formData.append('currency', currency ? currency : '')
     const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/upload?${buildURLParams()}`
     return fetch(url, {
       method: 'POST',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -49,12 +49,13 @@ export default {
     .then((response) => response.json())
   },
 
-  createProof(proofImage, type='PRICE_TAG', date=null) {
+  createProof(proofImage, type='PRICE_TAG', date=null, currency=null) {
     const store = useAppStore()
     let formData = new FormData()
     formData.append('file', proofImage, proofImage.name)
     formData.append('type', type)
     formData.append('date', date)
+    formData.append('currency', currency)
     const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/upload?${buildURLParams()}`
     return fetch(url, {
       method: 'POST',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -50,6 +50,7 @@ export default {
   },
 
   createProof(proofImage, type='PRICE_TAG', date=null, currency=null) {
+    console.log('createProof', proofImage, type, date, currency)
     const store = useAppStore()
     let formData = new FormData()
     formData.append('file', proofImage, proofImage.name)

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -19,7 +19,7 @@
         <v-card-text>
           <ProofInputRow :proofType="proofType" :proofForm="addPriceMultipleForm" />
         </v-card-text>
-        <v-overlay v-model="disableProofLocationDateForm" scrim="#E8F5E9" contained persistent />
+        <v-overlay v-model="disableProofLocationForm" scrim="#E8F5E9" contained persistent />
       </v-card>
     </v-col>
 
@@ -29,9 +29,9 @@
         :title="$t('AddPriceSingle.WhereWhen.Title')"
         prepend-icon="mdi-map-marker-outline"
         height="100%"
-        :style="locationDateFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'"
+        :style="locationFormFilled ? 'border: 1px solid #4CAF50' : 'border: 1px solid transparent'"
       >
-        <template v-if="locationDateFormFilled" #append>
+        <template v-if="locationFormFilled" #append>
           <v-icon icon="mdi-checkbox-marked-circle" color="success" />
         </template>
         <v-divider />
@@ -56,21 +56,8 @@
           <p v-if="!locationFormFilled" class="text-red mb-2">
             <i>{{ $t('AddPriceSingle.WhereWhen.SelectLocation') }}</i>
           </p>
-
-          <h3 class="mt-4 mb-1">
-            {{ $t('AddPriceSingle.WhereWhen.Date') }}
-          </h3>
-          <v-row>
-            <v-col cols="12" sm="6">
-              <v-text-field
-                v-model="addPriceMultipleForm.date"
-                :label="$t('AddPriceSingle.WhereWhen.DateLabel')"
-                type="date"
-              />
-            </v-col>
-          </v-row>
         </v-card-text>
-        <v-overlay v-model="disableProofLocationDateForm" scrim="#E8F5E9" contained persistent />
+        <v-overlay v-model="disableProofLocationForm" scrim="#E8F5E9" contained persistent />
       </v-card>
     </v-col>
 
@@ -252,7 +239,7 @@ export default {
   computed: {
     ...mapStores(useAppStore),
     proofFormFilled() {
-      let keys = ['proof_id']
+      let keys = ['proof_id', 'date']
       return Object.keys(this.addPriceMultipleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceMultipleForm[k])
     },
     recentLocations() {
@@ -262,12 +249,8 @@ export default {
       let keys = ['location_osm_id', 'location_osm_type']
       return Object.keys(this.addPriceMultipleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceMultipleForm[k])
     },
-    locationDateFormFilled() {
-      let keys = ['location_osm_id', 'location_osm_type', 'date']
-      return Object.keys(this.addPriceMultipleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceMultipleForm[k])
-    },
     proofLocationFormFilled() {
-      return this.proofFormFilled && this.locationDateFormFilled
+      return this.proofFormFilled && this.locationFormFilled
     },
     pricePerFormFilled() {
       let keys = ['price_per']
@@ -282,7 +265,7 @@ export default {
     formFilled() {
       return this.proofLocationFormFilled && !!this.productPriceUploadedList.length && !Object.keys(this.productPriceForm).length
     },
-    disableProofLocationDateForm() {
+    disableProofLocationForm() {
       return this.proofLocationFormFilled && !!this.productPriceUploadedList.length
     },
     disablePriceAlreadyUploadedCard() {

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -127,7 +127,7 @@
                 </v-item>
               </v-item-group>
             </h3>
-            <PriceInputRow :priceForm="productPriceForm" @filled="pricePriceFormFilled = $event" />
+            <PriceInputRow :priceForm="productPriceForm" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
           </v-card-text>
           <v-divider />
           <v-card-text>
@@ -205,6 +205,7 @@ export default {
         location_osm_id: null,
         location_osm_type: '',
         date: utils.currentDate(),
+        currency: null  // see initPriceMultipleForm
       },
       productPriceForm: {},
       productFormFilled: false,
@@ -228,7 +229,7 @@ export default {
         price_per: null, // see PriceInputRow
         price_is_discounted: false,
         price_without_discount: null,
-        currency: null,  // see PriceInputRow
+        currency: null  // see initNewProductPriceForm
       },
       categoryPricePerList: [
         {key: 'KILOGRAM', value: this.$t('AddPriceSingle.CategoryPricePer.PerKg'), icon: 'mdi-weight-kilogram'},
@@ -283,6 +284,7 @@ export default {
        * (init form done in initNewProductPriceForm)
        */
       this.proofType = this.$route.path.endsWith('/receipt') ? 'RECEIPT' : 'PRICE_TAG'
+      this.addPriceMultipleForm.currency = this.appStore.getUserLastCurrencyUsed
       if (this.recentLocations.length) {
         this.setLocationData(this.recentLocations[0])
       }
@@ -311,8 +313,8 @@ export default {
       this.clearProductPriceForm()
       this.productPriceForm = JSON.parse(JSON.stringify(this.productPriceNew))  // deep copy
       this.productPriceForm.mode = this.appStore.user.last_product_mode_used
-      this.productPriceForm.currency = this.appStore.getUserLastCurrencyUsed
       this.productPriceForm.price_per = this.categoryPricePerList[0].key // init to 'KILOGRAM' because it's the most common use-case
+      this.productPriceForm.currency = this.addPriceMultipleForm.currency
     },
     createPrice() {
       this.createPriceLoading = true

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -19,7 +19,7 @@
         <v-card-text>
           <ProofInputRow :proofType="proofType" :proofForm="addPriceMultipleForm" />
         </v-card-text>
-        <v-overlay v-model="disableProofLocationForm" scrim="#E8F5E9" contained persistent />
+        <v-overlay v-model="disableProofForm" scrim="#E8F5E9" contained persistent />
       </v-card>
     </v-col>
 
@@ -57,7 +57,7 @@
             <i>{{ $t('AddPriceSingle.WhereWhen.SelectLocation') }}</i>
           </p>
         </v-card-text>
-        <v-overlay v-model="disableProofLocationForm" scrim="#E8F5E9" contained persistent />
+        <v-overlay v-model="disableLocationForm" scrim="#E8F5E9" contained persistent />
       </v-card>
     </v-col>
 
@@ -240,7 +240,7 @@ export default {
   computed: {
     ...mapStores(useAppStore),
     proofFormFilled() {
-      let keys = ['proof_id', 'date']
+      let keys = ['proof_id', 'date', 'currency']
       return Object.keys(this.addPriceMultipleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceMultipleForm[k])
     },
     recentLocations() {
@@ -266,8 +266,11 @@ export default {
     formFilled() {
       return this.proofLocationFormFilled && !!this.productPriceUploadedList.length && !Object.keys(this.productPriceForm).length
     },
-    disableProofLocationForm() {
-      return this.proofLocationFormFilled && !!this.productPriceUploadedList.length
+    disableProofForm() {
+      return this.proofFormFilled
+    },
+    disableLocationForm() {
+      return !this.proofFormFilled || (this.proofLocationFormFilled && !!this.productPriceUploadedList.length)
     },
     disablePriceAlreadyUploadedCard() {
       // return !!this.productPriceUploadedList.length


### PR DESCRIPTION
### What

- move up `date` & `currency` form fields to the Proof section (`ProofInputRow` created in #632)
- new "Upload" button
- and display the `ProofCard` once it is uploaded (or selected if coming from an existing proof)

### Screenshot

|1. Select proof|2. Upload proof|3. Display proof|
|---|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/e4eb0e8d-5a9d-44e7-92c4-7c57df97950d)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/5a2f5bb4-d444-45c0-8164-ae81bc40cd89)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/47da1a42-9bef-4519-81c1-a7ff72712ebb)|