### PR TITLE
refactor(proof edit): cleanup is_public. Allow editing date if no prices

### DIFF
--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -3,7 +3,7 @@
     <v-icon>mdi-dots-vertical</v-icon>
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
-        <v-list-item v-if="proofIsPrivateReceipt" :slim="true" prepend-icon="mdi-pencil" :disabled="!proofIsReceipt" @click="openEditDialog">
+        <v-list-item :slim="true" prepend-icon="mdi-pencil" @click="openEditDialog">
           {{ $t('Common.Edit') }}
         </v-list-item>
         <v-list-item :slim="true" prepend-icon="mdi-delete" :disabled="!userCanDeleteProof" @click="openDeleteConfirmationDialog">
@@ -73,11 +73,10 @@ export default {
     }
   },
   computed: {
-    proofIsReceipt() {
-      return this.proof.type === 'RECEIPT'
-    },
-    proofIsPrivateReceipt() {
-      return this.proofIsReceipt && !this.proof.is_public
+    userCanEditProof() {
+      // user must be proof owner
+      // and proof must not have any prices
+      return this.proof.price_count === 0
     },
     userCanDeleteProof() {
       // user must be proof owner

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -7,7 +7,7 @@
     <v-divider v-if="!hideProofHeader" />
 
     <v-card-text>
-      <v-img v-if="proof.file_path" :src="getProofUrl(proof)" />
+      <v-img v-if="proof.file_path" :src="getProofUrl(proof)" :style="'max-height:' + imageHeight" />
     </v-card-text>
 
     <v-divider />
@@ -50,9 +50,9 @@ export default {
       type: Boolean,
       default: false,
     },
-    height: {
+    imageHeight: {
       type: String,
-      default: 'auto',
+      default: '100%',
     },
   },
   emits: ['proofSelected', 'close'],

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -7,16 +7,25 @@
 
       <v-divider />
 
-      <v-card-text v-if="proofIsReceipt">
-        <h3>{{ $t('ProofDetail.Privacy') }}</h3>
-        <v-switch
-          v-model="isPublic"
-          color="green"
-          density="compact"
-          inset
-          :label="isPublic ? $t('ProofDetail.Public') : $t('ProofDetail.Private')"
-          hide-details
-        />
+      <v-card-text>
+        <ProofCard :proof="proof" :hideProofHeader="true" :hideProofActions="true" :readonly="true" imageHeight="100px" />
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-text>
+        <h3 class="mb-1">
+          {{ $t('Common.Date') }}
+        </h3>
+        <v-row>
+          <v-col cols="12" sm="6">
+            <v-text-field
+              v-model="updateProofForm.date"
+              :label="$t('Common.Date')"
+              type="date"
+            />
+          </v-col>
+        </v-row>
       </v-card-text>
 
       <v-divider />
@@ -35,10 +44,14 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
 import { useAppStore } from '../store'
 import api from '../services/api'
 
 export default {
+  components: {
+    ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue'))
+  },
   props: {
     proof: {
       type: Object,
@@ -48,30 +61,32 @@ export default {
   emits: ['update', 'close'],
   data() {
     return {
-      isPublic: false,
+      updateProofForm: {
+        type: null,
+        currency: null,
+        date: null,
+      },
       loading: false
     }
   },
   computed: {
-    proofIsReceipt() {
-      return this.proof.type === 'RECEIPT'
-    },
   },
   mounted() {
-    this.isPublic = this.proof.is_public
+    this.initUpdateProofForm()
   },
   methods: {
+    initUpdateProofForm() {
+      Object.keys(this.updateProofForm).forEach((key) => {
+        this.updateProofForm[key] = this.proof[key]
+      })
+    },
     updateProof() {
-      const params = {
-        is_public: this.isPublic
-      }
-      // update proof
       api
-        .updateProof(this.proof.id, params)
+        .updateProof(this.proof.id, this.updateProofForm)
         .then((response) => {
           // if response.status == 204
           const store = useAppStore()
-          store.updateProof(this.proof.id, params)
+          store.updateProof(this.proof.id, this.updateProofForm)
           this.$emit('update', response.data)
           this.close()
         })

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -2,7 +2,6 @@
   <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof" />
-      <ProofPrivateChip v-if="proofIsPrivateReceipt" class="mr-1" :proof="proof" />
       <LocationChip class="mr-1" :location="proof.location" :locationId="proof.location_id" :readonly="readonly" />
       <ProofDateChip v-if="proof.date" class="mr-1" :proof="proof" />
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()" />
@@ -22,7 +21,6 @@ import { useAppStore } from '../store'
 export default {
   components: {
     ProofTypeChip: defineAsyncComponent(() => import('../components/ProofTypeChip.vue')),
-    ProofPrivateChip: defineAsyncComponent(() => import('../components/ProofPrivateChip.vue')),
     LocationChip: defineAsyncComponent(() => import('../components/LocationChip.vue')),
     PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
     ProofDateChip: defineAsyncComponent(() => import('../components/ProofDateChip.vue')),
@@ -55,9 +53,6 @@ export default {
     proofIsReceipt() {
       return this.proof.type === 'RECEIPT'
     },
-    proofIsPrivateReceipt() {
-      return this.proofIsReceipt && !this.proof.is_public
-    }
   },
   methods: {
     goToProof() {


### PR DESCRIPTION
### What

following #462

- cleanup remainings of "proof private" - #506
- start allowing editing proofs (if 0 prices for now)

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/1165291a-6175-4d9a-b798-3b3a72e4327f)
