### PR TITLE
refactor(proof store): disable proof store because of inconsistencies

### DIFF
--- a/src/components/ProofDeleteConfirmationDialog.vue
+++ b/src/components/ProofDeleteConfirmationDialog.vue
@@ -33,7 +33,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { useAppStore } from '../store'
 import api from '../services/api'
 
 export default {
@@ -63,8 +62,6 @@ export default {
           // if response.status == 204
           this.loading = false
           this.deleteSuccessMessage = true
-          const store = useAppStore()
-          store.removeProof(this.proof.id)
           this.$emit('delete')
           this.closeDialog()
         })

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -45,7 +45,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { useAppStore } from '../store'
 import api from '../services/api'
 
 export default {
@@ -85,8 +84,6 @@ export default {
         .updateProof(this.proof.id, this.updateProofForm)
         .then((response) => {
           // if response.status == 204
-          const store = useAppStore()
-          store.updateProof(this.proof.id, this.updateProofForm)
           this.$emit('update', response.data)
           this.close()
         })

--- a/src/components/ProofInputRow.vue
+++ b/src/components/ProofInputRow.vue
@@ -251,8 +251,6 @@ export default {
           .then((data) => {
             this.loading = false
             if (data.id) {
-              const store = useAppStore()
-              store.addProof(data)
               this.proofForm.proof_id = data.id
               this.proofObject = {...data, ...{location: this.locationObject}}
               this.proofSuccessMessage = true

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -20,12 +20,14 @@
     {{ $t('UserDashboard.LatestProofs') }}
     <v-progress-circular v-if="loading" indeterminate :size="30" />
   </h2>
+
   <v-row>
-    <v-col v-for="proof in appStore.user.proofs" :key="proof" cols="12" sm="6" md="4">
-      <ProofCard :proof="proof" :hideProofHeader="true" :isEditable="true" height="100%" @proofUpdated="handleProofUpdated" />
+    <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="4">
+      <ProofCard :proof="proof" :hideProofHeader="true" height="100%" @proofUpdated="handleProofUpdated" />
     </v-col>
   </v-row>
-  <v-row v-if="appStore.user.proofs.length < appStore.getUserProofTotal" class="mb-2">
+
+  <v-row v-if="userProofList.length < userProofTotal" class="mb-2">
     <v-col align="center">
       <v-btn size="small" :loading="loading" @click="getUserProofs">
         {{ $t('UserDashboard.LoadMore') }}
@@ -54,6 +56,8 @@ export default {
   },
   data() {
     return {
+      userProofList: [],
+      userProofTotal: null,
       userProofPage: 0,
       loading: false,
       proofUpdated: false
@@ -74,9 +78,8 @@ export default {
       this.userProofPage += 1
       return api.getProofs({ owner: this.username, page: this.userProofPage })
         .then((data) => {
-          data.items.forEach(proof => this.appStore.addProof(proof))
-          this.appStore.user.proofs.sort((a, b) => new Date(b.created) - new Date(a.created))
-          this.appStore.setProofTotal(data.total)
+          this.userProofList.push(...data.items)
+          this.userProofTotal = data.total
           this.loading = false
         })
     },


### PR DESCRIPTION
### What

In #378 we started using the store to keep user proofs and avoid fetching them again.

But there regularly some inconsistencies, in particular the proof's `price_count` is important because it currently decides if the proof is editable/deletable.