### PR TITLE
refactor(proof card): if currency missing, show chip with error & tooltip

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -1,7 +1,12 @@
 <template>
-  <v-chip label size="small" density="comfortable">
-    <v-icon start icon="mdi-cash" />
-    {{ proof.currency }}
+  <v-chip label size="small" prepend-icon="mdi-cash" density="comfortable" :color="currencyMissingAndShowError ? 'error' : 'default'">
+    <span v-if="proof.currency">{{ proof.currency }}</span>
+    <span v-else-if="currencyMissingAndShowError">
+      <i class="text-lowercase">{{ $t('Common.Currency') }}</i>
+      <v-tooltip activator="parent" open-on-click location="top">
+        {{ $t('Common.CurrencyMissing') }}
+      </v-tooltip>
+    </span>
   </v-chip>
 </template>
 
@@ -12,6 +17,15 @@ export default {
       type: Object,
       default: null
     },
+    showErrorIfCurrencyMissing: {
+      type: Boolean,
+      default: false
+    }
   },
+  computed: {
+    currencyMissingAndShowError() {
+      return !this.proof.currency && this.showErrorIfCurrencyMissing
+    }
+  }
 }
 </script>

--- a/src/components/ProductBrands.vue
+++ b/src/components/ProductBrands.vue
@@ -16,7 +16,7 @@
     />
   </span>
   <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning" class="mr-1">
-    <i>{{ $t('ProductCard.BrandLower') }}</i>
+    <i class="text-lowercase">{{ $t('Common.Brand') }}</i>
     <v-tooltip activator="parent" open-on-click location="top">
       {{ $t('ProductCard.BrandMissing') }}
     </v-tooltip>

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -3,9 +3,9 @@
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof" />
       <LocationChip class="mr-1" :location="proof.location" :locationId="proof.location_id" :readonly="readonly" />
-      <ProofDateChip v-if="proof.date" class="mr-1" :proof="proof" />
+      <ProofDateChip class="mr-1" :proof="proof" />
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()" />
-      <CurrencyChip v-if="proof.currency" class="mr-1" :proof="proof" />
+      <CurrencyChip class="mr-1" :proof="proof" :showErrorIfCurrencyMissing="true" />
       <RelativeDateTimeChip :dateTime="proof.created" />
     </v-col>
   </v-row>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -109,8 +109,10 @@
 	"Common": {
 		"AddPrice": "Add a price",
 		"AddToOFF": "Add to {name}",
+		"Brand": "Brand",
 		"Country": "Country",
 		"Currency": "Currency",
+		"CurrencyMissing": "Currency missing",
 		"Language": "Languages",
 		"Locations": "Locations",
 		"Date": "Date",


### PR DESCRIPTION
### What

Following #640 we started showing a currency chip in the Proof card footer.

This data is important / mandatory, so show an error if it is missing.

### Screenshot

||Image|
|---|---|
|Before|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/6013077f-8925-4dbb-a412-17de40e9301a)|
|After|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/1d6940e7-9424-4334-b6bc-5e5d081a5030)|
