### PR TITLE
refactor(proof edit): allow editing proof currency. additional cleanup

### DIFF
--- a/src/components/ProofDateCurrencyInputRow.vue
+++ b/src/components/ProofDateCurrencyInputRow.vue
@@ -8,6 +8,7 @@
         v-model="proofDateCurrencyForm.date"
         :label="$t('Common.Date')"
         type="date"
+        :max="currentDate"
         hide-details="auto"
       />
     </v-col>
@@ -40,8 +41,13 @@ export default {
   props: {
     proofDateCurrencyForm: {
       type: Object,
-      default: () => ({ date: utils.currentDate(), currency: null })
+      default: () => ({ date: this.currentDate, currency: null })
     },
+  },
+  data() {
+    return {
+      currentDate: utils.currentDate(),
+    }
   },
   computed: {
     ...mapStores(useAppStore),

--- a/src/components/ProofDateCurrencyInputRow.vue
+++ b/src/components/ProofDateCurrencyInputRow.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-row>
+    <v-col cols="6">
+      <h3 class="mb-1">
+        {{ $t('Common.Date') }}
+      </h3>
+      <v-text-field
+        v-model="proofDateCurrencyForm.date"
+        :label="$t('Common.Date')"
+        type="date"
+        hide-details="auto"
+      />
+    </v-col>
+    <v-col cols="6">
+      <h3 class="mb-1">
+        {{ $t('Common.Currency') }}
+        <span class="text-caption font-weight-regular">
+          <a href="#">{{ $t('Common.Help') }}</a>
+          <v-tooltip activator="parent" open-on-click location="top">
+            {{ $t('ChangeCurrencyDialog.AddCurrencies') }}
+          </v-tooltip>
+        </span>
+      </h3>
+      <v-select
+        v-model="proofDateCurrencyForm.currency"
+        :label="$t('Common.Currency')"
+        :items="userFavoriteCurrencies"
+        hide-details="auto"
+      />
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import utils from '../utils.js'
+
+export default {
+  props: {
+    proofDateCurrencyForm: {
+      type: Object,
+      default: () => ({ date: utils.currentDate(), currency: null })
+    },
+  },
+  computed: {
+    ...mapStores(useAppStore),
+    proofDateCurrencyFormFilled() {
+      let keys = ['date', 'currency']
+      return Object.keys(this.proofDateCurrencyForm).filter(k => keys.includes(k)).every(k => !!this.proofDateCurrencyForm[k])
+    },
+    userFavoriteCurrencies() {
+      return this.appStore.getUserFavoriteCurrencies
+    }
+  }
+}
+</script>

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -14,18 +14,7 @@
       <v-divider />
 
       <v-card-text>
-        <h3 class="mb-1">
-          {{ $t('Common.Date') }}
-        </h3>
-        <v-row>
-          <v-col cols="12" sm="6">
-            <v-text-field
-              v-model="updateProofForm.date"
-              :label="$t('Common.Date')"
-              type="date"
-            />
-          </v-col>
-        </v-row>
+        <ProofDateCurrencyInputRow :proofDateCurrencyForm="updateProofForm" />
       </v-card-text>
 
       <v-divider />
@@ -33,6 +22,7 @@
       <v-card-actions>
         <v-btn
           elevation="1"
+          :disabled="!formFilled"
           :loading="loading"
           @click="updateProof"
         >
@@ -49,7 +39,8 @@ import api from '../services/api'
 
 export default {
   components: {
-    ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue'))
+    ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
+    ProofDateCurrencyInputRow: defineAsyncComponent(() => import('../components/ProofDateCurrencyInputRow.vue')),
   },
   props: {
     proof: {
@@ -62,13 +53,16 @@ export default {
     return {
       updateProofForm: {
         type: null,
-        currency: null,
         date: null,
+        currency: null,
       },
       loading: false
     }
   },
   computed: {
+    formFilled() {
+      return Object.values(this.updateProofForm).every(x => !!x)
+    }
   },
   mounted() {
     this.initUpdateProofForm()

--- a/src/components/ProofFooter.vue
+++ b/src/components/ProofFooter.vue
@@ -10,7 +10,7 @@
     </v-col>
   </v-row>
 
-  <ProofActionMenuButton v-if="!readonly && !hideProofActions && userIsProofOwner" :proof="proof" />
+  <ProofActionMenuButton v-if="!hideProofActions && userIsProofOwner" :proof="proof" />
 </template>
 
 <script>

--- a/src/components/ProofInputRow.vue
+++ b/src/components/ProofInputRow.vue
@@ -55,36 +55,7 @@
       <LocationInputRow :locationForm="proofForm" @location="locationObject = $event" />
 
       <!-- proof date & currency -->
-      <v-row>
-        <v-col cols="6">
-          <h3 class="mb-1">
-            {{ $t('Common.Date') }}
-          </h3>
-          <v-text-field
-            v-model="proofForm.date"
-            :label="$t('Common.Date')"
-            type="date"
-            hide-details="auto"
-          />
-        </v-col>
-        <v-col cols="6">
-          <h3 class="mb-1">
-            {{ $t('Common.Currency') }}
-            <span class="text-caption font-weight-regular">
-              <a href="#">{{ $t('Common.Help') }}</a>
-              <v-tooltip activator="parent" open-on-click location="top">
-                {{ $t('ChangeCurrencyDialog.AddCurrencies') }}
-              </v-tooltip>
-            </span>
-          </h3>
-          <v-select
-            v-model="proofForm.currency"
-            :label="$t('Common.Currency')"
-            :items="userFavoriteCurrencies"
-            hide-details="auto"
-          />
-        </v-col>
-      </v-row>
+      <ProofDateCurrencyInputRow :proofDateCurrencyForm="proofForm" />
 
       <!-- proof upload button -->
       <v-row v-if="proofFormImage">
@@ -129,8 +100,6 @@
 import Compressor from 'compressorjs'
 import ExifReader from 'exifreader'
 import { defineAsyncComponent } from 'vue'
-import { mapStores } from 'pinia'
-import { useAppStore } from '../store'
 import api from '../services/api'
 import utils from '../utils.js'
 
@@ -145,6 +114,7 @@ Compressor.setDefaults({
 export default {
   components: {
     UserRecentProofsDialog: defineAsyncComponent(() => import('../components/UserRecentProofsDialog.vue')),
+    ProofDateCurrencyInputRow: defineAsyncComponent(() => import('../components/ProofDateCurrencyInputRow.vue')),
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
     LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
   },
@@ -177,7 +147,6 @@ export default {
     }
   },
   computed: {
-    ...mapStores(useAppStore),
     proofDateCurrencyFormFilled() {
       let keys = ['date', 'currency']
       return Object.keys(this.proofForm).filter(k => keys.includes(k)).every(k => !!this.proofForm[k])
@@ -185,9 +154,6 @@ export default {
     proofFormFilled() {
       return !!this.proofFormImage && this.proofDateCurrencyFormFilled
     },
-    userFavoriteCurrencies() {
-      return this.appStore.getUserFavoriteCurrencies
-    }
   },
   watch: {
     proofObject(newProofObject, oldProofObject) {  // eslint-disable-line no-unused-vars


### PR DESCRIPTION
### What

Following #652

- allow owners to edit their proof's currency
- new `ProofDateCurrencyInputRow` component for reuse between `ProofInputRow` & `ProofEditDialog`
- proof detail page: allow editing