### PR TITLE
fix(proof card): fill in location data from price if missing from proof

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -132,6 +132,12 @@ export default {
   },
   mounted() {
     this.getPriceProductTitle()
+    // hack: add price.location object to price.proof if missing
+    if (this.price && this.price.location && this.price.proof && !this.price.proof.location) {
+      if (this.price.location_id === this.price.proof.location_id) {
+        this.price.proof.location = this.price.location
+      }
+    }
   },
   methods: {
     getPriceProductTitle() {


### PR DESCRIPTION
### What

Solves a specific case where, when fetching price data, we have their proofs but not their proof's locations.
So when displaying the proof dialog, it showed only the proof's location_id instead of the text.

Found a hack to display it.

Long-term solution : return the proof location object as well ? adds a SQL join...

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/f5ec47da-7bef-4871-ac61-9598bdfccb4c)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/d2ef3d13-e43d-40d4-8967-a6db52ef2c1f)|
