### PR TITLE
refactor(price add): reorganise a bit the price add workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,5 @@
 name: Run release-please
+
 on:
   push:
     branches:

--- a/src/components/ProofInputRow.vue
+++ b/src/components/ProofInputRow.vue
@@ -18,7 +18,10 @@
             <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.Gallery') }}</span>
             <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectFromGallery') }}</span>
           </v-btn>
-          <v-btn v-if="!hideRecentProofChoice" class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" @click="userRecentProofsDialog = true">
+          <v-btn
+            v-if="!hideRecentProofChoice" class="mb-2" size="small" prepend-icon="mdi-receipt-text-clock" :loading="loading"
+            :disabled="loading" @click="userRecentProofsDialog = true"
+          >
             <span class="d-sm-none">{{ $t('AddPriceSingle.PriceDetails.RecentProof') }}</span>
             <span class="d-none d-sm-inline-flex">{{ $t('AddPriceSingle.PriceDetails.SelectRecentProof') }}</span>
           </v-btn>
@@ -58,9 +61,9 @@
       <ProofDateCurrencyInputRow :proofDateCurrencyForm="proofForm" />
 
       <!-- proof upload button -->
-      <v-row v-if="proofFormImage">
+      <v-row>
         <v-col>
-          <v-btn color="success" :loading="loading" :disabled="!proofFormFilled" @click="uploadProof">
+          <v-btn color="success" :loading="loading" :disabled="!proofFormFilled || loading" @click="uploadProof">
             {{ $t('Common.Upload') }}
           </v-btn>
         </v-col>

--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -9,7 +9,7 @@
 
       <v-card-text>
         <v-row>
-          <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="3">
+          <v-col v-for="proof in userProofList" :key="proof" cols="12" md="6" lg="4">
             <ProofCard :proof="proof" :hideProofHeader="true" :hideProofActions="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof" />
           </v-col>
         </v-row>

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -23,11 +23,11 @@
       </v-card>
     </v-col>
 
-    <!-- Step 2a: product prices already uploaded -->
-    <v-col cols="12" md="6">
+    <v-col v-if="proofFormFilled" cols="12" md="6">
+      <!-- Step 2a: product prices already uploaded -->
       <v-card
+        class="mb-4"
         prepend-icon="mdi-tag-check-outline"
-        height="100%"
         style="border: 1px solid #4CAF50"
       >
         <template #title>
@@ -50,12 +50,10 @@
         </v-card-text>
         <v-overlay v-model="disablePriceAlreadyUploadedCard" scrim="#E8F5E9" contained persistent />
       </v-card>
-    </v-col>
 
-    <!-- Step 2b: new product price form -->
-    <v-col cols="12" md="6">
+      <!-- Step 2b: new product price form -->
       <v-btn
-        v-if="!Object.keys(productPriceForm).length && !productPriceUploadedList.length"
+        v-if="!Object.keys(productPriceForm).length"
         class="mr-2"
         prepend-icon="mdi-plus"
         color="primary"
@@ -69,7 +67,6 @@
         <v-card
           :title="$t('AddPriceMultiple.ProductPriceDetails.NewPrice')"
           prepend-icon="mdi-tag-outline"
-          append-icon="mdi-delete"
           height="100%"
           style="border: 1px solid transparent"
         >
@@ -107,12 +104,12 @@
     </v-col>
   </v-row>
 
-  <v-row>
+  <v-row v-if="productPriceUploadedList.length">
     <v-col>
       <v-btn
         type="submit"
         :loading="createPriceLoading"
-        :disabled="!proofFormFilled || !productPriceUploadedList.length"
+        :disabled="productPriceFormFilled"
         @click="done"
       >
         {{ $t('AddPriceMultiple.Done') }}


### PR DESCRIPTION
### What

- responsive : columns & blocks
- hide some buttons until they are useful

### Screenshots

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/ce31d3a8-efb7-45bc-97a2-c81883f7a9ce)|![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/6c072ba5-90f8-4af3-aac6-c8d211a33361)|