### PR TITLE
feat(proof edit): allow editing a proof type

### DIFF
--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -14,21 +14,7 @@
       <v-divider />
 
       <v-card-text>
-        <v-row>
-          <v-col cols="6">
-            <h3 class="mb-1">
-              {{ $t('Common.Type') }}
-            </h3>
-            <v-item-group v-model="updateProofForm.type" class="d-inline" mandatory>
-              <v-item v-for="pt in proofTypeList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
-                <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
-                  <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                  {{ $t('ProofCard.' + pt.value) }}
-                </v-chip>
-              </v-item>
-            </v-item-group>
-          </v-col>
-        </v-row>
+        <ProofTypeInputRow :proofTypeForm="updateProofForm" />
         <ProofDateCurrencyInputRow :proofDateCurrencyForm="updateProofForm" />
       </v-card-text>
 
@@ -51,11 +37,11 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import api from '../services/api'
-import constants from '../constants'
 
 export default {
   components: {
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
+    ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
     ProofDateCurrencyInputRow: defineAsyncComponent(() => import('../components/ProofDateCurrencyInputRow.vue')),
   },
   props: {
@@ -72,7 +58,6 @@ export default {
         date: null,
         currency: null,
       },
-      proofTypeList: constants.PROOF_TYPE_LIST,
       loading: false
     }
   },

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -14,6 +14,21 @@
       <v-divider />
 
       <v-card-text>
+        <v-row>
+          <v-col cols="6">
+            <h3 class="mb-1">
+              {{ $t('Common.Type') }}
+            </h3>
+            <v-item-group v-model="updateProofForm.type" class="d-inline" mandatory>
+              <v-item v-for="pt in proofTypeList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
+                <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
+                  <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
+                  {{ $t('ProofCard.' + pt.value) }}
+                </v-chip>
+              </v-item>
+            </v-item-group>
+          </v-col>
+        </v-row>
         <ProofDateCurrencyInputRow :proofDateCurrencyForm="updateProofForm" />
       </v-card-text>
 
@@ -36,6 +51,7 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import api from '../services/api'
+import constants from '../constants'
 
 export default {
   components: {
@@ -56,13 +72,14 @@ export default {
         date: null,
         currency: null,
       },
+      proofTypeList: constants.PROOF_TYPE_LIST,
       loading: false
     }
   },
   computed: {
     formFilled() {
       return Object.values(this.updateProofForm).every(x => !!x)
-    }
+    },
   },
   mounted() {
     this.initUpdateProofForm()

--- a/src/components/ProofTypeInputRow.vue
+++ b/src/components/ProofTypeInputRow.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-row>
+    <v-col cols="12">
+      <h3 class="mb-1">
+        {{ $t('Common.Type') }}
+      </h3>
+      <v-item-group v-model="proofTypeForm.type" class="d-inline" mandatory>
+        <v-item v-for="pt in proofTypeList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
+          <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
+            <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
+            {{ $t('ProofCard.' + pt.value) }}
+          </v-chip>
+        </v-item>
+      </v-item-group>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import constants from '../constants'
+
+export default {
+  props: {
+    proofTypeForm: {
+      type: Object,
+      default: () => ({ type: null })
+    },
+  },
+  data() {
+    return {
+      proofTypeList: constants.PROOF_TYPE_LIST,
+    }
+  }
+}
+</script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,10 @@ export default {
     { key: 'opf', value: OPF_NAME, icon: OPF_ICON },
     { key: 'opff', value: OPFF_NAME, icon: OPFF_ICON },
   ],
+  PROOF_TYPE_LIST: [
+    {key: 'PRICE_TAG', value: 'PRICE_TAG', icon: 'mdi-library-shelves'},
+    {key: 'RECEIPT', value: 'RECEIPT', icon: 'mdi-receipt-text-outline'}
+  ],
   QUERY_PARAM: 'q',
   FILTER_PARAM: 'filter',
   PRODUCT_FILTER_LIST: [

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -18,14 +18,7 @@
           </template>
           <v-divider />
           <v-card-text>
-            <v-item-group v-model="addProofSingleForm.type" class="d-inline" mandatory>
-              <v-item v-for="pt in proofTypeList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
-                <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
-                  <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                  {{ pt.value }}
-                </v-chip>
-              </v-item>
-            </v-item-group>
+            <ProofTypeInputRow :proofTypeForm="addProofSingleForm" />
           </v-card-text>
           <v-overlay v-model="disableProofTypeForm" scrim="#E8F5E9" contained persistent />
         </v-card>
@@ -120,14 +113,11 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
     ProofInputRow: defineAsyncComponent(() => import('../components/ProofInputRow.vue')),
   },
   data() {
     return {
-      proofTypeList: [
-        {key: 'PRICE_TAG', value: this.$t('AddPriceHome.MultipleProductMode.Title'), icon: 'mdi-library-shelves'},
-        {key: 'RECEIPT', value: this.$t('AddPriceHome.ReceiptMode.Title'), icon: 'mdi-receipt-text-outline'}
-      ],
       addProofSingleForm: {
         type: 'PRICE_TAG',
         proof_id: null,


### PR DESCRIPTION
### What

Allow editing the proof type (note : edit still only allowed for proofs without prices)
New `ProofTypeInputRow` component

### Screenshot

![image](https://github.com/openfoodfacts/open-prices-frontend/assets/7147385/224d1e4c-a8a9-4c6f-baf7-78dc44b577c3)
