### PR TITLE
refactor(Price card): move price date to footer

### DIFF
--- a/src/components/DateChip.vue
+++ b/src/components/DateChip.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chip label size="small" prepend-icon="mdi-calendar-today" density="comfortable" :color="dateMissingAndShowError ? 'error' : 'default'">
+  <v-chip label size="small" prepend-icon="mdi-calendar-today" density="comfortable" :color="dateMissingAndShowError ? 'error' : 'default'" @click="goToDate()">
     <span v-if="date">{{ getDateFormatted(date) }}</span>
     <span v-else-if="dateMissingAndShowError">
       <i class="text-lowercase">{{ $t('Common.Date') }}</i>
@@ -22,7 +22,11 @@ export default {
     showErrorIfDateMissing: {
       type: Boolean,
       default: false
-    }
+    },
+    readonly: {
+      type: Boolean,
+      default: false
+    },
   },
   computed: {
     dateMissingAndShowError() {
@@ -32,6 +36,12 @@ export default {
   methods: {
     getDateFormatted(dateString) {
       return utils.prettyDate(dateString)
+    },
+    goToDate() {
+      if (this.readonly || !this.date) {
+        return
+      }
+      this.$router.push({ path: `/dates/${this.date}` })
     },
   }
 }

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -28,7 +28,7 @@
         </v-col>
       </v-row>
 
-      <PricePriceRow v-if="price" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" :hidePriceDate="hidePriceDate" />
+      <PricePriceRow v-if="price" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" />
 
       <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceLocation="hidePriceLocation" :hidePriceProof="hidePriceProof" :readonly="readonly" />
     </v-container>
@@ -70,10 +70,6 @@ export default {
       default: false
     },
     hideProductDetails: {
-      type: Boolean,
-      default: false
-    },
-    hidePriceDate: {
       type: Boolean,
       default: false
     },

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -2,16 +2,16 @@
   <v-card :id="'price_' + price.id" data-name="price-card">
     <v-container class="pa-2">
       <v-row>
-        <v-col v-if="!hideProductImage" style="max-width:15%">
-          <v-img v-if="product && product.image_url" :src="product.image_url" style="max-height:50px;width:50px" @click="goToProduct()" />
+        <v-col v-if="!hideProductImage" class="pr-2" style="max-width:20%;">
+          <v-img v-if="product && product.image_url" :src="product.image_url" style="max-height:100px;" @click="goToProduct()" />
           <v-img v-else :src="productImageDefault" style="height:50px;width:50px;filter:invert(.9);" />
         </v-col>
-        <v-col :style="hideProductImage ? '' : 'max-width:85%'">
+        <v-col :style="hideProductImage ? '' : 'max-width:80%'">
           <h3 v-if="!hideProductTitle" @click="goToProduct()">
             {{ productTitle }}
           </h3>
 
-          <p v-if="!hideProductDetails" class="mb-2">
+          <p v-if="!hideProductDetails">
             <span v-if="hasProduct">
               <PriceCountChip :count="product.price_count" @click="goToProduct()" />
               <span v-if="hasProductSource">
@@ -25,10 +25,10 @@
               <PriceLabels v-if="hasPriceLabels" class="mr-1" :priceLabels="price.labels_tags" />
             </span>
           </p>
+
+          <PricePriceRow v-if="price" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" />
         </v-col>
       </v-row>
-
-      <PricePriceRow v-if="price" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" />
 
       <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceLocation="hidePriceLocation" :hidePriceProof="hidePriceProof" :readonly="readonly" />
     </v-container>

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -2,7 +2,7 @@
   <v-card :id="'price_' + price.id" data-name="price-card">
     <v-container class="pa-2">
       <v-row>
-        <v-col v-if="!hideProductImage" class="pr-2" style="max-width:20%;">
+        <v-col v-if="!hideProductImage" class="pr-0" style="max-width:20%;">
           <v-img v-if="product && product.image_url" :src="product.image_url" style="max-height:100px;" @click="goToProduct()" />
           <v-img v-else :src="productImageDefault" style="height:50px;width:50px;filter:invert(.9);" />
         </v-col>

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -3,8 +3,9 @@
     <v-col :cols="userIsPriceOwner ? '11' : '12'">
       <LocationChip v-if="!hidePriceLocation" class="mr-1" :location="price.location" :locationId="price.location_id" :readonly="readonly" />
       <UserChip class="mr-1" :username="price.owner" :readonly="readonly" />
-      <RelativeDateTimeChip class="mr-1" :dateTime="price.created" />
-      <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
+      <DateChip class="mr-1" :date="price.date" :readonly="readonly" />
+      <ProofChip v-if="price.proof && !hidePriceProof" class="mr-1" :proof="price.proof" />
+      <RelativeDateTimeChip :dateTime="price.created" />
     </v-col>
   </v-row>
 
@@ -20,8 +21,9 @@ export default {
   components: {
     LocationChip: defineAsyncComponent(() => import('../components/LocationChip.vue')),
     UserChip: defineAsyncComponent(() => import('../components/UserChip.vue')),
-    RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
+    DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
     ProofChip: defineAsyncComponent(() => import('../components/ProofChip.vue')),
+    RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
     PriceActionMenuButton: defineAsyncComponent(() => import('../components/PriceActionMenuButton.vue')),
   },
   props: {

--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -9,11 +9,6 @@
           <v-tooltip v-if="priceWithoutDiscountValue" activator="parent" open-on-click location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(priceWithoutDiscountValue) }}</v-tooltip>
         </v-chip>
       </span>
-      <i18n-t v-if="!hidePriceDate" keypath="PriceCard.PriceDate" tag="span">
-        <template #date>
-          <i>{{ getDateFormatted(price.date) }}</i>
-        </template>
-      </i18n-t>
     </v-col>
   </v-row>
 </template>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -2,11 +2,11 @@
   <v-card data-name="product-card">
     <v-container class="pa-2">
       <v-row v-if="product">
-        <v-col style="max-width:25%">
-          <v-img v-if="product.image_url" :src="product.image_url" style="max-height:100px;width:100px" @click="goToProduct()" />
+        <v-col class="pr-0" style="max-width:20%">
+          <v-img v-if="product.image_url" :src="product.image_url" style="max-height:100px;" @click="goToProduct()" />
           <v-img v-if="!product.image_url" :src="productImageDefault" style="height:100px;width:100px;filter:invert(.9);" />
         </v-col>
-        <v-col style="max-width:75%">
+        <v-col style="max-width:80%">
           <h3 id="product-title" @click="goToProduct()">
             {{ getProductTitle() }}
           </h3>

--- a/src/components/ProofChip.vue
+++ b/src/components/ProofChip.vue
@@ -8,11 +8,10 @@
     @click="openDialog"
   >
     <v-icon icon="mdi-image" />
+    <v-dialog v-model="dialog" scrollable max-height="80%" width="80%">
+      <ProofCard :proof="proof" :hideProofActions="true" @close="closeDialog" />
+    </v-dialog>
   </v-chip>
-
-  <v-dialog v-model="dialog" scrollable max-height="80%" width="80%">
-    <ProofCard :proof="proof" :hideProofActions="true" @close="closeDialog" />
-  </v-dialog>
 </template>
 
 <script>

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -44,7 +44,7 @@
         <v-card-text>
           <v-row>
             <v-col v-for="productPriceUploaded in productPriceUploadedList" :key="productPriceUploaded" cols="12">
-              <PriceCard :price="productPriceUploaded" :product="productPriceUploaded.product" :hidePriceDate="true" :hidePriceFooterRow="true" :readonly="true" />
+              <PriceCard :price="productPriceUploaded" :product="productPriceUploaded.product" :hidePriceFooterRow="true" :readonly="true" />
             </v-col>
           </v-row>
         </v-card-text>


### PR DESCRIPTION
### What

Changes to the `PriceCard`, following the new `DateDetail` page (#675) and allow users to navigate to the dates/month/years.
- moved the price date to the footer
- link to the date detail when clicking on the date chip
- give a bit more space the product image

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/769ce23f-6bf2-4d1a-ab02-fa957957f930)|![image](https://github.com/user-attachments/assets/99923019-91d8-406d-bf41-25434e25723f)|