### PR TITLE
refactor(Location card): new action menu with OSM link

### DIFF
--- a/src/components/LocationActionMenuButton.vue
+++ b/src/components/LocationActionMenuButton.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-btn :style="style" icon size="small" density="comfortable" variant="text">
+    <v-icon>mdi-dots-vertical</v-icon>
+    <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
+      <v-list>
+        <OpenStreetMapLink :location="location" display="list-item" />
+      </v-list>
+    </v-menu>
+  </v-btn>
+</template>
+
+<script>
+import { defineAsyncComponent } from 'vue'
+
+export default {
+  components: {
+    OpenStreetMapLink: defineAsyncComponent(() => import('../components/OpenStreetMapLink.vue'))
+  },
+  props: {
+    location: {
+      type: Object,
+      default: null
+    },
+    style: {
+      type: String,
+      default: 'position:absolute;bottom:6px;right:0;'
+    }
+  }
+}
+</script>

--- a/src/components/LocationCard.vue
+++ b/src/components/LocationCard.vue
@@ -9,6 +9,7 @@
       <PriceCountChip :count="location.price_count" :withLabel="true" />
       <LocationOSMTagChip :location="location" class="mr-1" />
       <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
+      <LocationActionMenuButton :location="location" />
     </v-card-text>
   </v-card>
 </template>
@@ -24,6 +25,7 @@ export default {
     PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
     LocationOSMTagChip: defineAsyncComponent(() => import('../components/LocationOSMTagChip.vue')),
     LocationOSMIDChip: defineAsyncComponent(() => import('../components/LocationOSMIDChip.vue')),
+    LocationActionMenuButton: defineAsyncComponent(() => import('../components/LocationActionMenuButton.vue')),
   },
   props: {
     location: {

--- a/src/components/OpenStreetMapLink.vue
+++ b/src/components/OpenStreetMapLink.vue
@@ -5,6 +5,9 @@
   <v-btn v-if="display === 'button'" size="small" append-icon="mdi-open-in-new" :href="getLocationOSMUrl" target="_blank">
     {{ OSM_NAME }}
   </v-btn>
+  <v-list-item v-else-if="display === 'list-item'" :slim="true" append-icon="mdi-open-in-new" :href="getLocationOSMUrl" target="_blank">
+    {{ OSM_NAME }}
+  </v-list-item>
 </template>
 
 <script>
@@ -20,7 +23,8 @@ export default {
     },
     display: {
       type: String,
-      default: 'link'
+      default: 'link',
+      examples: ['link', 'button', 'list-item']
     },
   },
   data() {

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -7,7 +7,6 @@
 
   <v-row class="mt-0">
     <v-col v-if="locationFound" cols="12">
-      <OpenStreetMapLink :location="location" display="button" />
       <ShareButton />
     </v-col>
     <v-col v-else cols="12">
@@ -56,7 +55,6 @@ export default {
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
-    OpenStreetMapLink: defineAsyncComponent(() => import('../components/OpenStreetMapLink.vue')),
     ShareButton: defineAsyncComponent(() => import('../components/ShareButton.vue')),
   },
   data() {


### PR DESCRIPTION
### What

Similar to #696

In the Location card (and Location details), move the "OpenStreetMap link" to a new `LocationActionMenuButton`