### PR TITLE
refactor(Proof card): move PriceAdd action to menu

### DIFF
--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -3,6 +3,8 @@
     <v-icon>mdi-dots-vertical</v-icon>
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
+        <PriceAddLink :proofId="proof.id" :proofType="proof.type" display="list-item" :disabled="!userCanAddPrice" />
+        <v-divider />
         <v-list-item :slim="true" prepend-icon="mdi-pencil" :disabled="!userCanEditProof" @click="openEditDialog">
           {{ $t('Common.Edit') }}
         </v-list-item>
@@ -50,6 +52,7 @@ import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    PriceAddLink: defineAsyncComponent(() => import('../components/PriceAddLink.vue')),
     ProofEditDialog: defineAsyncComponent(() => import('../components/ProofEditDialog.vue')),
     ProofDeleteConfirmationDialog: defineAsyncComponent(() => import('../components/ProofDeleteConfirmationDialog.vue'))
   },
@@ -73,6 +76,9 @@ export default {
     }
   },
   computed: {
+    userCanAddPrice() {
+      return this.proof && (this.proof.type === 'PRICE_TAG' || this.proof.type === 'RECEIPT')
+    },
     userCanEditProof() {
       // user must be proof owner
       // and proof must not have any prices

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -8,12 +8,6 @@
     </v-col>
   </v-row>
 
-  <v-row v-if="allowPriceAdd" class="mt-0">
-    <v-col cols="12">
-      <PriceAddLink class="mr-2" :proofId="proof.id" :proofType="proof.type" />
-    </v-col>
-  </v-row>
-
   <br>
 
   <h2 v-if="proof" class="text-h6 mb-1">
@@ -42,7 +36,6 @@ import api from '../services/api'
 
 export default {
   components: {
-    PriceAddLink: defineAsyncComponent(() => import('../components/PriceAddLink.vue')),
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
   },
@@ -54,11 +47,6 @@ export default {
       proofPriceTotal: null,
       proofPricePage: 0,
       loading: false,
-    }
-  },
-  computed: {
-    allowPriceAdd() {
-      return this.proof && (this.proof.type === 'PRICE_TAG' || this.proof.type === 'RECEIPT')
     }
   },
   mounted() {


### PR DESCRIPTION
### What

Similar to #700

Move the PriceAdd button inside the `ProofActionMenuButton`

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/8deb7aa7-96c0-4f41-9927-6c33dd02a331)|![image](https://github.com/user-attachments/assets/25f0e02c-8f2b-41d1-bc7f-1175db83164f)|