### PR TITLE
refactor(Product card): move Share action to menu

### DIFF
--- a/src/components/ProductActionMenuButton.vue
+++ b/src/components/ProductActionMenuButton.vue
@@ -4,6 +4,7 @@
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
         <PriceAddLink :productCode="product.code" display="list-item" />
+        <ShareLink :overrideUrl="'/products/' + product.code" display="list-item" />
         <v-divider />
         <OpenFoodFactsLink :source="product.source" facet="product" :value="product.code" display="list-item" />
       </v-list>
@@ -17,6 +18,7 @@ import { defineAsyncComponent } from 'vue'
 export default {
   components: {
     PriceAddLink: defineAsyncComponent(() => import('../components/PriceAddLink.vue')),
+    ShareLink: defineAsyncComponent(() => import('../components/ShareLink.vue')),
     OpenFoodFactsLink: defineAsyncComponent(() => import('../components/OpenFoodFactsLink.vue'))
   },
   props: {

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -23,14 +23,11 @@
     </v-col>
   </v-row>
 
-  <v-row v-if="!productOrCategoryNotFound" class="mt-0">
+  <v-row v-if="productIsCategory" class="mt-0">
     <v-col cols="12">
-      <PriceAddLink v-if="category" class="mr-2" :productCode="category.name" />
-      <ShareLink display="button" />
+      <PriceAddLink class="mr-2" :productCode="category.name" />
     </v-col>
   </v-row>
-
-  <br>
 
   <v-row>
     <v-col>
@@ -89,7 +86,6 @@ export default {
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
     LeafletMap: defineAsyncComponent(() => import('../components/LeafletMap.vue')),
     OpenFoodFactsAddMenu: defineAsyncComponent(() => import('../components/OpenFoodFactsAddMenu.vue')),
-    ShareLink: defineAsyncComponent(() => import('../components/ShareLink.vue'))
   },
   data() {
     return {


### PR DESCRIPTION
### What

Following #698 

Move the `ShareLink` button to the `ProductActionMenuButton`

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/2d9b7e2e-24dc-4703-943c-cfb18326c0f6)|![image](https://github.com/user-attachments/assets/898a1aea-c7cf-4a3e-9e15-53cbc10e6ef4)|