### PR TITLE
refactor(Location card): move Share action to menu

### DIFF
--- a/src/components/LocationActionMenuButton.vue
+++ b/src/components/LocationActionMenuButton.vue
@@ -3,6 +3,8 @@
     <v-icon>mdi-dots-vertical</v-icon>
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
+        <ShareLink :overrideUrl="'/locations/' + location.id" display="list-item" />
+        <v-divider />
         <OpenStreetMapLink :location="location" display="list-item" />
       </v-list>
     </v-menu>
@@ -14,6 +16,7 @@ import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    ShareLink: defineAsyncComponent(() => import('../components/ShareLink.vue')),
     OpenStreetMapLink: defineAsyncComponent(() => import('../components/OpenStreetMapLink.vue'))
   },
   props: {

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -5,18 +5,13 @@
     </v-col>
   </v-row>
 
-  <v-row class="mt-0">
-    <v-col v-if="locationFound" cols="12">
-      <ShareLink display="button" />
-    </v-col>
-    <v-col v-else cols="12">
+  <v-row v-if="!locationFound" class="mt-0">
+    <v-col cols="12">
       <v-alert v-if="!loading" type="error" variant="outlined" icon="mdi-alert">
         <i>{{ $t('LocationDetail.LocationNotFound') }}</i>
       </v-alert>
     </v-col>
   </v-row>
-
-  <br>
 
   <v-row>
     <v-col>
@@ -55,7 +50,6 @@ export default {
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
-    ShareLink: defineAsyncComponent(() => import('../components/ShareLink.vue')),
   },
   data() {
     return {


### PR DESCRIPTION
### What

Similar to #704 

Move the `ShareLink` button to the `LocationActionMenuButton` (created in #697)