### PR TITLE
refactor(User card): move Share action to menu

### DIFF
--- a/src/components/UserActionMenuButton.vue
+++ b/src/components/UserActionMenuButton.vue
@@ -3,6 +3,8 @@
     <v-icon>mdi-dots-vertical</v-icon>
     <v-menu activator="parent" scroll-strategy="close" transition="slide-y-transition">
       <v-list>
+        <ShareLink :overrideUrl="'/users/' + user.user_id" display="list-item" />
+        <v-divider />
         <OpenFoodFactsLink facet="editor" :value="user.user_id" display="list-item" />
       </v-list>
     </v-menu>
@@ -14,6 +16,7 @@ import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    ShareLink: defineAsyncComponent(() => import('../components/ShareLink.vue')),
     OpenFoodFactsLink: defineAsyncComponent(() => import('../components/OpenFoodFactsLink.vue'))
   },
   props: {

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -5,14 +5,6 @@
     </v-col>
   </v-row>
 
-  <v-row class="mt-0">
-    <v-col cols="12">
-      <ShareLink display="button" />
-    </v-col>
-  </v-row>
-
-  <br>
-
   <v-row>
     <v-col>
       <h2 class="text-h6 d-inline mr-2">
@@ -51,8 +43,7 @@ export default {
     UserCard: defineAsyncComponent(() => import('../components/UserCard.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
-    PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
-    ShareLink: defineAsyncComponent(() => import('../components/ShareLink.vue'))
+    PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue'))
   },
   data() {
     return {


### PR DESCRIPTION
### What

Similar to #704 

Move the `ShareLink` button to the `UserActionMenuButton` (created in #696)