### PR TITLE
refactor(proofs): add a Proof Action to the details page

### DIFF
--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -5,6 +5,9 @@
       <v-list>
         <PriceAddLink :proofId="proof.id" :proofType="proof.type" display="list-item" :disabled="!userCanAddPrice" />
         <v-divider />
+        <v-list-item :slim="true" prepend-icon="mdi-eye-outline" :to="getProofDetailUrl">
+          {{ $t('Common.Details') }}
+        </v-list-item>
         <v-list-item :slim="true" prepend-icon="mdi-pencil" :disabled="!userCanEditProof" @click="openEditDialog">
           {{ $t('Common.Edit') }}
         </v-list-item>
@@ -76,6 +79,9 @@ export default {
     }
   },
   computed: {
+    getProofDetailUrl() {
+      return `/proofs/${this.proof.id}`
+    },
     userCanAddPrice() {
       return this.proof && (this.proof.type === 'PRICE_TAG' || this.proof.type === 'RECEIPT')
     },


### PR DESCRIPTION
### What

- similar to #797 (for Price), we add a "Details" action in the `ProofActionMenu`
- we also add a "PROOF" title

### Screenshot

![image](https://github.com/user-attachments/assets/41cbab83-f9d1-43ee-a0ff-d4c5b72cd8ca)

