### PR TITLE
feat(users): show location, product & proof counts

### DIFF
--- a/src/components/PriceCountChip.vue
+++ b/src/components/PriceCountChip.vue
@@ -1,7 +1,7 @@
 <template>
   <v-chip label size="small" density="comfortable" :color="getColor()" class="mr-1">
     <v-icon start icon="mdi-tag-outline" />
-    <span v-if="withLabel" id="price-count">{{ $t('PriceCountChip.PriceCount', { count: count }) }}</span>
+    <span v-if="withLabel" id="price-count">{{ $t('Common.PriceCount', { count: count }) }}</span>
     <span v-else id="price-count">{{ count }}</span>
   </v-chip>
 </template>

--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -7,15 +7,15 @@
   >
     <v-card-text>
       <PriceCountChip :count="user.price_count" :withLabel="true" />
-      <v-chip label size="small" density="comfortable" class="mr-1">
+      <v-chip v-if="user.location_count" label size="small" density="comfortable" class="mr-1">
         <v-icon start icon="mdi-map-marker-outline" />
         <span id="product-count">{{ $t('Common.LocationCount', { count: user.location_count }) }}</span>
       </v-chip>
-      <v-chip label size="small" density="comfortable" class="mr-1">
+      <v-chip v-if="user.product_count" label size="small" density="comfortable" class="mr-1">
         <v-icon start icon="mdi-database-outline" />
         <span id="product-count">{{ $t('Common.ProductCount', { count: user.product_count }) }}</span>
       </v-chip>
-      <v-chip label size="small" density="comfortable">
+      <v-chip v-if="user.proof_count" label size="small" density="comfortable">
         <v-icon start icon="mdi-image" />
         <span id="product-count">{{ $t('Common.ProofCount', { count: user.proof_count }) }}</span>
       </v-chip>

--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -7,6 +7,18 @@
   >
     <v-card-text>
       <PriceCountChip :count="user.price_count" :withLabel="true" />
+      <v-chip label size="small" density="comfortable" class="mr-1">
+        <v-icon start icon="mdi-map-marker-outline" />
+        <span id="product-count">{{ $t('Common.LocationCount', { count: user.location_count }) }}</span>
+      </v-chip>
+      <v-chip label size="small" density="comfortable" class="mr-1">
+        <v-icon start icon="mdi-database-outline" />
+        <span id="product-count">{{ $t('Common.ProductCount', { count: user.product_count }) }}</span>
+      </v-chip>
+      <v-chip label size="small" density="comfortable">
+        <v-icon start icon="mdi-image" />
+        <span id="product-count">{{ $t('Common.ProofCount', { count: user.proof_count }) }}</span>
+      </v-chip>
       <UserActionMenuButton :user="user" />
     </v-card-text>
   </v-card>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -164,6 +164,7 @@
 		"PriceCount": "{count} prices",
 		"PriceCreated": "Price created!",
 		"ProductCount": "{count} products",
+		"ProofCount": "{count} proofs",
 		"SignInOFFAccount": "Sign in with your {url} account",
 		"SignedIn": "Signed in!",
 		"Share": "Share",


### PR DESCRIPTION
### What

Thanks to new fields in the backend - see https://github.com/openfoodfacts/open-prices/issues/419 - we can display the User's location, product & proof counts

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/96732e14-701e-4da7-8e47-b4668591f496)|![image](https://github.com/user-attachments/assets/007f4dd4-7c5f-43a7-8572-328e67bd3e3f) |