### PR TITLE
feat(prices): replace Load More with infinite scroll

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,17 @@ import CountriesWithEmoji from './data/countries-with-emoji.json'
 import constants from './constants'
 
 
+function debounce(callback, wait) {
+  let timeoutId = null;
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback(...args)
+    }, wait)
+  }
+}
+
+
 function isNumber(value) {
   // return /^\d+$/.test(value)
   return !isNaN(parseFloat(value)) && isFinite(value)
@@ -328,6 +339,7 @@ function getMapCenter(results) {
 
 
 export default {
+  debounce,
   isNumber,
   isValidBarcode,
   addObjectToArray,

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,10 @@ function debounce(callback, wait) {
   }
 }
 
+function getDocumentScrollPercentage() {
+  return (document.documentElement.scrollTop + document.body.scrollTop) / (document.documentElement.scrollHeight - document.documentElement.clientHeight) * 100
+}
+
 
 function isNumber(value) {
   // return /^\d+$/.test(value)
@@ -340,6 +344,7 @@ function getMapCenter(results) {
 
 export default {
   debounce,
+  getDocumentScrollPercentage,
   isNumber,
   isValidBarcode,
   addObjectToArray,


### PR DESCRIPTION
### What

Basic custom infinite scroller on the Price list page.
When the page reaches 90%, fetch new data.

### Links used

- debounce : https://stackoverflow.com/a/75988895/4293684
- calculate scroll percentage : https://stackoverflow.com/a/2387222/4293684
- ` v-infinite-scroll`  didn't work for me
- nor ` infinite-scroller` 