### PR TITLE
feat(locations): show user, product & proof counts

### DIFF
--- a/src/components/LocationCard.vue
+++ b/src/components/LocationCard.vue
@@ -8,6 +8,19 @@
   >
     <v-card-text v-if="location">
       <PriceCountChip :count="location.price_count" :withLabel="true" />
+      <v-chip label size="small" density="comfortable" class="mr-1">
+        <v-icon start icon="mdi-account" />
+        <span id="user-count">{{ $t('Common.UserCount', { count: location.user_count }) }}</span>
+      </v-chip>
+      <v-chip label size="small" density="comfortable" class="mr-1">
+        <v-icon start icon="mdi-database-outline" />
+        <span id="product-count">{{ $t('Common.ProductCount', { count: location.product_count }) }}</span>
+      </v-chip>
+      <v-chip label size="small" density="comfortable">
+        <v-icon start icon="mdi-image" />
+        <span id="proof-count">{{ $t('Common.ProofCount', { count: location.proof_count }) }}</span>
+      </v-chip>
+      <br>
       <LocationOSMTagChip class="mr-1" :location="location" />
       <LocationOSMIDChip v-if="showLocationOSMID" class="mr-1" :location="location" />
       <v-chip

--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -9,7 +9,7 @@
       <PriceCountChip :count="user.price_count" :withLabel="true" />
       <v-chip v-if="user.location_count" label size="small" density="comfortable" class="mr-1">
         <v-icon start icon="mdi-map-marker-outline" />
-        <span id="product-count">{{ $t('Common.LocationCount', { count: user.location_count }) }}</span>
+        <span id="location-count">{{ $t('Common.LocationCount', { count: user.location_count }) }}</span>
       </v-chip>
       <v-chip v-if="user.product_count" label size="small" density="comfortable" class="mr-1">
         <v-icon start icon="mdi-database-outline" />
@@ -17,7 +17,7 @@
       </v-chip>
       <v-chip v-if="user.proof_count" label size="small" density="comfortable">
         <v-icon start icon="mdi-image" />
-        <span id="product-count">{{ $t('Common.ProofCount', { count: user.proof_count }) }}</span>
+        <span id="proof-count">{{ $t('Common.ProofCount', { count: user.proof_count }) }}</span>
       </v-chip>
       <UserActionMenuButton :user="user" />
     </v-card-text>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -186,6 +186,7 @@
 		"Upload": "Upload",
 		"User": "User",
 		"Users": "Users",
+		"UserCount": "{count} users",
 		"View": "View",
 		"Yes": "Yes",
 		"No": "No",


### PR DESCRIPTION
### What

Similar to #809
Thanks to new Location fields in the backend (see https://github.com/openfoodfacts/open-prices/issues/420), we can display the Location's user, product & proof counts

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/c4568410-e9bf-47a4-9ffc-f2aaa504ebd0)|![image](https://github.com/user-attachments/assets/10733310-452a-4184-acaf-1f596c8facd0)|