### PR TITLE
feat(locations): new order menu by counts

### DIFF
--- a/src/components/OrderMenu.vue
+++ b/src/components/OrderMenu.vue
@@ -29,7 +29,7 @@ export default {
     kind: {
       type: String,
       default: 'product',
-      examples: ['product', 'price', 'proof', 'user']
+      examples: ['product', 'price', 'proof', 'location', 'user']
     }
   },
   emits: ['update:currentOrder'],
@@ -38,6 +38,7 @@ export default {
       productOrderList: constants.PRODUCT_ORDER_LIST,
       priceOrderList: constants.PRICE_ORDER_LIST,
       proofOrderList: constants.PROOF_ORDER_LIST,
+      locationOrderList: constants.LOCATION_ORDER_LIST,
       userOrderList: constants.USER_ORDER_LIST,
     }
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -71,7 +71,15 @@ export default {
     { key: '-date', value: 'OrderProofDateDESC', icon: 'mdi-calendar-today' },
     { key: '-created', value: 'OrderProofCreatedDESC', icon: 'mdi-clock-outline' },
   ],
+  LOCATION_ORDER_LIST: [
+    // same order as LocationCard chips
+    { key: '-price_count', value: 'OrderPriceCountDESC', icon: 'mdi-tag-multiple-outline' },
+    { key: '-user_count', value: 'OrderUserCountDESC', icon: 'mdi-account' },
+    { key: '-product_count', value: 'OrderProductCountDESC', icon: 'mdi-database-outline' },
+    { key: '-proof_count', value: 'OrderProofCountDESC', icon: 'mdi-image' },
+  ],
   USER_ORDER_LIST: [
+    // same order as UserCard chips
     { key: '-price_count', value: 'OrderPriceCountDESC', icon: 'mdi-tag-multiple-outline' },
     { key: '-location_count', value: 'OrderLocationCountDESC', icon: 'mdi-map-marker-outline' },
     { key: '-product_count', value: 'OrderProductCountDESC', icon: 'mdi-database-outline' },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -173,6 +173,7 @@
 		"OrderProofCountDESC": "Proof count",
 		"OrderProofCreatedDESC": "Addition date",
 		"OrderProofDateDESC": "Proof date",
+		"OrderUserCountDESC": "User count",
 		"PriceCount": "{count} prices",
 		"PriceCreated": "Price created!",
 		"ProductCount": "{count} products",

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -9,6 +9,7 @@
         {{ $t('LocationList.LocationTotal', { count: locationTotal }) }}
       </v-chip>
       <FilterMenu v-if="!loading" kind="location" :currentFilter="currentFilter" @update:currentFilter="toggleLocationFilter($event)" />
+      <OrderMenu kind="location" :currentOrder="currentOrder" @update:currentOrder="selectLocationOrder($event)" />
     </v-col>
   </v-row>
 
@@ -35,6 +36,7 @@ export default {
   components: {
     LocationCard: defineAsyncComponent(() => import('../components/LocationCard.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
+    OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
   },
   data() {
     return {
@@ -45,11 +47,12 @@ export default {
       loading: false,
       // filter & order
       currentFilter: '',
+      currentOrder: constants.LOCATION_ORDER_LIST[0].key,  // price_count
     }
   },
   computed: {
     getLocationsParams() {
-      let defaultParams = { order_by: '-price_count', page: this.locationPage }
+      let defaultParams = { order_by: this.currentOrder, page: this.locationPage }
       if (this.currentFilter && this.currentFilter === 'hide_price_count_gte_1') {
         defaultParams['price_count'] = 0
       }
@@ -94,6 +97,13 @@ export default {
       this.currentFilter = this.currentFilter ? '' : filterKey
       this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.currentFilter } })
       // this.initLocationList() will be called in watch $route
+    },
+    selectLocationOrder(orderKey) {
+      if (this.currentOrder !== orderKey) {
+        this.currentOrder = orderKey
+        this.$router.push({ query: { ...this.$route.query, [constants.ORDER_PARAM]: this.currentOrder } })
+        // this.initLocationList() will be called in watch $route
+      }
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars
       if (utils.getDocumentScrollPercentage() > 90) {

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -40,15 +40,15 @@ export default {
   },
   data() {
     return {
-      // filter & order
-      currentFilter: '',
-      currentSource: '',
-      currentOrder: constants.PRODUCT_ORDER_LIST[0].key,  // price_count
       // data
       productList: [],
       productTotal: null,
       productPage: 0,
       loading: false,
+      // filter & order
+      currentFilter: '',
+      currentSource: '',
+      currentOrder: constants.PRODUCT_ORDER_LIST[0].key,  // price_count
     }
   },
   computed: {


### PR DESCRIPTION
### What

Foliowing #853. Similar to #856

Add the `OrderMenu` with the 4 counts as choices

### Screenshot

![image](https://github.com/user-attachments/assets/36059612-debc-45a2-8c2e-e3948cea17e7)
