### PR TITLE
feat(Home): reorganize home page sections. move buttons to header

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -7,14 +7,21 @@
         {{ APP_NAME }}
       </span>
     </v-app-bar-title>
+    <v-btn v-if="!$vuetify.display.smAndUp" icon="mdi-magnify" to="/search" :aria-label="$t('Common.Search')" />
+    <v-btn v-else prepend-icon="mdi-magnify" to="/search" :aria-label="$t('Common.Search')">
+      {{ $t('Common.Search') }}
+    </v-btn>
+    <v-btn v-if="!$vuetify.display.smAndUp" color="primary" icon="mdi-tag-plus-outline" to="/prices/add" :aria-label="$t('Common.AddPrice')" />
+    <v-btn v-else color="primary" prepend-icon="mdi-tag-plus-outline" to="/prices/add" :aria-label="$t('Common.AddPrice')">
+      {{ $t('Common.AddPrice') }}
+    </v-btn>
     <template v-if="!username" #append>
-      <v-btn v-if="!$vuetify.display.smAndUp" icon="mdi-login" to="/sign-in" :aria-label="$t('Header.SignIn')" />
-      <v-btn v-else prepend-icon="mdi-login" to="/sign-in" :aria-label="$t('Header.SignIn')">
-        {{ $t('Header.SignIn') }}
+      <v-btn v-if="!$vuetify.display.smAndUp" icon="mdi-login" to="/sign-in" :aria-label="$t('Common.SignIn')" />
+      <v-btn v-else prepend-icon="mdi-login" to="/sign-in" :aria-label="$t('Common.SignIn')">
+        {{ $t('Common.SignIn') }}
       </v-btn>
     </template>
     <template v-else #append>
-      <v-btn color="primary" icon="mdi-tag-plus-outline" to="/prices/add" :aria-label="$t('Home.AddPrice')" />
       <v-menu scroll-strategy="close">
         <template #activator="{ props }">
           <v-btn v-if="!$vuetify.display.smAndUp" v-bind="props" icon="mdi-account-circle" />
@@ -27,14 +34,14 @@
             {{ username }}
           </v-list-item>
           <v-divider class="d-sm-none" />
-          <v-list-item :slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard" :aria-label="$t('Header.Dashboard')">
-            {{ $t('Header.Dashboard') }}
+          <v-list-item :slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard" :aria-label="$t('Common.Dashboard')">
+            {{ $t('Common.Dashboard') }}
           </v-list-item>
-          <v-list-item :slim="true" prepend-icon="mdi-cog-outline" to="/settings" :aria-label="$t('Header.Settings')">
-            {{ $t('Header.Settings') }}
+          <v-list-item :slim="true" prepend-icon="mdi-cog-outline" to="/settings" :aria-label="$t('Common.Settings')">
+            {{ $t('Common.Settings') }}
           </v-list-item>
-          <v-list-item :slim="true" prepend-icon="mdi-logout" :aria-label="$t('Header.SignOut')" @click="signOut">
-            {{ $t('Header.SignOut') }}
+          <v-list-item :slim="true" prepend-icon="mdi-logout" :aria-label="$t('Common.SignOut')" @click="signOut">
+            {{ $t('Common.SignOut') }}
           </v-list-item>
         </v-list>
       </v-menu>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -123,6 +123,7 @@
 		"Country": "Country",
 		"Currency": "Currency",
 		"CurrencyMissing": "Currency missing",
+		"Dashboard": "Dashboard",
 		"Display": "Display",
 		"DisplayList": "List",
 		"DisplayPriceList": "List",
@@ -176,12 +177,18 @@
 		"OrderUserCountDESC": "User count",
 		"PriceCount": "{count} prices",
 		"PriceCreated": "Price created!",
+		"PricesMore": "More prices",
 		"ProductCount": "{count} products",
 		"ProofCount": "{count} proofs",
+		"Search": "Search",
+		"Settings": "Settings",
 		"SignInOFFAccount": "Sign in with your {url} account",
 		"SignedIn": "Signed in!",
+		"SignIn": "Sign in",
+		"SignOut": "Sign out",
 		"Share": "Share",
 		"Source": "Source",
+		"Stats": "Stats",
 		"Thanks": "Thanks",
 		"TopContributors": "Top contributors",
 		"TopLocations": "Top locations",
@@ -227,6 +234,7 @@
 		"SettingsUpdated": "Settings updated!",
 		"TodayPriceStat": "No prices added today | {todayPriceNumber} new prices added today | {todayPriceNumber} new prices added today!",
 		"Welcome": {
+			"Generic": "An open crowdsourced database of prices 🏷🍊💲",
 			"Subtitle": "An open crowdsourced database of food prices 🏷🍊💲",
 			"Title": "Welcome to {name}!"
 		}
@@ -418,6 +426,8 @@
 	},
 	"Stats": {
 		"Prices": "Prices",
+		"PricesToday": "Prices added today",
+		"PricesTotal": "Total prices",
 		"ProductsWithPrices": "Products with prices",
 		"Title": "Stats",
 		"Products": "Products",


### PR DESCRIPTION
### What

See issue #843 

Improved Home Page
- show basic stats
- show 5 latest prices + button to see more
- Search & Add actions moved to the header (and they remain available in the top-left menu)

### Todo (here or next PR)

- more stats (locations, users)
- center "Latest prices" button

### Screenshot

||Before|After|
|---|---|---|
|Desktop|![image](https://github.com/user-attachments/assets/e617ca33-9232-45e1-a759-5f719d2ad9e9)|![image](https://github.com/user-attachments/assets/17960847-8030-4c16-ad44-1abcdc7d504f)|
|Mobile|![image](https://github.com/user-attachments/assets/1327ea70-9aa5-4c31-b208-0fe52fd3147f)|![image](https://github.com/user-attachments/assets/31e3a9d2-7583-40b2-8643-a8c7091d83e9)|