### PR TITLE
refactor: show 4 columns on xl screens

### DIFF
--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -17,7 +17,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="product in brandProductList" :key="product" cols="12" sm="6" md="4">
+    <v-col v-for="product in brandProductList" :key="product" cols="12" sm="6" md="4" xl="3">
       <ProductCard :product="product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/CategoryDetail.vue
+++ b/src/views/CategoryDetail.vue
@@ -17,7 +17,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="product in categoryProductList" :key="product" cols="12" sm="6" md="4">
+    <v-col v-for="product in categoryProductList" :key="product" cols="12" sm="6" md="4" xl="3">
       <ProductCard :product="product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/CountryCityDetail.vue
+++ b/src/views/CountryCityDetail.vue
@@ -18,7 +18,7 @@
   <v-window v-model="currentDisplay" disabled>
     <v-window-item value="list">
       <v-row class="mt-0 mb-1">
-        <v-col v-for="location in countryCityLocationList" :key="location" cols="12" sm="6" md="4">
+        <v-col v-for="location in countryCityLocationList" :key="location" cols="12" sm="6" md="4" xl="3">
           <LocationCard :location="location" :hideLocationOSMID="true" :hideCountryCity="true" height="100%" />
         </v-col>
       </v-row>

--- a/src/views/CountryDetail.vue
+++ b/src/views/CountryDetail.vue
@@ -18,7 +18,7 @@
   <v-window v-model="currentDisplay" disabled>
     <v-window-item value="list">
       <v-row class="mt-0 mb-1">
-        <v-col v-for="location in countryLocationList" :key="location" cols="12" sm="6" md="4">
+        <v-col v-for="location in countryLocationList" :key="location" cols="12" sm="6" md="4" xl="3">
           <LocationCard :location="location" :hideLocationOSMID="true" :hideCountryCity="true" height="100%" />
         </v-col>
       </v-row>

--- a/src/views/DateDetail.vue
+++ b/src/views/DateDetail.vue
@@ -16,7 +16,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="price in datePriceList" :key="price" cols="12" sm="6" md="4">
+    <v-col v-for="price in datePriceList" :key="price" cols="12" sm="6" md="4" xl="3">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/LabelDetail.vue
+++ b/src/views/LabelDetail.vue
@@ -17,7 +17,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="product in labelProductList" :key="product" cols="12" sm="6" md="4">
+    <v-col v-for="product in labelProductList" :key="product" cols="12" sm="6" md="4" xl="3">
       <ProductCard :product="product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -25,7 +25,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="price in locationPriceList" :key="price" cols="12" sm="6" md="4">
+    <v-col v-for="price in locationPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
       <PriceCard :price="price" :product="price.product" :hidePriceLocation="true" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -14,7 +14,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="location in locationList" :key="location" cols="12" sm="6" md="4">
+    <v-col v-for="location in locationList" :key="location" cols="12" sm="6" md="4" xl="3">
       <LocationCard :location="location" :hideLocationOSMID="true" :hideCountryCity="true" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -4,7 +4,7 @@
   </h1>
 
   <v-row>
-    <v-col v-for="price in priceList" :key="price" cols="12" sm="6" md="4">
+    <v-col v-for="price in priceList" :key="price" cols="12" sm="6" md="4" xl="3">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -39,7 +39,7 @@
   <v-window v-model="currentDisplay" disabled>
     <v-window-item value="list">
       <v-row class="mt-0 mb-1">
-        <v-col v-for="price in productPriceList" :key="price" cols="12" sm="6" md="4">
+        <v-col v-for="price in productPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
           <PriceCard :price="price" :product="product" :hideProductImage="true" :hideProductTitle="true" :hideProductDetails="productIsCategory ? false : true" elevation="1" height="100%" />
         </v-col>
       </v-row>

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -14,7 +14,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="product in productList" :key="product" cols="12" sm="6" md="4">
+    <v-col v-for="product in productList" :key="product" cols="12" sm="6" md="4" xl="3">
       <ProductCard :product="product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -18,7 +18,7 @@
   </v-row>
 
   <v-row v-if="proof">
-    <v-col v-for="price in proofPriceList" :key="price" cols="12" sm="6" md="4">
+    <v-col v-for="price in proofPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
       <PriceCard :price="price" :product="price.product" :hidePriceProof="true" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -34,7 +34,7 @@
   </p>
 
   <v-row v-if="productTotal > 0" class="mt-0">
-    <v-col v-for="product in productList" :key="product" cols="12" sm="6" md="4">
+    <v-col v-for="product in productList" :key="product" cols="12" sm="6" md="4" xl="3">
       <ProductCard :product="product" :latestPrice="product.latest_price" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -25,7 +25,7 @@
   </v-row>
 
   <v-row>
-    <v-col v-for="price in userPriceList" :key="price" cols="12" sm="6" md="4">
+    <v-col v-for="price in userPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -26,7 +26,7 @@
   </v-row>
 
   <v-row>
-    <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="4">
+    <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="4" xl="3">
       <ProofCard :proof="proof" :hideProofHeader="true" height="100%" @proofUpdated="handleProofUpdated" />
     </v-col>
   </v-row>

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -17,7 +17,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="price in userPriceList" :key="price" cols="12" sm="6" md="4">
+    <v-col v-for="price in userPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
       <PriceCard :price="price" :product="price.product" elevation="1" height="100%" />
     </v-col>
   </v-row>

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -14,7 +14,7 @@
   </v-row>
 
   <v-row class="mt-0">
-    <v-col v-for="user in userList" :key="user" cols="12" sm="6" md="4">
+    <v-col v-for="user in userList" :key="user" cols="12" sm="6" md="4" xl="3">
       <UserCard :user="user" height="100%" />
     </v-col>
   </v-row>


### PR DESCRIPTION
### What

Following a similar change on the Home page - https://github.com/openfoodfacts/open-prices-frontend/commit/c3d04ed4a2ee4489a6972613fbcd8295036ee81c - we generalize the 4 columns on xl screens on every page

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/c990ad65-561e-4b78-9589-e4d3e5f8516c)|![image](https://github.com/user-attachments/assets/59de0450-ba2b-4c30-8dc8-6ea9c5721605)|