### PR TITLE
fix(utils): relative time display

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,7 +126,7 @@ function offDateTime(dateTimeString) {
  * changes: add short (replace 'days' with 'd', remove 'Yesterday') & shortest (remove 'ago'), extend days & weeks
  */
 function prettyRelativeDateTime(dateTimeString, size=null) {
-  var date = new Date((dateTimeString || "")),
+  var date = new Date(dateTimeString || ''),
       diff = (((new Date()).getTime() - date.getTime()) / 1000),
       day_diff = Math.floor(diff / 86400);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,7 +126,7 @@ function offDateTime(dateTimeString) {
  * changes: add short (replace 'days' with 'd', remove 'Yesterday') & shortest (remove 'ago'), extend days & weeks
  */
 function prettyRelativeDateTime(dateTimeString, size=null) {
-  var date = new Date((dateTimeString || "").replace(/-/g, "/").replace(/[TZ]/g, " ")),
+  var date = new Date((dateTimeString || "")),
       diff = (((new Date()).getTime() - date.getTime()) / 1000),
       day_diff = Math.floor(diff / 86400);
 


### PR DESCRIPTION
### What
- Make new price show  "Xs" ago or "Xm" ago instead of "2h" ago

### Screenshot
| Before | After |
| --- | --- | 
|![before](https://github.com/user-attachments/assets/45107a76-2924-4142-9a20-fd2d067856a4)|![after](https://github.com/user-attachments/assets/db8f8e7a-af43-43a1-9a2a-46e0247f510a)|

### Fixes bug(s)
- Fixes #877 

