### PR TITLE
refactor(User Dashboard Lists): properly remove Prices and Proof cards after delete

### DIFF
--- a/src/components/PriceActionMenuButton.vue
+++ b/src/components/PriceActionMenuButton.vue
@@ -48,7 +48,7 @@
     v-if="deleteConfirmationDialog"
     v-model="deleteConfirmationDialog"
     :price="price"
-    @delete="showDeleteSuccessMessage"
+    @delete="handlePriceDelete"
     @close="closeDeleteConfirmationDialog"
   />
 
@@ -98,6 +98,7 @@ export default {
       default: 'position:absolute;bottom:6px;right:0;'
     }
   },
+  emits: ['delete'],
   data() {
     return {
       loading: false,
@@ -149,8 +150,9 @@ export default {
     closeDeleteConfirmationDialog() {
       this.deleteConfirmationDialog = false
     },
-    showDeleteSuccessMessage() {
+    handlePriceDelete() {
       this.deleteSuccessMessage = true
+      this.$emit("delete")
     }
   }
 }

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -32,7 +32,7 @@
         </v-col>
       </v-row>
 
-      <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceProof="hidePriceProof" :hidePriceCreated="hidePriceCreated" :hideProductDetails="hideProductDetails" :readonly="readonly" />
+      <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceProof="hidePriceProof" :hidePriceCreated="hidePriceCreated" :hideProductDetails="hideProductDetails" :readonly="readonly" @delete="$emit('delete')" />
     </v-container>
   </v-card>
 </template>
@@ -109,6 +109,7 @@ export default {
       default: false
     },
   },
+  emits: ['delete'],
   data() {
     return {
       productTitle: null,  // see init

--- a/src/components/PriceDeleteConfirmationDialog.vue
+++ b/src/components/PriceDeleteConfirmationDialog.vue
@@ -63,13 +63,9 @@ export default {
         .then((response) => {  // eslint-disable-line no-unused-vars
           // if response.status == 204
           this.loading = false
-          this.removePriceCard()
           this.$emit('delete')
           this.closeDialog()
         })
-    },
-    removePriceCard() {
-      document.getElementById(`price_${this.price.id}`).remove()
     },
     closeDialog() {
       this.$emit('close')

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -9,7 +9,7 @@
     </v-col>
   </v-row>
 
-  <PriceActionMenuButton :price="price" :hideProductActions="hideProductDetails" />
+  <PriceActionMenuButton :price="price" :hideProductActions="hideProductDetails" @delete="$emit('delete')" />
 </template>
 
 <script>
@@ -57,6 +57,7 @@ export default {
       type: Boolean,
       default: false
     },
-  }
+  },
+  emits: ['delete']
 }
 </script>

--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -33,7 +33,7 @@
     v-if="deleteConfirmationDialog"
     v-model="deleteConfirmationDialog"
     :proof="proof"
-    @delete="showDeleteSuccessMessage"
+    @delete="handleDelete"
     @close="closeDeleteConfirmationDialog"
   />
 
@@ -72,6 +72,7 @@ export default {
       default: 'position:absolute;bottom:6px;right:0;'
     }
   },
+  emits: ['delete'],
   data() {
     return {
       loading: false,
@@ -115,8 +116,9 @@ export default {
     closeDeleteConfirmationDialog() {
       this.deleteConfirmationDialog = false
     },
-    showDeleteSuccessMessage() {
+    handleDelete() {
       this.deleteSuccessMessage = true
+      this.$emit('delete')
     }
   }
 }

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -13,7 +13,7 @@
     <v-divider />
 
     <v-card-actions>
-      <ProofFooterRow :proof="proof" :hideProofActions="hideProofActions" :readonly="readonly" />
+      <ProofFooterRow :proof="proof" :hideProofActions="hideProofActions" :readonly="readonly" @delete="$emit('delete')" />
     </v-card-actions>
   </v-card>
 </template>
@@ -51,7 +51,7 @@ export default {
       default: '100%',
     },
   },
-  emits: ['proofSelected', 'close'],
+  emits: ['proofSelected', 'close', 'delete'],
   data() {
     return {
       proofEditDialog: false,

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -11,7 +11,7 @@
     </v-col>
   </v-row>
 
-  <ProofActionMenuButton v-if="!hideProofActions && userIsProofOwner" :proof="proof" />
+  <ProofActionMenuButton v-if="!hideProofActions && userIsProofOwner" :proof="proof" @delete="$emit('delete')" />
 </template>
 
 <script>
@@ -44,6 +44,7 @@ export default {
       default: false,
     },
   },
+  emits: ['delete'],
   computed: {
     ...mapStores(useAppStore),
     username() {

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -26,7 +26,7 @@
 
   <v-row>
     <v-col v-for="price in userPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
-      <PriceCard :price="price" :product="price.product" elevation="1" height="100%" />
+      <PriceCard :price="price" :product="price.product" elevation="1" height="100%" @delete="handlePriceDelete(price)" />
     </v-col>
   </v-row>
 
@@ -93,6 +93,10 @@ export default {
         this.getUserPrices()
       }
     },
+    handlePriceDelete(price) {
+      this.userPriceList = this.userPriceList.filter(p => p.id != price.id)
+      this.userPriceTotal = this.userPriceList.length
+    }
   }
 }
 </script>

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -27,7 +27,7 @@
 
   <v-row>
     <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="4" xl="3">
-      <ProofCard :proof="proof" :hideProofHeader="true" height="100%" @proofUpdated="handleProofUpdated" />
+      <ProofCard :proof="proof" :hideProofHeader="true" height="100%" @proofUpdated="handleProofUpdated" @delete="handleProofDelete(proof)" />
     </v-col>
   </v-row>
 
@@ -141,6 +141,10 @@ export default {
         this.getUserProofs()
       }
     },
+    handleProofDelete(proof) {
+      this.userProofList = this.userProofList.filter(p => p.id != proof.id)
+      this.userProofTotal = this.userProofList.length
+    }
   }
 }
 </script>


### PR DESCRIPTION
### What
In user dashboard lists:
- Deleting a proof did not visually remove the ProofCard and did not update the number of proofs
- Deleting a price did remove its card, but did not update the number of prices

In both cases, this is properly updated when refreshing the page.

To fix this, I'm forwarding the "delete" event all the way from the dialogs to the UserDashboardPriceList and UseDashboardProofList views.

The views then handle the event and remove the deleted element from their respective lists.

### Screenshot

#### Price list before / after change

| Before | After | 
| --- | --- | 
| ![price-del-before](https://github.com/user-attachments/assets/59da2808-cbe1-48ee-9f1a-12f4a271808a) |   ![price-del-after](https://github.com/user-attachments/assets/71ed98ea-395f-4ec4-8c67-ce9750a883e2) | 

#### Proof list before / after change

| Before | After | 
| --- | --- | 
| ![proof-del-before](https://github.com/user-attachments/assets/7ac1a86a-4e08-4363-b8e8-87f204520e33) | ![proof-del-after](https://github.com/user-attachments/assets/a6d299b2-a195-4861-b50b-2220f57a1fc0) |

### Notes
I'm not too sure on how this PR handles the edge cases when pagination takes effect. For example, what happens when deleting the last price of a page ?