### PR TITLE
refactor(Proofs): show image_thumb instead of (full) file image

### DIFF
--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -11,6 +11,9 @@
         <v-list-item :slim="true" prepend-icon="mdi-eye-outline" :to="getProofDetailUrl">
           {{ $t('Common.Details') }}
         </v-list-item>
+        <v-list-item :slim="true" prepend-icon="mdi-open-in-new" :href="getProofFullUrl" target="_blank">
+          {{ $t('Common.ImageFull') }}
+        </v-list-item>
         <v-list-item :slim="true" prepend-icon="mdi-pencil" :disabled="!userCanEditProof" @click="openEditDialog">
           {{ $t('Common.Edit') }}
         </v-list-item>
@@ -82,6 +85,11 @@ export default {
     }
   },
   computed: {
+    getProofFullUrl() {
+      // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'  // PRICE_TAG
+      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'  // RECEIPT
+      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.file_path}`
+    },
     getProofDetailUrl() {
       return `/proofs/${this.proof.id}`
     },

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -66,6 +66,9 @@ export default {
     getProofUrl(proof) {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'  // PRICE_TAG
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'  // RECEIPT
+      if (proof.image_thumb_path) {
+        return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.image_thumb_path}`
+      }
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
     },
     close() {

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -64,8 +64,8 @@ export default {
       }
     },
     getProofUrl(proof) {
-      // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'  // PRICE_TAG
-      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'  // RECEIPT
+      // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.400.webp'  // PRICE_TAG
+      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.400.webp'  // RECEIPT
       if (proof.image_thumb_path) {
         return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.image_thumb_path}`
       }

--- a/src/components/ProofChip.vue
+++ b/src/components/ProofChip.vue
@@ -8,7 +8,7 @@
     @click="openDialog"
   >
     <v-icon icon="mdi-image" />
-    <v-dialog v-model="dialog" scrollable max-height="80%" width="80%">
+    <v-dialog v-model="dialog" scrollable max-height="80%" width="auto">
       <ProofCard :proof="proof" :hideProofActions="true" @close="closeDialog" />
     </v-dialog>
   </v-chip>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -199,6 +199,7 @@
 		"Help": "Help",
 		"History": "History",
 		"Image": "Image",
+		"ImageFull": "Full-size image",
 		"LinkCopySuccess": "Link copied",
 		"LocationCount": "{count} locations",
 		"Map": "Map",


### PR DESCRIPTION
### What

Thanks to https://github.com/openfoodfacts/open-prices/issues/340 we now have proof image thumbnails.
- we display them instead of the full/slow proof images
- Proof action menu: added a link to view the full-size image

### Screenshot

![image](https://github.com/user-attachments/assets/7cc544e5-d5f4-4c47-b3da-05f0dcf8c000)


