### PR TITLE
feat(User dashboard): improve look & feel

### DIFF
--- a/src/components/StatCard.vue
+++ b/src/components/StatCard.vue
@@ -4,7 +4,15 @@
     :subtitle="subtitle"
     variant="tonal"
     density="compact"
-  />
+    :to="to ? to : null"
+  >
+    <template v-if="prependIcon" #prepend>
+      <v-icon>{{ prependIcon }}</v-icon>
+    </template>
+    <template v-if="to" #append>
+      <v-icon>mdi-arrow-right</v-icon>
+    </template>
+  </v-card>
 </template>
 
 <script>
@@ -18,6 +26,14 @@ export default {
       type: String,
       default: ''
     },
+    prependIcon: {
+      type: String,
+      default: ''
+    },
+    to: {
+      type: String,
+      default: ''
+    }
   }
 }
 </script>

--- a/src/components/UserActionMenuButton.vue
+++ b/src/components/UserActionMenuButton.vue
@@ -7,6 +7,9 @@
           {{ $t('Common.User') }}
         </v-list-subheader>
         <v-divider />
+        <v-list-item :slim="true" prepend-icon="mdi-cog-outline" to="/settings">
+          {{ $t('UserDashboard.Settings') }}
+        </v-list-item>
         <ShareLink :overrideUrl="getShareLinkUrl" display="list-item" />
         <OpenFoodFactsLink facet="editor" :value="user.user_id" display="list-item" />
       </v-list>
@@ -16,6 +19,8 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
 
 export default {
   components: {
@@ -33,6 +38,13 @@ export default {
     }
   },
   computed: {
+    ...mapStores(useAppStore),
+    username() {
+      return this.appStore.user.username
+    },
+    userIsPriceOwner() {
+      return this.username && (this.user.user_id === this.username)
+    },
     getShareLinkUrl() {
       return `/users/${this.user.user_id}`
     }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -54,6 +54,19 @@ export default {
     .then((response) => response.json())
   },
 
+  // can only fetch the user's own data
+  getUserById(userId) {
+    const store = useAppStore()
+    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/users/${userId}?${buildURLParams()}`
+    return fetch(url, {
+      method: 'GET',
+      headers: Object.assign({}, OP_DEFAULT_HEADERS, {
+        'Authorization': `Bearer ${store.user.token}`
+      }),
+    })
+    .then((response) => response.json())
+  },
+
   createProof(proofImage, type='PRICE_TAG', location_osm_id=null, location_osm_type=null, date=null, currency=null) {
     const store = useAppStore()
     let formData = new FormData()

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -1,12 +1,7 @@
 <template>
-  <v-row>
-    <v-col>
-      <v-chip class="mr-2" label variant="text" prepend-icon="mdi-account">
-        {{ username }}
-      </v-chip>
-      <v-btn size="small" prepend-icon="mdi-cog-outline" to="/settings">
-        {{ $t('UserDashboard.Settings') }}
-      </v-btn>
+  <v-row v-if="user">
+    <v-col cols="12" sm="6">
+      <UserCard :user="user" readonly />
     </v-col>
   </v-row>
 
@@ -33,13 +28,18 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
 
 export default {
+  components: {
+    UserCard: defineAsyncComponent(() => import('../components/UserCard.vue')),
+  },
   data() {
     return {
+      user: null,
       userPriceTotal: null,
       userProofTotal: null,
       loading: false,
@@ -52,10 +52,19 @@ export default {
     },
   },
   mounted() {
+    this.getUser()
     this.getUserPriceCount()
     this.getUserProofCount()
   },
   methods: {
+    getUser() {
+      this.loading = true
+      return api.getUserById(this.username)
+        .then((data) => {
+          this.user = data
+          this.loading = false
+        })
+    },
     getUserPriceCount() {
       this.loading = true
       return api.getPrices({ owner: this.username, size: 1 })

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -7,22 +7,10 @@
 
   <v-row>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <v-card
-        :title="$t('UserDashboard.MyPrices')"
-        :subtitle="userPriceCount"
-        prepend-icon="mdi-tag-multiple-outline"
-        height="100%"
-        to="/dashboard/prices"
-      />
+      <StatCard :value="userPriceCount" :subtitle="$t('Common.Prices')" to="/dashboard/prices" />
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <v-card
-        :title="$t('UserDashboard.MyProofs')"
-        :subtitle="userProofCount"
-        prepend-icon="mdi-image"
-        height="100%"
-        to="/dashboard/proofs"
-      />
+      <StatCard :value="userProofCount" :subtitle="$t('Common.Proofs')" to="/dashboard/proofs" />
     </v-col>
   </v-row>
 
@@ -51,6 +39,7 @@ import api from '../services/api'
 export default {
   components: {
     UserCard: defineAsyncComponent(() => import('../components/UserCard.vue')),
+    StatCard: defineAsyncComponent(() => import('../components/StatCard.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue'))
   },
   data() {

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -6,23 +6,38 @@
   </v-row>
 
   <v-row>
-    <v-col cols="12" sm="6" lg="4">
+    <v-col cols="6" sm="4" md="3" lg="2">
       <v-card
         :title="$t('UserDashboard.MyPrices')"
-        :subtitle="userPriceTotal"
+        :subtitle="userPriceCount"
         prepend-icon="mdi-tag-multiple-outline"
         height="100%"
         to="/dashboard/prices"
       />
     </v-col>
-    <v-col cols="12" sm="6" lg="4">
+    <v-col cols="6" sm="4" md="3" lg="2">
       <v-card
         :title="$t('UserDashboard.MyProofs')"
-        :subtitle="userProofTotal"
+        :subtitle="userProofCount"
         prepend-icon="mdi-image"
         height="100%"
         to="/dashboard/proofs"
       />
+    </v-col>
+  </v-row>
+
+  <br>
+
+  <v-row>
+    <v-col v-for="price in displayedPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
+      <PriceCard :price="price" :product="price.product" :hidePriceCreated="false" elevation="1" height="100%" />
+    </v-col>
+    <v-col cols="12" sm="6" md="4" xl="3" align="center">
+      <br v-if="$vuetify.display.smAndUp"><!-- TODO: center vertically instead of br -->
+      <br v-if="$vuetify.display.smAndUp">
+      <v-btn to="/dashboard/prices" prepend-icon="mdi-tag-multiple-outline" append-icon="mdi-arrow-right">
+        {{ $t('UserDashboard.MyPrices') }}
+      </v-btn>
     </v-col>
   </v-row>
 </template>
@@ -36,12 +51,14 @@ import api from '../services/api'
 export default {
   components: {
     UserCard: defineAsyncComponent(() => import('../components/UserCard.vue')),
+    PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue'))
   },
   data() {
     return {
       user: null,
-      userPriceTotal: null,
-      userProofTotal: null,
+      userPriceCount: null,
+      userProofCount: null,
+      userPriceList: [],
       loading: false,
     }
   },
@@ -50,11 +67,18 @@ export default {
     username() {
       return this.appStore.user.username
     },
+    displayedPriceList() {
+      if (!this.$vuetify.display.smAndUp) {
+        return this.userPriceList.slice(0, 5)
+      } else {
+        return this.userPriceList
+      }
+    }
   },
   mounted() {
     this.getUser()
-    this.getUserPriceCount()
     this.getUserProofCount()
+    this.getPrices()
   },
   methods: {
     getUser() {
@@ -65,19 +89,20 @@ export default {
           this.loading = false
         })
     },
-    getUserPriceCount() {
-      this.loading = true
-      return api.getPrices({ owner: this.username, size: 1 })
-        .then((data) => {
-          this.userPriceTotal = data.total
-          this.loading = false
-        })
-    },
     getUserProofCount() {
       this.loading = true
       return api.getProofs({ owner: this.username, size: 1 })
         .then((data) => {
-          this.userProofTotal = data.total
+          this.userProofCount = data.total
+          this.loading = false
+        })
+    },
+    getPrices() {
+      this.loading = true
+      return api.getPrices({ owner: this.username, size: 25 })
+        .then((data) => {
+          this.userPriceList = data.items
+          this.userPriceCount = data.total
           this.loading = false
         })
     },


### PR DESCRIPTION
### What

New user dashboard
- show user card at the top
  - load data thanks to https://github.com/openfoodfacts/open-prices/pull/500
  - add a link to the user settings in the action menu
- show stats (with CTA to see the full list)
- show latest prices (like home)

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/52c7f2d0-b747-48f8-8892-8aa5d3a36292)|![image](https://github.com/user-attachments/assets/e7ed0392-779e-4aff-a034-8668cca59fb8)|


