### PR TITLE
refactor(Price add): Improve barcode manual input by prefilling with current code

### DIFF
--- a/src/components/BarcodeManualInputDialog.vue
+++ b/src/components/BarcodeManualInputDialog.vue
@@ -35,6 +35,12 @@
 
 <script>
 export default {
+  props: {
+    preFillValue: {
+      type: String,
+      default: ''
+    }
+  },
   emits: ['barcode', 'close'],
   data() {
     return {
@@ -49,6 +55,9 @@ export default {
     }
   },
   mounted() {
+    if (this.preFillValue) {
+      this.barcodeForm.barcode = this.preFillValue
+    }
     this.$refs.barcodeInput.focus()
   },
   methods: {

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -72,6 +72,7 @@
   <BarcodeManualInputDialog
     v-if="barcodeManualInputDialog"
     v-model="barcodeManualInputDialog"
+    :preFillValue="productForm.product_code"
     @barcode="setProductCode($event)"
     @close="barcodeManualInputDialog = false"
   />


### PR DESCRIPTION
### What

When adding a price, users have the possibility to type the code manually. But sometimes a mistake a make (same for the barcode scanner).
Now, when trying to input the code again, it will be prefilled with the existing value.

### Screenshot

![image](https://github.com/user-attachments/assets/37026a1e-b636-4b81-8617-e052bd93cb04)
