### PR TITLE
refactor(ProofCard): Only show proof thumb image in User Dashboard Proof List

### DIFF
--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -7,7 +7,7 @@
     <v-divider v-if="!hideProofHeader" />
 
     <v-card-text>
-      <v-img v-if="proof.file_path" :src="getProofUrl(proof)" :style="'max-height:' + imageHeight" />
+      <v-img v-if="proof.file_path" :src="getProofUrl(proof, showThumbImage)" :style="'max-height:' + imageHeight" />
     </v-card-text>
 
     <v-divider />
@@ -50,6 +50,10 @@ export default {
       type: String,
       default: '100%',
     },
+    showThumbImage: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['proofSelected', 'close'],
   data() {
@@ -63,10 +67,10 @@ export default {
         this.$emit('proofSelected', this.proof)
       }
     },
-    getProofUrl(proof) {
+    getProofUrl(proof, showThumbImage) {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.400.webp'  // PRICE_TAG
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.400.webp'  // RECEIPT
-      if (proof.image_thumb_path) {
+      if (proof.image_thumb_path && showThumbImage) {
         return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.image_thumb_path}`
       }
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -7,7 +7,7 @@
     <v-divider v-if="!hideProofHeader" />
 
     <v-card-text>
-      <v-img v-if="proof.file_path" :src="getProofUrl(proof, showThumbImage)" :style="'max-height:' + imageHeight" />
+      <v-img v-if="proof.file_path" :src="getProofUrl()" :style="'max-height:' + imageHeight" />
     </v-card-text>
 
     <v-divider />
@@ -50,7 +50,7 @@ export default {
       type: String,
       default: '100%',
     },
-    showThumbImage: {
+    showImageThumb: {
       type: Boolean,
       default: false,
     },
@@ -67,13 +67,13 @@ export default {
         this.$emit('proofSelected', this.proof)
       }
     },
-    getProofUrl(proof, showThumbImage) {
+    getProofUrl() {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.400.webp'  // PRICE_TAG
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.400.webp'  // RECEIPT
-      if (proof.image_thumb_path && showThumbImage) {
-        return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.image_thumb_path}`
+      if (this.proof.image_thumb_path && this.showImageThumb) {
+        return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.image_thumb_path}`
       }
-      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${proof.file_path}`
+      return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.file_path}`
     },
     close() {
       this.$emit('close')

--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -7,7 +7,7 @@
     <v-divider v-if="!hideProofHeader" />
 
     <v-card-text>
-      <v-img v-if="proof.file_path" :src="getProofUrl()" :style="'max-height:' + imageHeight" />
+      <v-img v-if="proof.file_path" :src="getProofUrl" :style="'max-height:' + imageHeight" />
     </v-card-text>
 
     <v-divider />
@@ -34,6 +34,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    showImageThumb: {
+      type: Boolean,
+      default: false,
+    },
     hideProofActions: {
       type: Boolean,
       default: false,
@@ -50,10 +54,6 @@ export default {
       type: String,
       default: '100%',
     },
-    showImageThumb: {
-      type: Boolean,
-      default: false,
-    },
   },
   emits: ['proofSelected', 'close'],
   data() {
@@ -61,12 +61,7 @@ export default {
       proofEditDialog: false,
     }
   },
-  methods: {
-    selectProof() {
-      if (this.isSelectable) {
-        this.$emit('proofSelected', this.proof)
-      }
-    },
+  computed: {
     getProofUrl() {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.400.webp'  // PRICE_TAG
       // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.400.webp'  // RECEIPT
@@ -74,6 +69,13 @@ export default {
         return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.image_thumb_path}`
       }
       return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.file_path}`
+    },
+  },
+  methods: {
+    selectProof() {
+      if (this.isSelectable) {
+        this.$emit('proofSelected', this.proof)
+      }
     },
     close() {
       this.$emit('close')

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -12,7 +12,7 @@
 
   <v-row>
     <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="4" xl="3">
-      <ProofCard :proof="proof" :hideProofHeader="true" height="100%" @proofUpdated="handleProofUpdated" />
+      <ProofCard :proof="proof" :hideProofHeader="true" :showThumbImage="true" height="100%" @proofUpdated="handleProofUpdated" />
     </v-col>
   </v-row>
 

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -12,7 +12,7 @@
 
   <v-row>
     <v-col v-for="proof in userProofList" :key="proof" cols="12" sm="6" md="4" xl="3">
-      <ProofCard :proof="proof" :hideProofHeader="true" :showThumbImage="true" height="100%" @proofUpdated="handleProofUpdated" />
+      <ProofCard :proof="proof" :hideProofHeader="true" :showImageThumb="true" height="100%" @proofUpdated="handleProofUpdated" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

- Following #924
- Only show proof thumb image in User Dashboard Proof List
- All other pages should display the original proof image, as to not offuscate important details

### Fixes bug(s)
- Fixes #952
