### PR TITLE
feat(SignIn): parse and use username from access_token on signin, allows usage of emails to login

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -49,8 +49,8 @@ export const useAppStore = defineStore('app', {
     }
   },
   actions: {
-    signIn(username, token) {
-      this.user.username = username
+    signIn(token) {
+      this.user.username = utils.getOFFUsernameFromAuthToken(token)
       this.user.token = token
     },
     signOut() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -164,6 +164,13 @@ function dateType(dateString) {
   return null
 }
 
+/**
+ * OFF auth token format: 'username__uuid'
+ */
+function getOFFUsernameFromAuthToken(token) {
+  return token.split("__")[0]
+}
+
 function getCategoryName(categoryId) {
   let category = CategoryTags.find(ct => ct.id === categoryId)
   return category ? category.name : categoryId
@@ -372,6 +379,7 @@ export default {
   offDateTime,
   prettyRelativeDateTime,
   dateType,
+  getOFFUsernameFromAuthToken,
   getCategoryName,
   getLocaleCategoryTags,
   getLocaleCategoryTag,

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -74,7 +74,7 @@ export default {
         .signIn(this.signinForm.username.toLowerCase().trim(), this.signinForm.password)
         .then((data) => {
           if (data['access_token']) {
-            this.appStore.signIn(data['access_token'].split("__")[0], data['access_token'])
+            this.appStore.signIn(data['access_token'])
             this.done()
           } else {
             alert(this.$t('SignIn.WrongCredentials'))

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -74,7 +74,7 @@ export default {
         .signIn(this.signinForm.username.toLowerCase().trim(), this.signinForm.password)
         .then((data) => {
           if (data['access_token']) {
-            this.appStore.signIn(this.signinForm.username.toLowerCase().trim(), data['access_token'])
+            this.appStore.signIn(data['access_token'].split("__")[0], data['access_token'])
             this.done()
           } else {
             alert(this.$t('SignIn.WrongCredentials'))


### PR DESCRIPTION
### What
I've noticed that my acces_token always takes the following shape: `<username>__U<uuid>`, even when I use an email as login.

If this is true, maybe parsing this access token, extracting the username and feeding it to the appStore could allow user to still use email as login.


### Fixes bug(s)
- Fixes #947

### Note
This might require some testing, I couldn't find documentation on what the OFF token should look like, so I only have my own experience as data.
