### PR TITLE
refactor(Proof card): hide by default the proof owner chip

### DIFF
--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -6,7 +6,7 @@
       <LocationChip class="mr-1" :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
       <DateChip class="mr-1" :date="proof.date" :showErrorIfDateMissing="true" />
       <CurrencyChip class="mr-1" :currency="proof.currency" :showErrorIfCurrencyMissing="true" />
-      <UserChip class="mr-1" :username="proof.owner" :readonly="readonly" />
+      <UserChip v-if="!hideProofOwner" class="mr-1" :username="proof.owner" :readonly="readonly" />
       <RelativeDateTimeChip :dateTime="proof.created" />
     </v-col>
   </v-row>
@@ -34,6 +34,10 @@ export default {
     proof: {
       type: Object,
       default: null
+    },
+    hideProofOwner: {
+      type: Boolean,
+      default: true
     },
     hideProofActions: {
       type: Boolean,


### PR DESCRIPTION
### What

Following #806 where we hide by default the price owner chip (in the Price card) & https://github.com/openfoodfacts/open-prices-frontend/commit/ee4468019fc222af6c96dcb3bc523578500c9bfe (prop to toggle).
Here we do the same but in the Proof card

### Why

a bit of privacy