### PR TITLE
refactor(Proof detail): add history section at the bottom

### DIFF
--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -28,6 +28,12 @@
       <v-progress-circular indeterminate :size="30" />
     </v-col>
   </v-row>
+
+  <v-row v-if="proof">
+    <v-col cols="12" sm="6">
+      <HistoryCard :price="proof" />
+    </v-col>
+  </v-row>
 </template>
 
 <script>
@@ -40,6 +46,7 @@ export default {
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
+    HistoryCard: defineAsyncComponent(() => import('../components/HistoryCard.vue')),
   },
   data() {
     return {


### PR DESCRIPTION
### What

Similar to #806 (Price detail history section), but in the Proof detail page

### Why

- we removed the Proof owner chip in #959, and we display it in the history section instead
- to mimic the Price detail page
- to close #804 ^^