### PR TITLE
refactor(Stats page): add extra count by location & proof type

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -291,6 +291,10 @@
 			"Title": "Welcome to {name}!"
 		}
 	},
+	"LocationCard": {
+		"OSM": "OpenStreetMap",
+		"ONLINE": "Online"
+	},
 	"LocationDetail": {
 		"LatestPrices": "Latest prices",
 		"LoadMore": "Load more",
@@ -401,7 +405,8 @@
 		"Proof": "Proof",
 		"PRICE_TAG": "Price tag",
 		"RECEIPT": "Receipt",
-		"GDPR_REQUEST": "GDPR request"
+		"GDPR_REQUEST": "GDPR request",
+		"SHOP_IMPORT": "Shop import"
 	},
 	"ProofCreate": {
 		"SelectProof": "Select a proof",

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -47,6 +47,12 @@
     <v-col cols="6" sm="4" md="3" lg="2">
       <StatCard :value="stats.location_with_price_count" :subtitle="$t('Stats.Total')" />
     </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.location_type_osm_count" :subtitle="$t('LocationCard.OSM')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.location_type_online_count" :subtitle="$t('LocationCard.ONLINE')" />
+    </v-col>
   </v-row>
 
   <br>
@@ -64,7 +70,10 @@
       <StatCard :value="stats.proof_type_price_tag_count" :subtitle="$t('ProofCard.PRICE_TAG')" />
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.proof_type_receipt_count" :subtitle="$t('ProofCard.RECEIPT')" />
+      <StatCard :value="stats.proof_type_gdpr_request_count" :subtitle="$t('ProofCard.GDPR_REQUEST')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.proof_type_shop_import_count" :subtitle="$t('ProofCard.SHOP_IMPORT')" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

Following https://github.com/openfoodfacts/open-prices/pull/524 (backend), display 4 new stats : 
- Location count by types OSM & ONLINE
- Proof count by types GDPR_REQUEST & SHOP_IMPORT