### PR TITLE
feat(Proof card): show new consumption-related fields in the footer

### DIFF
--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -64,7 +64,7 @@ export default {
   computed: {
     getProofUrl() {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.400.webp'  // PRICE_TAG
-      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.400.webp'  // RECEIPT
+      // return 'https://prices.openfoodfacts.net/img/0001/lZGFga9ZOT.webp'  // RECEIPT
       if (this.proof.image_thumb_path && this.showImageThumb) {
         return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${this.proof.image_thumb_path}`
       }

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -2,6 +2,12 @@
   <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof" />
+      <v-chip v-if="showReceiptPriceCount" class="mr-1" label size="small" variant="flat" density="comfortable">
+        {{ $t('Common.PriceCount', { count: proof.receipt_price_count }) }}
+      </v-chip>
+      <v-chip v-if="showReceiptPriceTotal" class="mr-1" label size="small" variant="flat" density="comfortable">
+        {{ getPriceValueDisplay(proof.receipt_price_total) }}
+      </v-chip>
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()" />
       <LocationChip class="mr-1" :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
       <DateChip class="mr-1" :date="proof.date" :showErrorIfDateMissing="true" />
@@ -18,6 +24,8 @@
 import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
+import constants from '../constants'
+import utils from '../utils.js'
 
 export default {
   components: {
@@ -56,8 +64,24 @@ export default {
     userIsProofOwner() {
       return this.username && (this.proof.owner === this.username)
     },
+    isTypeReceipt() {
+      return this.proof && this.proof.type === constants.PROOF_TYPE_RECEIPT
+    },
+    showReceiptPriceCount() {
+      return this.userIsProofOwner && this.isTypeReceipt && this.proof.receipt_price_count
+    },
+    showReceiptPriceTotal() {
+      return this.userIsProofOwner && this.isTypeReceipt && this.proof.receipt_price_total
+    },
   },
   methods: {
+    getPriceValue(priceValue, priceCurrency) {
+      return utils.prettyPrice(priceValue, priceCurrency)
+    },
+    getPriceValueDisplay(price) {
+      price = parseFloat(price)
+      return this.getPriceValue(price, this.proof.currency)
+    },
     goToProof() {
       if (this.readonly || !this.userIsProofOwner) {
         return

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -2,10 +2,10 @@
   <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
       <ProofTypeChip class="mr-1" :proof="proof" />
-      <v-chip v-if="showReceiptPriceCount" class="mr-1" label size="small" variant="flat" density="comfortable">
+      <v-chip v-if="showReceiptPriceCount" class="mr-1" label size="small" variant="flat" density="comfortable" :title="$t('Common.ReceiptPriceCount')">
         {{ $t('Common.PriceCount', { count: proof.receipt_price_count }) }}
       </v-chip>
-      <v-chip v-if="showReceiptPriceTotal" class="mr-1" label size="small" variant="flat" density="comfortable">
+      <v-chip v-if="showReceiptPriceTotal" class="mr-1" label size="small" variant="flat" density="comfortable" :title="$t('Common.ReceiptPriceTotal')">
         {{ getPriceValueDisplay(proof.receipt_price_total) }}
       </v-chip>
       <PriceCountChip :count="proof.price_count" :withLabel="true" @click="goToProof()" />


### PR DESCRIPTION
### What

Following #976 some proofs will now have 2 extra metadata.
If the data is available, and if the user is the proof owner, we display them.

### Screenshot

![image](https://github.com/user-attachments/assets/dfaae3b8-58da-4470-b2f3-c54494fa3fb4)
