### PR TITLE
ci: rename preprod to staging

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,4 @@
+VITE_OPEN_PRICES_ENV = "local"
 VITE_OPEN_PRICES_APP_URL = "http://127.0.0.1:8000"
 VITE_OPEN_PRICES_API_URL = "http://127.0.0.1:8000/api/v1"
 VITE_MANIFEST_PATH = "/manifest.local.json"

--- a/.env.prod
+++ b/.env.prod
@@ -1,3 +1,4 @@
+VITE_OPEN_PRICES_ENV = "prod"
 VITE_OPEN_PRICES_APP_URL = "https://prices.openfoodfacts.org"
 VITE_OPEN_PRICES_API_URL = "https://prices.openfoodfacts.org/api/v1"
 VITE_MANIFEST_PATH = "/manifest.prod.json"

--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,7 @@
+VITE_OPEN_PRICES_ENV = "staging"
 VITE_OPEN_PRICES_APP_URL = "https://prices.openfoodfacts.net"
 VITE_OPEN_PRICES_API_URL = "https://prices.openfoodfacts.net/api/v1"
-VITE_MANIFEST_PATH = "/manifest.preprod.json"
+VITE_MANIFEST_PATH = "/manifest.staging.json"
 VITE_DEFAULT_LOCALE = en
 VITE_FALLBACK_LOCALE = en
 VITE_DEFAULT_COUNTRY = FR

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build-staging": "vite build --mode preprod",
+    "build-staging": "vite build --mode staging",
     "build-prod": "vite build --mode prod",
     "preview": "vite preview",
     "lint": "eslint",

--- a/public/manifest.staging.json
+++ b/public/manifest.staging.json
@@ -1,6 +1,6 @@
 {
-    "name": "Open Prices (Preprod)",
-    "short_name": "OpenPrices (Preprod)",
+    "name": "Open Prices (Staging)",
+    "short_name": "OpenPrices (Staging)",
     "description": "An open crowdsourced database of prices",
     "icons": [
         {

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,12 +17,12 @@ const LOCATION_TYPE_ONLINE_ICON = 'mdi-web'
 
 export default {
   APP_NAME: 'Open Prices',
-  APP_URL: 'https://prices.openfoodfacts.org',
-  APP_API_URL: 'https://prices.openfoodfacts.org/api/docs',
+  APP_URL: import.meta.env.VITE_OPEN_PRICES_APP_URL,
+  APP_API_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/api/docs`,
   APP_USER_AGENT: 'Open Prices Web App',
-  APP_DUMP_PRICES_URL: 'https://prices.openfoodfacts.org/data/prices.jsonl.gz',
-  APP_DUMP_PROOFS_URL: 'https://prices.openfoodfacts.org/data/proofs.jsonl.gz',
-  APP_DUMP_LOCATIONS_URL: 'https://prices.openfoodfacts.org/data/locations.jsonl.gz',
+  APP_DUMP_PRICES_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/data/prices.jsonl.gz`,
+  APP_DUMP_PROOFS_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/data/proofs.jsonl.gz`,
+  APP_DUMP_LOCATIONS_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/data/locations.jsonl.gz`,
   APP_GITHUB_FRONTEND_URL: 'https://github.com/openfoodfacts/open-prices-frontend',
   OFF_NAME: OFF_NAME,
   OFF_URL: 'https://world.openfoodfacts.org',


### PR DESCRIPTION
### What

- use "staging" instead of "preprod"
- new "VITE_OPEN_PRICES_ENV" variable
