### PR TITLE
feat(Header): hide old User settings, move Sign Out to drawer

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -23,34 +23,30 @@
       </v-btn>
     </template>
     <template v-else #append>
-      <v-menu scroll-strategy="close">
-        <template #activator="{ props }">
-          <v-btn v-if="!$vuetify.display.smAndUp" v-bind="props" icon="mdi-account-circle" />
-          <v-btn v-else v-bind="props" class="text-lowercase" prepend-icon="mdi-account-circle">
-            {{ username }}
-          </v-btn>
-        </template>
-        <v-list>
-          <v-list-item class="d-sm-none" :slim="true" prepend-icon="mdi-account" disabled>
-            {{ username }}
-          </v-list-item>
-          <v-divider class="d-sm-none" />
-          <v-list-item :slim="true" prepend-icon="mdi-view-dashboard-outline" to="/dashboard" :aria-label="$t('Common.Dashboard')">
-            {{ $t('Common.Dashboard') }}
-          </v-list-item>
-          <v-list-item :slim="true" prepend-icon="mdi-cog-outline" to="/dashboard/settings" :aria-label="$t('Common.Settings')">
-            {{ $t('Common.Settings') }}
-          </v-list-item>
-          <v-list-item :slim="true" prepend-icon="mdi-logout" :aria-label="$t('Common.SignOut')" @click="signOut">
-            {{ $t('Common.SignOut') }}
-          </v-list-item>
-        </v-list>
-      </v-menu>
+      <v-btn v-if="!$vuetify.display.smAndUp" icon="mdi-account-circle" to="/dashboard" :aria-label="$t('Common.Dashboard')" />
+      <v-btn v-else class="text-lowercase" prepend-icon="mdi-account-circle" to="/dashboard" :aria-label="$t('Common.Dashboard')">
+        {{ username }}
+      </v-btn>
     </template>
   </v-app-bar>
 
   <v-navigation-drawer v-model="showDrawerMenu" temporary>
-    <v-list :items="getDrawerMenuItems" />
+    <v-list>
+      <v-list-item
+        v-for="item in getDrawerMenuItems"
+        :key="item.title"
+        :slim="true"
+        :title="item.title"
+        :prepend-icon="item.props['prepend-icon']"
+        :base-color="item.props['base-color']"
+        :to="item.props.to"
+      />
+    </v-list>
+    <template #append>
+      <v-list>
+        <v-list-item v-if="username" base-color="error" :slim="true" :title="$t('Common.SignOut')" :aria-label="$t('Common.SignOut')" prepend-icon="mdi-logout" @click="signOut" />
+      </v-list>
+    </template>
   </v-navigation-drawer>
 </template>
 

--- a/src/router.js
+++ b/src/router.js
@@ -6,7 +6,7 @@ import localeManager from './i18n/localeManager.js'
 const routes = [
   { path: '/', name: 'home', component: () => import('./views/Home.vue'), meta: { title: 'Home', icon: 'mdi-home', drawerMenu: true } },
   { path: '/sign-in', name: 'sign-in', component: () => import('./views/SignIn.vue'), meta: { title: 'SignIn', icon: 'mdi-login', drawerMenu: true, requiresAuth: false } },
-  { path: '/dashboard', name: 'dashboard', component: () => import('./views/UserDashboard.vue'), meta: { title: 'Dashboard', icon: 'mdi-view-dashboard-outline', drawerMenu: true, requiresAuth: true, breadcrumbs: [{title: 'Dashboard', disabled: true }] } },
+  { path: '/dashboard', name: 'dashboard', component: () => import('./views/UserDashboard.vue'), meta: { title: 'Dashboard', icon: 'mdi-account-circle', drawerMenu: true, requiresAuth: true, breadcrumbs: [{title: 'Dashboard', disabled: true }] } },
   { path: '/dashboard/prices', name: 'dashboard-prices', component: () => import('./views/UserDashboardPriceList.vue'), meta: { title: 'MyPrices', requiresAuth: true, breadcrumbs: [{title: 'Dashboard', disabled: false, to: '/dashboard' }, {title: 'MyPrices', disabled: true}] } },
   { path: '/dashboard/proofs', name: 'dashboard-proofs', component: () => import('./views/UserDashboardProofList.vue'), meta: { title: 'MyProofs', requiresAuth: true, breadcrumbs: [{title: 'Dashboard', disabled: false, to: '/dashboard' }, {title: 'MyProofs', disabled: true}] } },
   { path: '/dashboard/settings', name: 'dashboard-settings', component: () => import('./views/UserSettings.vue'), meta: { title: 'Settings', requiresAuth: true } },


### PR DESCRIPTION
### What

Header changes (when logged in)
- remove the user menu dropdown
- clicking on the user icon sends to the dashboard

Drawer (when logged in)
- change Dashboard icon (now same as user in the header)
- add Sign Out button at the bottom
