### PR TITLE
refactor(Location search): add search hint, improve map zoom for single result

### DIFF
--- a/src/components/LeafletMap.vue
+++ b/src/components/LeafletMap.vue
@@ -45,13 +45,7 @@ export default {
   },
   mounted() {
     if (this.locations.length) {
-      if (this.locations.length > 1) {
-        this.mapBounds = utils.getMapBounds(this.locations)
-      } else {
-        this.mapCenter = utils.getMapCenter(this.locations)
-        // this.mapZoom = 12
-        this.mapBounds = null
-      }
+      this.mapBounds = utils.getMapBounds(this.locations)
     }
     if (this.theme.global.name === "dark") {
       this.tiles = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -13,11 +13,13 @@
             ref="locationInput"
             v-model="locationSearchForm.q"
             :label="$t('LocationSelector.SearchByName')"
+            :hint="$t('Common.ExamplesWithColonAndValue', { value: 'Auchan Grenoble ; Carrefour rue la fayette 75010 paris ; N12208020359' })"
             type="text"
             append-inner-icon="mdi-magnify"
             :rules="[fieldRequired]"
             :loading="loading"
             required
+            persistent-hint
             @click:append-inner="search"
           />
         </v-form>
@@ -31,7 +33,7 @@
         </p>
 
         <v-sheet v-if="results">
-          <h3 class="mb-1">
+          <h3 class="mt-4 mb-1">
             <i18n-t keypath="LocationSelector.Result" tag="span">
               <template #resultNumber>
                 <small>{{ Array.isArray(results) ? results.length : 0 }}</small>

--- a/src/utils.js
+++ b/src/utils.js
@@ -360,7 +360,7 @@ function getMapCenter(results) {
     // OP
     return [results[0].osm_lat, results[0].osm_lon]
   }
-  results [45, 5]
+  return [45, 5]
 }
 
 // OP location


### PR DESCRIPTION
### What

A few small improvements in the location search dialog:
- show a search hint with examples
- allow searching for "N12208020359" (was already possible to search for "12208020359" thanks to #617)
- improve map zoom when only 1 result is returned

### Screenshot

![image](https://github.com/user-attachments/assets/2236dd9a-bfee-47be-8941-201c93047eed)
