### PR TITLE
feat(Product Map): Add prices count and average to map

### DIFF
--- a/src/components/LeafletMap.vue
+++ b/src/components/LeafletMap.vue
@@ -5,6 +5,7 @@
       <l-popup>
         <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
         {{ getLocationTitle(location, false, true, true) }}<br>
+        <span v-if="location.info">{{ location.info }}<br></span>
         <v-chip label size="small" density="comfortable">
           {{ getLocationTag(location) }}
         </v-chip>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -147,6 +147,7 @@
 		"AddPrice": "Add a price",
 		"AddToOFF": "Add to {name}",
 		"AdditionalInfo": "Additional information",
+		"Average": "Average",
 		"Brand": "Brand",
 		"Price": "Price",
 		"Prices": "Prices",

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -99,6 +99,7 @@ export default {
       productPriceTotal: 0,
       productPricePage: 0,
       priceLocationList: [],
+      priceLocationTotals: {},
       loading: false,
       // share
       shareLinkCopySuccessMessage: false,
@@ -197,8 +198,10 @@ export default {
           data.items.forEach((price) => {
             if (price.location) {
               utils.addObjectToArray(this.priceLocationList, price.location)
+              this.addPriceToLocationTotals(price)
             }
           })
+          this.addLocationsInfoToPriceLocationList()
           this.loading = false
         })
     },
@@ -224,6 +227,27 @@ export default {
         this.getProductPrices()
       }
     },
+    addPriceToLocationTotals(price) {
+      const locationId = utils.getLocationUniqueID(price.location)
+      if (!this.priceLocationTotals[locationId]) {
+        this.priceLocationTotals[locationId] = {total: 0, count: 0, currency: price.currency}
+      }
+      this.priceLocationTotals[locationId].total += price.price
+      this.priceLocationTotals[locationId].count += 1
+    },
+    addLocationsInfoToPriceLocationList() {
+      this.priceLocationList = this.priceLocationList.map(location => {
+        const locationId = utils.getLocationUniqueID(location)
+        const priceLocationTotal = this.priceLocationTotals[locationId]
+        if (priceLocationTotal) {
+          location.info = `
+            ${this.$t('Common.PriceCount', { count: priceLocationTotal.count })}. 
+            ${this.$t('Common.Average')}: ${utils.prettyPrice(priceLocationTotal.total / priceLocationTotal.count, priceLocationTotal.currency)}.
+          `
+        }
+        return location
+      })
+    }
   }
 }
 </script>


### PR DESCRIPTION
### What
- In product details, when displaying prices as a map, adds count and average prices for each location
- This new line appears in the popup when clicking on a map marker
- This line is stored in a generic "info" parameter, to keep LeafletMap component reusable
- The count and average matches the number of prices loaded (25 by default)

### Screenshot
![map](https://github.com/user-attachments/assets/6468048f-4b1f-443c-90e8-a4a4f8a65adf)


### Next Step
- It's a bit odd to average organic and non-organic products. We should either display them in two lines, or wait for an "organic" filter.
- Mixed unit (per kg / per unit) might also be an issue for some categories
- Mixed currencies shouldn't be an issue, it's unlikely that shops use more than one currency
