### PR TITLE
refactor(Location selector): Add tabs to choose between OSM & Recent

### DIFF
--- a/src/components/LoadedCountChip.vue
+++ b/src/components/LoadedCountChip.vue
@@ -1,10 +1,6 @@
 <template>
-  <v-chip
-    class="mr-2"
-    variant="tonal"
-    size="x-small"
-  >
-    <span v-if="totalCount">
+  <v-chip class="mr-2" variant="tonal" size="x-small">
+    <span v-if="loadedCount">
       {{ loadedCount }}&nbsp;/&nbsp;{{ totalCount }}
     </span>
     <span v-else>

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -1,100 +1,96 @@
 <template>
-  <v-dialog scrollable max-height="80%" min-width="50%" width="auto">
+  <v-dialog scrollable max-height="80%" width="80%">
     <v-card>
       <v-card-title>
-        {{ $t('LocationSelector.Title') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close" />
+        {{ $t('LocationSelector.Title') }} <v-btn
+          style="float:right;" variant="text" density="compact" icon="mdi-close"
+          @click="close"
+        />
       </v-card-title>
 
       <v-divider />
 
       <v-card-text>
-        <v-form @submit.prevent="search">
-          <v-text-field
-            ref="locationInput"
-            v-model="locationSearchForm.q"
-            :label="$t('LocationSelector.SearchByName')"
-            :hint="$t('Common.ExamplesWithColonAndValue', { value: 'Auchan Grenoble ; Carrefour rue la fayette 75010 paris ; N12208020359' })"
-            type="text"
-            append-inner-icon="mdi-magnify"
-            :rules="[fieldRequired]"
-            :loading="loading"
-            required
-            persistent-hint
-            @click:append-inner="search"
-          />
-        </v-form>
-
-        <p v-if="searchProvider === 'nominatim'" class="text-caption text-warning mt-2">
-          <i18n-t keypath="LocationSelector.Warning" tag="i">
-            <template #newline>
-              <br>
-            </template>
-          </i18n-t>
-        </p>
-
-        <v-sheet v-if="results">
-          <h3 class="mt-4 mb-1">
-            <i18n-t keypath="LocationSelector.Result" tag="span">
-              <template #resultNumber>
-                <small>{{ Array.isArray(results) ? results.length : 0 }}</small>
-              </template>
-            </i18n-t>
-          </h3>
-          <v-row v-if="Array.isArray(results)">
-            <v-col cols="12" sm="6">
-              <v-card
-                v-for="location in results"
-                :key="getLocationUniqueID(location)"
-                class="mb-2"
-                width="100%"
-                elevation="1"
-                @click="selectLocation(location)"
-              >
-                <v-card-text>
-                  <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
-                  {{ getLocationTitle(location, false, true, true) }}<br>
-                  <LocationOSMTagChip :location="location" class="mr-1" />
-                  <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
-                </v-card-text>
-              </v-card>
-            </v-col>
-            <v-col cols="12" sm="6" style="min-height:400px">
-              <LeafletMap :locations="results" />
-            </v-col>
-          </v-row>
-
-          <p v-else-if="typeof results === 'string'">
-            {{ results }}
-          </p>
-        </v-sheet>
-
-        <v-sheet v-if="recentLocations.length">
-          <v-divider class="mt-2 mb-2" />
-
-          <h3 class="mb-1">
-            <i18n-t keypath="LocationSelector.RecentLocations" tag="span">
-              <template #recentLocationNumber>
-                <small>{{ recentLocations.length }}</small>
-              </template>
-            </i18n-t>
-          </h3>
-          <v-chip
-            v-for="location in recentLocations"
-            :key="getLocationUniqueID(location)"
-            class="mb-2"
-            closable
-            prepend-icon="mdi-history"
-            close-icon="mdi-delete"
-            @click="selectLocation(location)"
-            @click:close="removeRecentLocation(location)"
-          >
-            {{ getLocationTitle(location, true, true, true) }}
-          </v-chip>
-          <br>
-          <v-btn size="small" @click="clearRecentLocations">
-            {{ $t('LocationSelector.Clear') }}
+        <v-btn-toggle v-model="currentDisplay" class="mb-2">
+          <v-btn v-for="item in displayItems" :key="item.key" :value="item.key">
+            <v-icon start>
+              {{ item.icon }}
+            </v-icon>
+            <span v-if="item.key === 'osm'">{{ item.value }}</span>
+            <span v-else>{{ $t('Common.' + item.value) }}</span>
+            <span v-if="item.key === 'recent'">
+              <LoadedCountChip :totalCount="recentLocations.length" />
+            </span>
           </v-btn>
-        </v-sheet>
+        </v-btn-toggle>
+
+        <v-window v-model="currentDisplay" disabled>
+          <v-window-item value="osm">
+            <v-form @submit.prevent="search">
+              <v-text-field
+                ref="locationInput" v-model="locationSearchForm.q"
+                :label="$t('LocationSelector.SearchByName')"
+                :hint="$t('Common.ExamplesWithColonAndValue', { value: 'Carrefour rue la fayette 75010 paris ; Auchan Grenoble ; N12208020359' })"
+                type="text" append-inner-icon="mdi-magnify" :rules="[fieldRequired]" :loading="loading" required
+                persistent-hint @click:append-inner="search"
+              />
+            </v-form>
+
+            <p v-if="searchProvider === 'nominatim'" class="text-caption text-warning mt-2">
+              <i18n-t keypath="LocationSelector.Warning" tag="i">
+                <template #newline>
+                  <br>
+                </template>
+              </i18n-t>
+            </p>
+
+            <v-sheet v-if="results">
+              <h3 class="mt-4 mb-1">
+                <i18n-t keypath="LocationSelector.Result" tag="span">
+                  <template #resultNumber>
+                    <small>{{ Array.isArray(results) ? results.length : 0 }}</small>
+                  </template>
+                </i18n-t>
+              </h3>
+              <v-row v-if="Array.isArray(results)">
+                <v-col cols="12" sm="6">
+                  <v-card
+                    v-for="location in results" :key="getLocationUniqueID(location)" class="mb-2" width="100%"
+                    elevation="1" @click="selectLocation(location)"
+                  >
+                    <v-card-text>
+                      <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
+                      {{ getLocationTitle(location, false, true, true) }}<br>
+                      <LocationOSMTagChip :location="location" class="mr-1" />
+                      <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
+                    </v-card-text>
+                  </v-card>
+                </v-col>
+                <v-col cols="12" sm="6" style="min-height:400px">
+                  <LeafletMap :locations="results" />
+                </v-col>
+              </v-row>
+
+              <p v-else-if="typeof results === 'string'">
+                {{ results }}
+              </p>
+            </v-sheet>
+          </v-window-item>
+
+          <v-window-item value="recent">
+            <v-chip
+              v-for="location in recentLocations" :key="getLocationUniqueID(location)" class="mb-2" closable
+              prepend-icon="mdi-history" close-icon="mdi-delete" @click="selectLocation(location)"
+              @click:close="removeRecentLocation(location)"
+            >
+              {{ getLocationTitle(location, true, true, true) }}
+            </v-chip>
+            <br>
+            <v-btn size="small" @click="clearRecentLocations">
+              {{ $t('LocationSelector.Clear') }}
+            </v-btn>
+          </v-window-item>
+        </v-window>
       </v-card-text>
 
       <v-divider />
@@ -103,8 +99,12 @@
         <div>
           <i18n-t keypath="LocationSelector.PoweredBy.text" tag="span">
             <template #url>
-              <a v-if="searchProvider === 'nominatim'" href="https://nominatim.openstreetmap.org" target="_blank">Nominatim (OpenStreetMap)</a>
-              <a v-if="searchProvider === 'photon'" href="https://photon.komoot.io" target="_blank">Komoot Photon (OpenStreetMap)</a>
+              <a
+                v-if="searchProvider === 'nominatim'" href="https://nominatim.openstreetmap.org"
+                target="_blank"
+              >Nominatim (OpenStreetMap)</a>
+              <a v-if="searchProvider === 'photon'" href="https://photon.komoot.io" target="_blank">Komoot Photon
+                (OpenStreetMap)</a>
             </template>
           </i18n-t>
         </div>
@@ -118,10 +118,12 @@ import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
+import constants from '../constants'
 import utils from '../utils.js'
 
 export default {
   components: {
+    LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     LocationOSMTagChip: defineAsyncComponent(() => import('../components/LocationOSMTagChip.vue')),
     LocationOSMIDChip: defineAsyncComponent(() => import('../components/LocationOSMIDChip.vue')),
     LeafletMap: defineAsyncComponent(() => import('../components/LeafletMap.vue')),
@@ -135,8 +137,10 @@ export default {
       },
       loading: false,
       results: null,
-      // search
-      searchProvider: 'photon',  // 'nominatim', 'photon'
+      // config
+      searchProvider: constants.LOCATION_SEARCH_PROVIDER_LIST[1].key,  // photon
+      displayItems: constants.LOCATION_SELECTOR_DISPLAY_LIST,
+      currentDisplay: constants.LOCATION_SELECTOR_DISPLAY_LIST[0].key,
     }
   },
   computed: {
@@ -164,30 +168,30 @@ export default {
       this.loading = true
       // search by id (N12208020359, 12208020359)
       if (utils.isNumber(this.locationSearchForm.q.substring(1))) {
-        const id = utils.isNumber(this.locationSearchForm.q.substring(0, 1)) ? this.locationSearchForm.q : this.locationSearchForm.q.substring(1) 
+        const id = utils.isNumber(this.locationSearchForm.q.substring(0, 1)) ? this.locationSearchForm.q : this.locationSearchForm.q.substring(1)
         api.openstreetmapNominatimLookup(id)
-        .then((data) => {
-          this.loading = false
-          if (data.length) {
-            this.results = data
-          } else {
-            this.results = this.$t('LocationSelector.NoResult')
-          }
-        })
-      // search by name
+          .then((data) => {
+            this.loading = false
+            if (data.length) {
+              this.results = data
+            } else {
+              this.results = this.$t('LocationSelector.NoResult')
+            }
+          })
+        // search by name
       } else {
         api.openstreetmapSearch(this.locationSearchForm.q, this.searchProvider)
-        .then((data) => {
-          this.loading = false
-          if (data.length) {
-            this.results = data
-          } else {
-            this.results = this.$t('LocationSelector.NoResult')
-          }
-        })
+          .then((data) => {
+            this.loading = false
+            if (data.length) {
+              this.results = data
+            } else {
+              this.results = this.$t('LocationSelector.NoResult')
+            }
+          })
       }
     },
-    getLocationTitle(location, withName=true, withRoad=false, withCity=true) {
+    getLocationTitle(location, withName = true, withRoad = false, withCity = true) {
       return utils.getLocationOSMTitle(location, withName, withRoad, withCity)
     },
     getLocationUniqueID(location) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ const LOCATION_TYPE_OSM = 'OSM'
 const LOCATION_TYPE_OSM_ICON = 'mdi-map-marker-outline'
 const LOCATION_TYPE_ONLINE = 'ONLINE'
 const LOCATION_TYPE_ONLINE_ICON = 'mdi-web'
+const OSM_NAME = 'OpenStreetMap'
 
 export default {
   APP_NAME: 'Open Prices',
@@ -128,10 +129,18 @@ export default {
     { key: 'list', value: 'DisplayList', icon: 'mdi-format-list-bulleted' },
     { key: 'map', value: 'DisplayPriceMap', icon: 'mdi-map-marker' },
   ],
+  LOCATION_SEARCH_PROVIDER_LIST: [
+    { key: 'nominatim' },
+    { key: 'photon' },
+  ],
+  LOCATION_SELECTOR_DISPLAY_LIST: [
+    { key: 'osm', value: OSM_NAME, icon: LOCATION_TYPE_OSM_ICON },
+    { key: 'recent', value: 'Recent', icon: 'mdi-history' },
+  ],
   DATE_FULL_REGEX_MATCH: /(\d{4})-(\d{2})-(\d{2})/,
   DATE_YEAR_MONTH_REGEX_MATCH: /(\d{4})-(\d{2})/,
   DATE_YEAR_REGEX_MATCH: /(\d{4})/,
-  OSM_NAME: 'OpenStreetMap',
+  OSM_NAME: OSM_NAME,
   OSM_URL: 'https://www.openstreetmap.org',
   OSM_NOMINATIM_SEARCH_URL: 'https://nominatim.openstreetmap.org/search',
   OSM_NOMINATIM_LOOKUP_URL: 'https://nominatim.openstreetmap.org/lookup',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -208,6 +208,7 @@
 		"LinkCopySuccess": "Link copied",
 		"LocationCount": "{count} locations",
 		"Map": "Map",
+		"Online": "Online",
 		"Order": "Order",
 		"OrderLocationCountDESC": "Location count",
 		"OrderProductUniqueScansDESC": "Number of scans",
@@ -231,6 +232,7 @@
 		"Receipts": "Receipts",
 		"ReceiptPriceCount": "Number of prices",
 		"ReceiptPriceTotal": "Total amount",
+		"Recent": "Recent",
 		"Search": "Search",
 		"Settings": "Settings",
 		"SignInOFFAccount": "Sign in with your {url} account",
@@ -304,7 +306,8 @@
 	},
 	"LocationCard": {
 		"OSM": "OpenStreetMap",
-		"ONLINE": "Online"
+		"ONLINE": "Online",
+		"RECENT": "Recent"
 	},
 	"LocationDetail": {
 		"LatestPrices": "Latest prices",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -304,11 +304,6 @@
 			"Title": "Welcome to {name}!"
 		}
 	},
-	"LocationCard": {
-		"OSM": "OpenStreetMap",
-		"ONLINE": "Online",
-		"RECENT": "Recent"
-	},
 	"LocationDetail": {
 		"LatestPrices": "Latest prices",
 		"LoadMore": "Load more",

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -51,7 +51,7 @@
       <StatCard :value="stats.location_type_osm_count" :subtitle="OSM_NAME" />
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.location_type_online_count" :subtitle="$t('LocationCard.ONLINE')" />
+      <StatCard :value="stats.location_type_online_count" :subtitle="$t('Common.Online')" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

Location selector: new tabs at the top to toggle between OpenStreetMap search & Recent locations.

### Why

- to move the recent locations to a dedicated section
- to prepare for a "Online" tab

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/ad62c4b1-c3a7-485a-ba1e-65ad8f3c1f76)|![image](https://github.com/user-attachments/assets/a69674b0-47e2-447e-9858-593575e8ecf9)|
