### PR TITLE
refactor(Settings): Move some settings to a new 'Developer mode' section

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -186,6 +186,7 @@
 		"DateMissing": "Date missing",
 		"Details": "Details",
 		"Delete": "Delete",
+		"DeveloperMode": "Developer mode",
 		"Discount": "Discount",
 		"Example": "Example",
 		"Examples": "Examples",

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -59,8 +59,38 @@
               <v-icon size="small" icon="mdi-open-in-new" />
             </a>
           </p>
+        </v-card-text>
+      </v-card>
+    </v-col>
+
+    <!-- Prices -->
+    <v-col cols="12" sm="6">
+      <v-card :title="$t('Common.Prices')" prepend-icon="mdi-tag-multiple-outline">
+        <v-divider />
+        <v-card-text>
+          <h3 class="mb-1">
+            {{ $t('UserSettings.FavoriteCurrencies') }}
+          </h3>
+          <v-autocomplete
+            v-model="appStore.user.favorite_currencies"
+            :label="$t('UserSettings.CurrencyLabel')"
+            :items="currencyList"
+            :rules="[v => !!(v && v.length) || $t('UserSettings.CurrencyRequired')]"
+            chips
+            closable-chips
+            multiple
+            hide-details="auto"
+          />
+        </v-card-text>
+      </v-card>
+    </v-col>
+
+    <v-col cols="12" sm="6">
+      <v-card :title="$t('Common.DeveloperMode')" prepend-icon="mdi-test-tube">
+        <v-divider />
+        <v-card-text>
           <!-- Side menu -->
-          <h3 class="mt-4 mb-1">
+          <h3 class="mb-1">
             {{ $t('Common.SideMenu') }}
           </h3>
           <v-switch
@@ -104,28 +134,6 @@
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'N652825274' })"
             density="compact"
             persistent-hint
-            hide-details="auto"
-          />
-        </v-card-text>
-      </v-card>
-    </v-col>
-
-    <!-- Prices -->
-    <v-col cols="12" sm="6">
-      <v-card :title="$t('Common.Prices')" prepend-icon="mdi-tag-multiple-outline">
-        <v-divider />
-        <v-card-text>
-          <h3 class="mb-1">
-            {{ $t('UserSettings.FavoriteCurrencies') }}
-          </h3>
-          <v-autocomplete
-            v-model="appStore.user.favorite_currencies"
-            :label="$t('UserSettings.CurrencyLabel')"
-            :items="currencyList"
-            :rules="[v => !!(v && v.length) || $t('UserSettings.CurrencyRequired')]"
-            chips
-            closable-chips
-            multiple
             hide-details="auto"
           />
         </v-card-text>


### PR DESCRIPTION
### What

Following #1029
Split the 'Display' section, and move some over to a new 'Developer mode'

### Why

- 'Display' section was getting too big
- Many apps have a 'Developer mode', these stuff belong there

### Screenshot

![image](https://github.com/user-attachments/assets/cdd00b4d-fa25-4ee2-8034-d7bb38c21e51)
