### PR TITLE
feat: new page to list known reuses

### DIFF
--- a/src/data/reuses.json
+++ b/src/data/reuses.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "Map (Shiny)",
+        "description": "A world map of all the contributions in Open Prices",
+        "background_image_url": null,
+        "url": "https://dmayaux.shinyapps.io/open_prices",
+        "code_url": null,
+        "date": "2024",
+        "author": "Damien",
+        "display": true
+    },
+    {
+        "name": "Le prix des carottes",
+        "description": "Simple price index of fruits and vegetables (in french)",
+        "background_image_url": null,
+        "url": "https://leprixdescarottes.fr",
+        "code_url": "https://github.com/TTalex/leprixdescarottes",
+        "date": "2024",
+        "author": "Alex",
+        "display": true
+    },
+    {
+        "name": "Do you want your receipt?",
+        "description": "Compare prices between 2 shops",
+        "background_image_url": null,
+        "url": "https://www.doyouwantyourreceipt.info",
+        "code_url": null,
+        "date": "2024",
+        "author": "Quentin",
+        "display": true
+    },
+    {
+        "name": "Product price evolution",
+        "description": null,
+        "background_image_url": null,
+        "url": "https://project.med3d.eu/fooddata/price_plot.html?ean=5000159451666",
+        "code_url": null,
+        "date": "2024",
+        "author": null,
+        "display": true
+    }
+]

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -488,6 +488,9 @@
 		"MyProofs": {
 			"Title": "My proofs"
 		},
+		"Reuses": {
+			"Title": "Reuses"
+		},
 		"Search": {
 			"Title": "Search"
 		},

--- a/src/router.js
+++ b/src/router.js
@@ -33,6 +33,7 @@ const routes = [
   { path: '/users', name: 'users', component: () => import('./views/UserList.vue'), meta: { title: 'TopContributors', icon: 'mdi-account-star-outline', drawerMenu: true, breadcrumbs: [{title: 'TopContributors', disabled: true }] }},
   { path: '/users/:username', name: 'user-detail', component: () => import('./views/UserDetail.vue'), meta: { title: 'User detail' }},
   { path: '/experiments', name: 'experiments', component: () => import('./views/Experiments.vue'), meta: { title: 'Experiments', icon: 'mdi-test-tube', drawerMenu: true, drawerMenuConditionalDisplay: 'drawer_display_experiments', breadcrumbs: [{title: 'Experiments', disabled: true }] }},
+  { path: '/reuses', name: 'reuses', component: () => import('./views/Reuses.vue'), meta: { title: 'Reuses', icon: 'mdi-account-group', drawerMenu: true, breadcrumbs: [{title: 'Reuses', disabled: true }] }},
   { path: '/stats', name: 'stats', component: () => import('./views/Stats.vue'), meta: { title: 'Stats', icon: 'mdi-chart-box-outline', drawerMenu: true, breadcrumbs: [{title: 'Stats', disabled: true }] }},
   { path: '/settings', name: 'settings', component: () => import('./views/Settings.vue'), meta: { title: 'Settings', icon: 'mdi-cog-outline', drawerMenu: true, breadcrumbs: [{title: 'Settings', disabled: true }] }},
   { path: '/about', name: 'about', component: () => import('./views/About.vue'), meta: { title: 'About', icon: 'mdi-information-outline', drawerMenu: true, breadcrumbs: [{title: 'About', disabled: true }] }},

--- a/src/views/Reuses.vue
+++ b/src/views/Reuses.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-row>
+    <v-col v-for="reuse in reusesList" :key="reuse.id" cols="12" sm="6" md="4" xl="3">
+      <v-card height="100%">
+        <v-img :src="reuse.background_image_url" height="200px" />
+        <v-card-title>{{ reuse.name }}</v-card-title>
+        <v-card-text>{{ reuse.description }}</v-card-text>
+        <v-card-actions>
+          <v-btn color="primary" append-icon="mdi-open-in-new" :href="reuse.url" target="_blank" title="View">
+            View
+          </v-btn>
+          <v-spacer />
+          <v-btn v-if="reuse.code_url" icon="mdi-xml" :href="reuse.code_url" target="_blank" title="Source code" />
+        </v-card-actions>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import Reuses from '../data/reuses.json'
+
+export default {
+  computed: {
+    reusesList() {
+      return Reuses.filter(r => r.display)
+    },
+  }
+}
+</script>


### PR DESCRIPTION
### What

New page to list reuses.
New `reuses.json` to store the details of each reuse (move this to the backend + API in a v2 ?)

### Screenshot

![image](https://github.com/user-attachments/assets/5dc29167-4f76-4109-baab-8da625d0e52b)

### Related discussion

https://github.com/openfoodfacts/open-prices/discussions/562