### PR TITLE
refactor(API): send the page url on every POST

### DIFF
--- a/src/components/ProofInputRow.vue
+++ b/src/components/ProofInputRow.vue
@@ -168,7 +168,7 @@ export default {
       })
       .then((proofImageCompressed) => {
         api
-          .createProof(proofImageCompressed, this.proofForm)
+          .createProof(proofImageCompressed, this.proofForm, this.$route.path)
           .then((data) => {
             this.loading = false
             if (data.id) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -15,6 +15,7 @@ const OP_DEFAULT_HEADERS = {
 }
 const OP_DEFAULT_PARAMS = {
   'app_name': constants.APP_USER_AGENT
+  // 'app_version'  // hack to store price/proof create source
 }
 
 function buildURLParams(params = {}) {
@@ -68,10 +69,8 @@ export default {
     })
     .then((response) => response.json())
   },
-  createProof(image, inputData) {
-    console.log('createProof', inputData)
+  createProof(image, inputData, source = null) {
     const data = filterBodyWithAllowedKeys(inputData, PROOF_CREATE_FIELDS)
-    console.log('createProof', data)
     const store = useAppStore()
     let formData = new FormData()
     formData.append('file', image, image.name)
@@ -92,7 +91,7 @@ export default {
         formData.append('receipt_price_total', data.receipt_price_total)
       }
     }
-    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/upload?${buildURLParams()}`
+    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/upload?${buildURLParams({'app_version': source})}`
     return fetch(url, {
       method: 'POST',
       headers: {
@@ -156,11 +155,11 @@ export default {
     // .then((response) => response.json())
   },
 
-  createPrice(inputData) {
+  createPrice(inputData, source = null) {
     const data = filterBodyWithAllowedKeys(inputData, PRICE_CREATE_FIELDS)
     const store = useAppStore()
     store.user.last_product_mode_used = data.product_code ? 'barcode' : 'category'
-    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/prices?${buildURLParams()}`
+    const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/prices?${buildURLParams({'app_version': source})}`
     return fetch(url, {
       method: 'POST',
       headers: Object.assign({}, OP_DEFAULT_HEADERS, {

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -296,7 +296,7 @@ export default {
       }
       // create price
       api
-        .createPrice(Object.assign({}, this.addPriceMultipleForm, this.productPriceForm))
+        .createPrice(Object.assign({}, this.addPriceMultipleForm, this.productPriceForm), this.$route.path)
         .then((data) => {
           if (data['detail']) {
             alert(`Error: with input ${data['detail'][0]['input']}`)

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -194,7 +194,7 @@ export default {
       }
       // create price
       api
-        .createPrice(this.addPriceSingleForm)
+        .createPrice(this.addPriceSingleForm, this.$route.path)
         .then((data) => {
           if (data['detail']) {
             alert(`Error: with input ${data['detail'][0]['input']}`)

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -227,7 +227,7 @@ export default {
             error: reject
           })
         })
-        proof = await api.createProof(proofImageCompressed, Object.assign({type: 'PRICE_TAG'}, this.locationForm, this.proofMetadataForm))
+        proof = await api.createProof(proofImageCompressed, Object.assign({type: 'PRICE_TAG'}, this.locationForm, this.proofMetadataForm), this.$route.path)
       }
       
       for (let i = 0; i < this.productPriceForms.length; i++) {
@@ -257,7 +257,7 @@ export default {
           delete priceData.product_code
           delete priceData.product
         }
-        await api.createPrice(priceData) // TODO: error handling
+        await api.createPrice(priceData, this.$route.path) // TODO: error handling
         this.productPriceForms[i].processed = true
       }
       this.addPricesLoading = false


### PR DESCRIPTION
### What

Following #1034 & #1025.
A bit of a hack, where we send the user's current page URL on each POST.

### Why

To have some stats on where the proofs & prices are created (as we have multiple forms now).
