### PR TITLE
refactor(ContributionAssistant): More UX tweaks following feedback

### DIFF
--- a/src/components/ContributionAssistantDrawCanvas.vue
+++ b/src/components/ContributionAssistantDrawCanvas.vue
@@ -20,7 +20,7 @@
         default: null
       }
     },
-    emits: ['croppedImages'],
+    emits: ['croppedImages', 'loaded'],
     data() {
       return {
         isDrawing: false,
@@ -30,9 +30,11 @@
         rectangles: []
       }
     },
-    watch: {
-      image(newImage) {
-        newImage.onload = this.init
+    mounted() {
+      if (this.image.complete) {
+        this.init()
+      } else {
+        this.image.onload = this.init
       }
     },
     methods: {
@@ -59,6 +61,7 @@
         
         this.rectangles = [] // reset rectangles
         this.drawRectangles(); // Draw previous rectangles after resizing
+        this.$emit('loaded')
       },
       startDrawing(event) {
         if (event.type == "touchstart") {

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -16,6 +16,14 @@
     />
     <v-card-text>
       <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingModes="true" @filled="productFormFilled = $event" />
+      <v-alert
+        v-if="productPriceForm.mode === 'barcode'"
+        class="mb-2"
+        type="info"
+        variant="plain"
+      >
+        Detected barcode: {{ productPriceForm.detected_product_code }}
+      </v-alert>
       <v-row>
         <v-col>
           <h3 class="required mb-1">
@@ -60,7 +68,8 @@ export default {
         price_without_discount: null,
         currency: null,
         proofImage: null,
-        processed: null
+        processed: null,
+        detected_product_code: null
       })
     },
   },

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -3,19 +3,13 @@
   <v-card
     class="mb-4"
     height="100%"
+    title="Label"
+    prepend-icon="mdi-tag-outline"
     style="border: 1px solid transparent"
   >
-    <v-card-item>
-      <template #prepend>
-        <v-icon icon="mdi-tag-outline" />
-      </template>
-      <h2 class="text-h6">
-        Label
-      </h2>
-      <template #append>
-        <v-btn icon="mdi-delete" @click="removePrice()" />
-      </template>
-    </v-card-item>
+    <template #append>
+      <v-icon icon="mdi-delete" color="error" @click="removePrice()" />
+    </template>
     <v-divider />
     <v-img
       height="200px"

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -2,12 +2,20 @@
 <template>
   <v-card
     class="mb-4"
-    title="Label"
-    prepend-icon="mdi-tag-outline"
     height="100%"
     style="border: 1px solid transparent"
-    :color="productPriceForm.processed ? 'success' : ''"
   >
+    <v-card-item>
+      <template #prepend>
+        <v-icon icon="mdi-tag-outline" />
+      </template>
+      <h2 class="text-h6">
+        Label
+      </h2>
+      <template #append>
+        <v-btn icon="mdi-delete" @click="removePrice()" />
+      </template>
+    </v-card-item>
     <v-divider />
     <v-img
       height="200px"
@@ -73,21 +81,21 @@ export default {
       })
     },
   },
+  emits: ['removePrice'],
   data() {
-  return {
-    productFormFilled: false,
-    pricePriceFormFilled: false,
-    categoryPricePerList: [
-    {key: 'KILOGRAM', value: "per kg", icon: 'mdi-weight-kilogram'},
-    {key: 'UNIT', value: "per unit", icon: 'mdi-numeric-1-circle'}
-    ],
-   }
-  },
-  computed: {
-  },
-  mounted() {
+    return {
+      productFormFilled: false,
+      pricePriceFormFilled: false,
+      categoryPricePerList: [
+      {key: 'KILOGRAM', value: "per kg", icon: 'mdi-weight-kilogram'},
+      {key: 'UNIT', value: "per unit", icon: 'mdi-numeric-1-circle'}
+      ],
+    }
   },
   methods: {
+    removePrice() {
+      this.$emit('removePrice')
+    }
   }
 }
 </script>

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -29,7 +29,7 @@
           <h3 class="required mb-1">
             Price
           </h3>
-          <h3 class="mb-1">
+          <h3 v-if="productPriceForm.mode == 'category'" class="mb-1">
             <v-item-group v-model="productPriceForm.price_per" class="d-inline" mandatory>
               <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
                 <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -221,7 +221,8 @@ export default {
           price_is_discounted: false,
           currency: this.appStore.getUserLastCurrencyUsed || 'EUR',
           proofImage: this.croppedImages[i],
-          product_code: label.barcode.toString()
+          product_code: label.barcode.toString(),
+          detected_product_code: label.barcode.toString()
         }
         this.productPriceForms.push(productPriceForm)
       }

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -40,13 +40,13 @@
             </v-col>
           </v-row>
           <v-row>
-            <v-col cols="12" md="6">
+            <v-col cols="12" lg="6">
               <h3 class="mb-4">
                 2. Draw squares around the labels
               </h3>
               <ContributionAssistantDrawCanvas ref="ContributionAssistantdrawCanvas" :image="image" @croppedImages="onCroppedImages($event)" />
             </v-col>
-            <v-col cols="12" md="6">
+            <v-col cols="12" lg="6">
               <h3 class="mb-4">
                 3. Check the readability of labels
               </h3>
@@ -73,6 +73,7 @@
               :key="index"
               cols="12"
               md="6"
+              xl="4"
             >
               <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" />
             </v-col>

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -1,16 +1,16 @@
 <template>
   <v-container>
     <v-tabs v-model="tab">
-      <v-tab value="LocationDate">
+      <v-tab value="LocationDate" :disabled="disableLocationDateTab">
         1. Location & Date
       </v-tab>
-      <v-tab value="Crop" :disabled="!locationForm.location_osm_id">
+      <v-tab value="Crop" :disabled="disableCropTab">
         2. Image crop
       </v-tab>
-      <v-tab value="Cleanup" :disabled="!productPriceForms.length">
+      <v-tab value="Cleanup" :disabled="disableCleanupTab">
         3. Cleanup
       </v-tab>
-      <v-tab value="Summary" :disabled="!(productPriceForms.length && (addPricesLoading || productPriceForms.length == numberOfPricesAdded))">
+      <v-tab value="Summary" :disabled="disableSummaryTab">
         4. Summary
       </v-tab>
     </v-tabs>
@@ -128,13 +128,13 @@
               >
                 <strong>{{ numberOfPricesAdded }} / {{ productPriceForms.length }} prices added</strong>
               </v-progress-linear>
-              <v-btn to="/dashboard" class="mt-4" :aria-label="$t('Common.Dashboard')" :disabled="productPriceForms.length != numberOfPricesAdded">
+              <v-btn to="/dashboard" class="mt-4" :aria-label="$t('Common.Dashboard')" :disabled="addPricesLoading">
                 Go to your dashboard
               </v-btn>
-              <v-btn v-if="recentProof" :to="'/proofs/' + recentProof.id" class="mt-4 ml-4" :disabled="productPriceForms.length != numberOfPricesAdded" @click="tab = 'Crop'">
+              <v-btn v-if="recentProof" :to="'/proofs/' + recentProof.id" class="mt-4 ml-4" :disabled="addPricesLoading">
                 Go to proof
               </v-btn>
-              <v-btn class="mt-4 ml-4" :disabled="productPriceForms.length != numberOfPricesAdded" @click="tab = 'Crop'">
+              <v-btn class="mt-4 ml-4" :disabled="addPricesLoading" @click="tab = 'Crop'">
                 Add a new image for location
               </v-btn>
             </v-col>
@@ -197,6 +197,25 @@ export default {
         return utils.getLocationOSMTitle(location, true, true, true)
       }
       return ''
+    },
+    disableLocationDateTab() {
+      // LocationDate tab should disabled during api calls to add prices
+      return this.addPricesLoading
+    },
+    disableCropTab() {
+      // Crop tab should only be enabled after the location is selected
+      // It should also be disabled during api calls to add prices
+      return !this.locationForm.location_osm_id || this.addPricesLoading
+    },
+    disableCleanupTab() {
+      // Cleanup tab should only be enabled after the gemini analysis is done
+      // It should also be disabled during api calls to add prices
+      return !this.productPriceForms.length || this.addPricesLoading
+    },
+    disableSummaryTab() {
+      // Summary tab should be enabled when there are product prices to be added and the add prices process is either running or done
+      const enableSummaryTab = this.productPriceForms.length && (this.addPricesLoading || this.productPriceForms.length == this.numberOfPricesAdded)
+      return !enableSummaryTab
     }
   },
   mounted() {

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container>
     <v-tabs v-model="tab">
-      <v-tab value="LocationDate" :disabled="disableLocationDateTab">
-        1. Location & Date
+      <v-tab value="ProofSelect" :disabled="disableProofSelectTab">
+        1. Proof selection
       </v-tab>
       <v-tab value="Crop" :disabled="disableCropTab">
         2. Image crop
@@ -15,16 +15,11 @@
       </v-tab>
     </v-tabs>
     <v-tabs-window v-model="tab">
-      <v-tabs-window-item value="LocationDate">
+      <v-tabs-window-item value="ProofSelect">
         <v-container>
           <v-row>
             <v-col cols="12" md="6">
-              <LocationInputRow :locationForm="locationForm" />
-              <ProofMetadataInputRow :proofMetadataForm="proofMetadataForm" />
-              <br>
-              <v-btn class="mt-4" color="success" :disabled="!locationForm.location_osm_id" @click="tab='Crop'">
-                Next
-              </v-btn>
+              <ProofInputRow :proofForm="proofForm" @proof="setProof($event)" />
             </v-col>
           </v-row>
         </v-container>
@@ -32,26 +27,16 @@
       <v-tabs-window-item value="Crop">
         <v-container>
           <v-row>
-            <v-col cols="12">
-              <h3 class="mb-4">
-                1. Select an image containing labels
-              </h3>
-              <ProofImageInputRow :hideProofImagePreview="true" :hideRecentProofChoice="false" @proof="setProof($event)" />
-              <p v-if="recentProof" class="mb-2">
-                <i>Selecting a recent proof has overwritten location, date and currency.</i>
-              </p>
-            </v-col>
-          </v-row>
-          <v-row>
             <v-col cols="12" lg="6">
               <h3 class="mb-4">
-                2. Draw squares around the labels
+                1. Draw squares around the labels
               </h3>
-              <ContributionAssistantDrawCanvas ref="ContributionAssistantdrawCanvas" :image="image" @croppedImages="onCroppedImages($event)" />
+              <v-progress-circular v-if="!drawCanvasLoaded" indeterminate />
+              <ContributionAssistantDrawCanvas ref="ContributionAssistantdrawCanvas" :image="image" @croppedImages="onCroppedImages($event)" @loaded="drawCanvasLoaded = true" />
             </v-col>
             <v-col cols="12" lg="6">
               <h3 class="mb-4">
-                3. Check the readability of labels
+                2. Check the readability of labels
               </h3>
               <ContributionAssistantCropImageList :croppedImages="croppedImages" @removeCrop="removeCrop($event)" />
             </v-col>
@@ -59,7 +44,7 @@
           <v-row>
             <v-col cols="12">
               <h3 class="mb-4">
-                4. Send the cropped images for automatic processing
+                3. Send the cropped images for automatic processing
               </h3>
               <v-btn color="success" :disabled="!croppedImages.length" :loading="processCroppedImagesLoading" @click="processCroppedImages">
                 Process Cropped Images
@@ -88,11 +73,8 @@
                 type="info"
                 variant="outlined"
               >
-                <p v-if="recentProof">
-                  {{ productPriceForms.length }} price{{ productPriceForms.length > 1 ? 's' : '' }} will be added to an existing proof on the {{ recentProof.date }} at {{ locationName }}.
-                </p>
-                <p v-if="!recentProof">
-                  1 proof and {{ productPriceForms.length }} price{{ productPriceForms.length > 1 ? 's' : '' }} will be added on the {{ proofMetadataForm.date }} at {{ locationName }}.
+                <p>
+                  {{ productPriceForms.length }} price{{ productPriceForms.length > 1 ? 's' : '' }} will be added to an existing proof on the {{ proofForm.date }} at {{ locationName }}.
                 </p>
               </v-alert>
               <v-btn class="mt-4" color="success" :loading="addPricesLoading" @click="addPrices">
@@ -110,16 +92,6 @@
                 Please wait for upload
               </h3>
               <v-progress-linear
-                v-if="addProofLoading"
-                color="info"
-                height="25"
-                stripped
-                indeterminate
-              >
-                <strong>Uploading proof...</strong>
-              </v-progress-linear>
-              <v-progress-linear
-                v-if="!addProofLoading"
                 v-model="numberOfPricesAdded"
                 :max="productPriceForms.length"
                 :color="productPriceForms.length == numberOfPricesAdded ? 'success' : 'info'"
@@ -128,14 +100,14 @@
               >
                 <strong>{{ numberOfPricesAdded }} / {{ productPriceForms.length }} prices added</strong>
               </v-progress-linear>
-              <v-btn to="/dashboard" class="mt-4" :aria-label="$t('Common.Dashboard')" :disabled="addPricesLoading">
+              <v-btn to="/dashboard" class="mt-4" :aria-label="$t('Common.Dashboard')" :disabled="!allDone">
                 Go to your dashboard
               </v-btn>
-              <v-btn v-if="recentProof" :to="'/proofs/' + recentProof.id" class="mt-4 ml-4" :disabled="addPricesLoading">
+              <v-btn :to="'/proofs/' + proofForm.id" class="mt-4 ml-4" :disabled="!allDone">
                 Go to proof
               </v-btn>
-              <v-btn class="mt-4 ml-4" :disabled="addPricesLoading" @click="tab = 'Crop'">
-                Add a new image for location
+              <v-btn class="mt-4 ml-4" :disabled="!allDone" @click="reloadPage">
+                Add a new proof
               </v-btn>
             </v-col>
           </v-row>
@@ -146,44 +118,41 @@
 </template>
 
 <script>
-import Compressor from 'compressorjs'
 import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
 import utils from '../utils.js'
+import constants from '../constants'
 
 export default {
   components: {
     ContributionAssistantPriceFormCard: defineAsyncComponent(() => import('../components/ContributionAssistantPriceFormCard.vue')),
-    LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
-    ProofImageInputRow: defineAsyncComponent(() => import('../components/ProofImageInputRow.vue')),
     ContributionAssistantDrawCanvas: defineAsyncComponent(() => import('../components/ContributionAssistantDrawCanvas.vue')),
     ContributionAssistantCropImageList: defineAsyncComponent(() => import('../components/ContributionAssistantCropImageList.vue')),
-    ProofMetadataInputRow: defineAsyncComponent(() => import('../components/ProofMetadataInputRow.vue')),
+    ProofInputRow: defineAsyncComponent(() => import('../components/ProofInputRow.vue')),
   },
   data() {
     return {
-      tab: 'LocationDate',
-      originalProofImage: null,
-      recentProof: null,
+      tab: 'ProofSelect',
+      drawCanvasLoaded: false,
       image: new Image(),
       croppedImages: [],
       croppedBlobs: [],
       productPriceForms : [],
-      locationForm: {
+      proofForm: {
+        type: constants.PROOF_TYPE_PRICE_TAG,
+        id: null,
+        location_id: null,
         location_osm_id: null,
-        location_osm_type: null
-      },
-      proofMetadataForm: {
+        location_osm_type: null,
         date: utils.currentDate(),
         currency: null,
         receipt_price_count: null,
-        receipt_price_total: null
+        receipt_price_total: null,
       },
       processCroppedImagesLoading: false,
       addPricesLoading: false,
-      addProofLoading: false,
       numberOfPricesAdded: 0
     }
   },
@@ -191,66 +160,54 @@ export default {
     ...mapStores(useAppStore),
     locationName() {
       const recentLocations = this.appStore.getRecentLocations()
-      const location = recentLocations.find((location) => location.properties.osm_id === this.locationForm.location_osm_id)
+      const location = recentLocations.find((location) => location.properties.osm_id === this.proofForm.location_osm_id)
       if (location) {
         if (location.type === 'ONLINE') return location.website_url
         return utils.getLocationOSMTitle(location, true, true, true)
       }
       return ''
     },
-    disableLocationDateTab() {
-      // LocationDate tab should disabled during api calls to add prices
-      return this.addPricesLoading
+    disableProofSelectTab() {
+      // ProofSelect tab should disabled on summary step
+      return this.tab == "Summary"
     },
     disableCropTab() {
-      // Crop tab should only be enabled after the location is selected
-      // It should also be disabled during api calls to add prices
-      return !this.locationForm.location_osm_id || this.addPricesLoading
+      // Crop tab should only be enabled after the proof is selected
+      // It should also be disabled on summary step
+      return !this.proofForm.id || this.tab == "Summary"
     },
     disableCleanupTab() {
-      // Cleanup tab should only be enabled after the gemini analysis is done
-      // It should also be disabled during api calls to add prices
-      return !this.productPriceForms.length || this.addPricesLoading
+      // Cleanup tab should only be enabled after the ai analysis is done
+      // It should also be disabled on summary step
+      return !this.productPriceForms.length || this.tab == "Summary"
+    },
+    allDone() {
+      return this.numberOfPricesAdded > 0 && this.productPriceForms.length == this.numberOfPricesAdded
     },
     disableSummaryTab() {
       // Summary tab should be enabled when there are product prices to be added and the add prices process is either running or done
-      const enableSummaryTab = this.productPriceForms.length && (this.addPricesLoading || this.productPriceForms.length == this.numberOfPricesAdded)
+      const enableSummaryTab = this.productPriceForms.length && (this.addPricesLoading || this.allDone)
       return !enableSummaryTab
     }
   },
   mounted() {
-    this.proofMetadataForm.currency = this.appStore.getUserLastCurrencyUsed
+    this.proofForm.currency = this.appStore.getUserLastCurrencyUsed
   },
   methods: {
+    reloadPage(){
+      window.location.reload()
+    },
     setProof(event) {
-      if (event instanceof File) {
-        // A new file was selected
-        this.recentProof = null
-        this.originalProofImage = event
-        const reader = new FileReader()
-        reader.onload = (e) => {
-          const image = new Image()
-          image.src = e.target.result
-          this.image = image
-        };
-        reader.readAsDataURL(event)
-      } else {
-        // An existing proof was selected
-        this.recentProof = event
-        this.originalProofImage = null
-        const image = new Image()
-        image.src = `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${event.file_path}`
-        image.crossOrigin = 'Anonymous'
-        this.image = image
-        this.proofMetadataForm.date = event.date
-        this.proofMetadataForm.currency = event.currency
-        this.locationForm.location_osm_id = event.location_osm_id
-        this.locationForm.location_osm_type = event.location_osm_type
-      }
+      const image = new Image()
+      image.src = `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${event.file_path}`
+      image.crossOrigin = 'Anonymous'
+      this.image = image
+      this.proofForm = event
 
       this.croppedImages = []
       this.croppedBlobs = []
       this.productPriceForms = []
+      this.tab = "Crop"
     },
     onCroppedImages(eventData) {
       this.croppedImages = eventData[0]
@@ -299,19 +256,6 @@ export default {
       this.addPricesLoading = true
       this.numberOfPricesAdded = 0
       this.tab = "Summary"
-      let proof = this.recentProof // Can be null if new proof
-      if (!proof) { // Implies an originalProofImage was set
-        this.addProofLoading = true
-        const proofImageCompressed = await new Promise((resolve, reject) => {
-          new Compressor(this.originalProofImage, {
-            success: resolve,
-            error: reject
-          })
-        })
-        proof = await api.createProof(proofImageCompressed, Object.assign({type: 'PRICE_TAG'}, this.locationForm, this.proofMetadataForm), this.$route.path)
-        this.addProofLoading = false
-      }
-      this.recentProof = proof
       
       for (let i = 0; i < this.productPriceForms.length; i++) {
         const productPriceForm = this.productPriceForms[i]
@@ -325,11 +269,11 @@ export default {
         const priceData = {
           ...productPriceForm,
           origins_tags: origins_tags,
-          date: proof.date,
-          location_id: proof.location_id,
-          location_osm_id: proof.location_osm_id,
-          location_osm_type: proof.location_osm_type,
-          proof_id: proof.id
+          date: this.proofForm.date,
+          location_id: this.proofForm.location_id,
+          location_osm_id: this.proofForm.location_osm_id,
+          location_osm_type: this.proofForm.location_osm_type,
+          proof_id: this.proofForm.id
         }
         // Cleanup unwanted fields for API
         if (productPriceForm.mode == 'barcode') {

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -75,7 +75,7 @@
               md="6"
               xl="4"
             >
-              <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" />
+              <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" @removePrice="removePrice(index)" />
             </v-col>
           </v-row>
           <v-row>
@@ -228,6 +228,9 @@ export default {
         this.productPriceForms.push(productPriceForm)
       }
       this.tab = 'Cleanup'
+    },
+    removePrice(index) {
+      this.productPriceForms.splice(index, 1)
     },
     async addPrices() {
       this.addPricesLoading = true


### PR DESCRIPTION
### What
- Display detected barcode below product suggestion, to compare
- Show more cols on larger screens
- Hide "price per" input when barcode is selected
- Allow for price removal at the cleanup step, with a trashcan icon
- Add a 4th step: Summary, with progress bars tracking proof and price uploads and navigation buttons to user profile, added proof or to go back to the image selection step

### Screenshots
![tweaks](https://github.com/user-attachments/assets/c953981c-5595-4e37-bfc0-3216a0e1c097)
![summary](https://github.com/user-attachments/assets/0a52d58e-1838-4d13-8edd-26125a2563e8)


### Part of 
- #1025
