### PR TITLE
fix(ContributionAssistant): remove labels_tags param when sending barcodes

### DIFF
--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -281,6 +281,7 @@ export default {
           delete priceData.price_per
           delete priceData.category_tag
           delete priceData.origins_tags
+          delete priceData.labels_tags
         } else if (productPriceForm.mode == 'category') {
           delete priceData.product_code
           delete priceData.product


### PR DESCRIPTION
### What
- In some rare cases, gemini sets the `labels_tags` to organic for images with barcodes.
- This is not supported by the API: `labels_tags [ "Should not be set if 'product_code' is filled" ]`
- This PR removes the field before calling the API
