### PR TITLE
refactor(UI): right-align all submit buttons. change color of Done buttons

### DIFF
--- a/src/components/BarcodeManualInputDialog.vue
+++ b/src/components/BarcodeManualInputDialog.vue
@@ -18,15 +18,11 @@
             prepend-inner-icon="mdi-barcode"
             :hint="barcodeForm.barcode.length.toString()"
             persistent-hint
-          />
-
-          <v-btn
-            type="submit"
-            class="mt-2"
-            :disabled="!formFilled"
           >
-            {{ $t('BarcodeManualInput.Submit') }}
-          </v-btn>
+            <template #append-inner>
+              <v-icon icon="mdi-plus" :disabled="!formFilled" @click="onSubmit" />
+            </template>
+          </v-text-field>
         </v-form>
       </v-card-text>
     </v-card>

--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -42,6 +42,7 @@
 
       <v-card-actions>
         <v-btn
+          class="float-right"
           color="success"
           variant="flat"
           elevation="1"

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -22,6 +22,7 @@
 
       <v-card-actions>
         <v-btn
+          class="float-right"
           color="success"
           variant="flat"
           elevation="1"

--- a/src/components/ProofInputRow.vue
+++ b/src/components/ProofInputRow.vue
@@ -8,7 +8,13 @@
       <ProofMetadataInputRow :proofType="proofForm.type" :proofMetadataForm="proofForm" />
       <v-row>
         <v-col>
-          <v-btn color="success" :loading="loading" :disabled="!proofFormFilled || loading" @click="uploadProofList">
+          <v-btn
+            class="float-right"
+            color="success"
+            :loading="loading"
+            :disabled="!proofFormFilled || loading"
+            @click="uploadProofList"
+          >
             <span v-if="!multiple">{{ $t('Common.Upload') }}</span>
             <span v-else>{{ $t('Common.UploadMultipleImages', proofImageList.length) }}</span>
           </v-btn>

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -102,7 +102,7 @@
             </v-row>
           </v-card-text>
           <v-divider />
-          <v-card-text>
+          <v-card-text class="float-right">
             <v-btn
               color="success"
               type="submit"
@@ -118,7 +118,6 @@
       <v-btn
         class="float-right"
         type="submit"
-        color="success"
         :loading="createPriceLoading"
         :disabled="productPriceFormFilled"
         @click="done"

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -71,6 +71,7 @@
       <v-col>
         <v-btn
           type="submit"
+          class="float-right"
           :color="formFilled ? 'success' : ''"
           :loading="createPriceLoading"
           :disabled="!formFilled"

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -22,6 +22,7 @@
   <v-row>
     <v-col>
       <v-btn
+        class="float-right"
         type="submit"
         :color="proofFormFilled ? 'success' : ''"
         :loading="loading"

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -22,6 +22,7 @@
   <v-row>
     <v-col>
       <v-btn
+        class="float-right"
         type="submit"
         :color="proofFormFilled ? 'success' : ''"
         :loading="loading"


### PR DESCRIPTION
### What

After some extensive price-adding with Justin this weekend, first of a few PRs to sightly improve the UI.

Submit buttons : 
- always right-align (people hold their phones with their right hand... though I'm left-handed ^^)
- avoid confusion between Submit & Done buttons

### Screenshot

|Page|Before|After|
|---|---|---|
|Add multiple prices|![image](https://github.com/user-attachments/assets/4e49b5af-998e-4b55-83ba-0f1e386a43a2)|![image](https://github.com/user-attachments/assets/b3e89309-a9bb-4628-a70c-1dc7ab740260)|