### PR TITLE
refactor(Price add): show count & sum of already added prices (receipts)

### DIFF
--- a/src/components/PriceAlreadyUploadedListCard.vue
+++ b/src/components/PriceAlreadyUploadedListCard.vue
@@ -10,7 +10,9 @@
     <template #append>
       <v-icon icon="mdi-checkbox-marked-circle" color="success" />
     </template>
+
     <v-divider />
+
     <v-card-text>
       <v-row>
         <v-col v-for="productPriceUploaded in proofPriceUploadedList" :key="productPriceUploaded" cols="12">
@@ -18,12 +20,29 @@
         </v-col>
       </v-row>
     </v-card-text>
+
+    <v-divider v-if="proofPriceUploadedList.length" />
+
+    <v-card-actions v-if="proofPriceUploadedList.length">
+      <v-row>
+        <v-col cols="12">
+          <v-chip class="mr-1" label size="small" density="comfortable">
+            {{ $t('Common.PriceCount', { count: proofPriceUploadedList.length }) }}
+          </v-chip>
+          <v-chip class="mr-1" label size="small" density="comfortable">
+            {{ getPriceValueDisplay(proofPriceUploadedListSum) }}
+          </v-chip>
+        </v-col>
+      </v-row>
+    </v-card-actions>
+
     <v-overlay v-model="disableCard" scrim="#E8F5E9" contained persistent />
   </v-card>
 </template>
 
 <script>
 import { defineAsyncComponent } from 'vue'
+import utils from '../utils.js'
 
 export default {
   components: {
@@ -47,7 +66,21 @@ export default {
   computed: {
     showCard() {
       return this.hideCardIfNoProofPriceUploaded && this.proofPriceUploadedList.length > 0
+    },
+    proofPriceUploadedListSum() {
+      return this.proofPriceUploadedList.reduce((acc, priceUploaded) => {
+        return acc + parseFloat(priceUploaded.price)
+      }, 0)
     }
+  },
+  methods: {
+    getPriceValue(priceValue, priceCurrency) {
+      return utils.prettyPrice(priceValue, priceCurrency)
+    },
+    getPriceValueDisplay(price) {
+      price = parseFloat(price)
+      return this.getPriceValue(price, this.proofPriceUploadedList[0].currency)
+    },
   }
 }
 </script>


### PR DESCRIPTION
### What

Following https://github.com/openfoodfacts/open-prices-frontend/commit/382cbff21d364b7aa109749c2f9674287d0e127e (new PriceAlreadyUploadedListCard component)
We start adding some useful info in the footer of the card

### Screenshot

![Screenshot from 2024-12-02 22-37-17](https://github.com/user-attachments/assets/67b442a5-4300-46e2-9172-5e8722133e5b)
