### PR TITLE
fix(ContributionAssitant): strip whitespaces from gemini detected barcodes

### DIFF
--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -231,7 +231,7 @@ export default {
       this.productPriceForms = []
       for (let i = 0; i < response.labels.length; i++) {
         const label = response.labels[i]
-        const barcodeString = label.barcode ? label.barcode.toString() : ''
+        const barcodeString = label.barcode ? label.barcode.toString().replace(/\s/g, '') : ''
         // TODO: some of these will be None if gemini did not give a proper reply, so detection and error handling is needed
         const productPriceForm = {
           mode: barcodeString.length > 10 ? 'barcode' : 'category',


### PR DESCRIPTION
### What
- See title

### Fixes bug(s)
- Fix #1083

### Note
- Linting is expected to fail since the ContributionAssistant still has hardcoded text, without translation support. But that's another issue.
