### PR TITLE
refactor(Price add): new Proof type form input (single button)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,3 +6,7 @@
     content:" *";
     color: #F44336;  /* red */
 }
+
+.v-btn-group--density-compact.v-btn-group {
+    height: 28px;  /* default is 36px; match v-btn size="small" height */
+}

--- a/src/components/ProofTypeInputRow.vue
+++ b/src/components/ProofTypeInputRow.vue
@@ -1,17 +1,11 @@
 <template>
   <v-row>
     <v-col cols="12">
-      <h3 class="required mb-1">
-        {{ $t('Common.Type') }}
-      </h3>
-      <v-item-group v-model="proofTypeForm.type" class="d-inline" mandatory>
-        <v-item v-for="pt in proofTypeList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
-          <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
-            <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-            {{ $t('ProofCard.' + pt.value) }}
-          </v-chip>
-        </v-item>
-      </v-item-group>
+      <v-btn-group divided density="compact" elevation="1" :style="proofTypeForm.type ? '' : 'border: 1px solid #F44336'">
+        <v-btn v-for="pt in proofTypeList" :key="pt.key" size="small" :value="pt.key" :prepend-icon="pt.icon" :style="isSelectedType(pt.key) ? 'border: 1px solid #4CAF50' : ''" @click="proofTypeForm.type = pt.key">
+          {{ $t('ProofCard.' + pt.value) }}
+        </v-btn>
+      </v-btn-group>
     </v-col>
   </v-row>
 </template>
@@ -29,6 +23,11 @@ export default {
   data() {
     return {
       proofTypeList: constants.PROOF_TYPE_LIST,
+    }
+  },
+  methods: {
+    isSelectedType(proofType) {
+      return this.proofTypeForm.type === proofType
     }
   }
 }


### PR DESCRIPTION
### What

Linked to #1085: start working on revamping/simplifying the price add form

Changes on the Proof type selector

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/350b65ec-9d79-43b5-bc3b-42af3b69b23c)|![image](https://github.com/user-attachments/assets/c7430185-3974-4651-86f7-e135a3d095ca)|