### PR TITLE
refactor(Price add): new Proof type form input (revert back to chips)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -13,6 +13,9 @@
 .border-success {
     border: 1px solid #4CAF50 !important;  /* green */
 }
+.border-transparent {
+    border: 1px solid transparent !important;
+}
 
 .v-btn-group--density-compact.v-btn-group {
     height: 28px !important;  /* default is 36px; match v-btn size="small" height */

--- a/src/components/ProofTypeInputRow.vue
+++ b/src/components/ProofTypeInputRow.vue
@@ -1,11 +1,15 @@
 <template>
   <v-row>
     <v-col cols="12">
-      <v-btn-group divided density="compact" elevation="1" :class="proofTypeForm.type ? '' : 'border-error'">
-        <v-btn v-for="pt in proofTypeList" :key="pt.key" size="small" :value="pt.key" :prepend-icon="pt.icon" :class="isSelectedType(pt.key) ? 'border-success' : ''" @click="proofTypeForm.type = pt.key">
-          {{ $t('ProofCard.' + pt.value) }}
-        </v-btn>
-      </v-btn-group>
+      <v-item-group v-model="proofTypeForm.type" class="d-inline" mandatory>
+        <v-item v-for="pt in proofTypeList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
+          <v-chip class="mr-1" :class="isSelected ? 'border-success' : ''" variant="outlined" @click="toggle">
+            <v-icon start :icon="pt.icon" />
+            {{ $t('ProofCard.' + pt.value) }}
+            <v-icon v-if="isSelected" end icon="mdi-checkbox-marked-circle" color="green" />
+          </v-chip>
+        </v-item>
+      </v-item-group>
     </v-col>
   </v-row>
 </template>
@@ -25,10 +29,5 @@ export default {
       proofTypeList: constants.PROOF_TYPE_LIST,
     }
   },
-  methods: {
-    isSelectedType(proofType) {
-      return this.proofTypeForm.type === proofType
-    }
-  }
 }
 </script>


### PR DESCRIPTION
### What

Linked to #1085: start working on revamping/simplifying the price add form

Changes on the Proof type selector. Revert changes done in #1096 (not a fan after all of the buttons)

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/350b65ec-9d79-43b5-bc3b-42af3b69b23c)|![image](https://github.com/user-attachments/assets/0099b21d-ae99-4436-b388-6be23d44c842)|
