### PR TITLE
refactor(Price add): gain some space near the product & price checkboxes

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -28,20 +28,15 @@
       </v-alert>
       <v-row>
         <v-col>
-          <h3 class="required mb-1">
-            Price
-          </h3>
-          <h3 v-if="productPriceForm.type == 'CATEGORY'" class="mb-1">
-            <v-item-group v-model="productPriceForm.price_per" class="d-inline" mandatory>
-              <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
-                <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
-                  <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                  {{ cpp.value }}
-                </v-chip>
-              </v-item>
-            </v-item-group>
-          </h3>
-          <PriceInputRow :priceForm="productPriceForm" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
+          <v-item-group v-if="productPriceForm.type == 'CATEGORY'" v-model="productPriceForm.price_per" class="d-inline" mandatory>
+            <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
+              <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
+                <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
+                {{ cpp.value }}
+              </v-chip>
+            </v-item>
+          </v-item-group>
+          <PriceInputRow class="mt-0" :priceForm="productPriceForm" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
         </v-col>
       </v-row>
     </v-card-text>

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="priceForm.price_is_discounted ? '6' : '12'">
+    <v-col :cols="priceForm.price_is_discounted ? '6' : '12'" class="pb-0">
       <v-text-field
         :model-value="priceForm.price"
         :label="priceForm.price_is_discounted ? $t('PriceForm.LabelDiscounted') : $t('PriceForm.Label')"
@@ -18,7 +18,7 @@
         </template>
       </v-text-field>
     </v-col>
-    <v-col v-if="priceForm.price_is_discounted" cols="6">
+    <v-col v-if="priceForm.price_is_discounted" cols="6" class="pb-0">
       <v-text-field
         :model-value="priceForm.price_without_discount"
         :label="$t('PriceForm.LabelFull')"
@@ -40,14 +40,14 @@
         hide-details="auto"
       />
     </v-col>
-  </v-row>
 
-  <ChangeCurrencyDialog
-    v-if="changeCurrencyDialog"
-    v-model="changeCurrencyDialog"
-    @newCurrencySelected="setCurrencyData($event)"
-    @close="changeCurrencyDialog = false"
-  />
+    <ChangeCurrencyDialog
+      v-if="changeCurrencyDialog"
+      v-model="changeCurrencyDialog"
+      @newCurrencySelected="setCurrencyData($event)"
+      @close="changeCurrencyDialog = false"
+    />
+  </v-row>
 </template>
 
 <script>

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="priceForm.price_is_discounted ? '6' : '12'" sm="6">
+    <v-col :cols="priceForm.price_is_discounted ? '6' : '12'">
       <v-text-field
         :model-value="priceForm.price"
         :label="priceForm.price_is_discounted ? $t('PriceForm.LabelDiscounted') : $t('PriceForm.Label')"
@@ -31,10 +31,16 @@
         @update:modelValue="newValue => priceForm.price_without_discount = fixComma(newValue)"
       />
     </v-col>
+    <v-col class="pt-0" cols="6">
+      <v-checkbox
+        v-model="priceForm.price_is_discounted"
+        density="compact"
+        :label="$t('Common.Discount')"
+        :true-value="true"
+        hide-details="auto"
+      />
+    </v-col>
   </v-row>
-  <div class="d-inline">
-    <v-switch v-model="priceForm.price_is_discounted" :label="$t('Common.Discount')" color="success" hide-details="auto" />
-  </div>
 
   <ChangeCurrencyDialog
     v-if="changeCurrencyDialog"

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -43,16 +43,17 @@
             hide-details="auto"
           />
         </v-col>
-        <div class="d-inline">
+        <v-col class="pt-0" cols="6">
           <v-checkbox
             v-for="lt in labelsTags"
             :key="lt.id"
             v-model="productForm.labels_tags"
+            density="compact"
             :label="lt.name"
             :value="lt.id"
             hide-details="auto"
           />
-        </div>
+        </v-col>
       </v-row>
     </v-col>
   </v-row>

--- a/src/views/AddPriceMultiple.vue
+++ b/src/views/AddPriceMultiple.vue
@@ -60,22 +60,17 @@
             </v-row>
             <v-row>
               <v-col>
-                <h3 class="required mb-1">
-                  {{ $t('Common.Price') }}
-                </h3>
-                <h3 class="mb-1">
-                  <v-item-group v-if="productPriceForm.type === 'CATEGORY'" v-model="productPriceForm.price_per" class="d-inline" mandatory>
-                    <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
-                      <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
-                        <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                        {{ cpp.value }}
-                      </v-chip>
-                    </v-item>
-                  </v-item-group>
-                </h3>
-                <PriceInputRow :priceForm="productPriceForm" :product="productPriceForm.product" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
+                <v-item-group v-if="productPriceForm.type === 'CATEGORY'" v-model="productPriceForm.price_per" class="d-inline" mandatory>
+                  <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
+                    <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
+                      <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
+                      {{ cpp.value }}
+                    </v-chip>
+                  </v-item>
+                </v-item-group>
               </v-col>
             </v-row>
+            <PriceInputRow class="mt-0" :priceForm="productPriceForm" :product="productPriceForm.product" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
             <v-row>
               <v-col>
                 <v-btn

--- a/src/views/AddPriceSingle.vue
+++ b/src/views/AddPriceSingle.vue
@@ -51,17 +51,19 @@
           </template>
           <v-divider />
           <v-card-text>
-            <h3 class="mb-1">
-              <v-item-group v-if="addPriceSingleForm.type === 'CATEGORY'" v-model="addPriceSingleForm.price_per" class="d-inline" mandatory>
-                <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
-                  <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
-                    <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                    {{ cpp.value }}
-                  </v-chip>
-                </v-item>
-              </v-item-group>
-            </h3>
-            <PriceInputRow :priceForm="addPriceSingleForm" :product="addPriceSingleForm.product" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
+            <v-row>
+              <v-col>
+                <v-item-group v-if="addPriceSingleForm.type === 'CATEGORY'" v-model="addPriceSingleForm.price_per" class="d-inline" mandatory>
+                  <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
+                    <v-chip class="mr-1" :style="isSelected ? 'border: 1px solid #9E9E9E' : 'border: 1px solid transparent'" @click="toggle">
+                      <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
+                      {{ cpp.value }}
+                    </v-chip>
+                  </v-item>
+                </v-item-group>
+              </v-col>
+            </v-row>
+            <PriceInputRow class="mt-0" :priceForm="addPriceSingleForm" :product="addPriceSingleForm.product" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
           </v-card-text>
         </v-card>
       </v-col>


### PR DESCRIPTION
### What

Price add form:
- Category mode: reduce spacing between fields & "Organic" checkbox
- reduce spacing between price fields & "Discount" checkbox (was a switch before)
- remove "Price" label

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/593f6ee7-e5a1-4025-a17c-630116ac35fc)|![image](https://github.com/user-attachments/assets/00e60bb0-4816-445d-b1ad-4fbe3840d4f6)|
|![image](https://github.com/user-attachments/assets/f578d693-7f51-4d9c-8360-06d510c7f061)|![image](https://github.com/user-attachments/assets/cf9b7df5-8135-49de-878b-98e236dcfe74)|