### PR TITLE
feat(Settings): new Barcode scanner default mode settings (scan or type)

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -65,6 +65,8 @@
 <script>
 import { Html5Qrcode, Html5QrcodeScanType } from 'html5-qrcode'
 import { defineAsyncComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
 import api from '../services/api'
 import constants from '../constants'
 
@@ -102,24 +104,42 @@ export default {
       product: null,
       // config
       displayItems: constants.PRODUCT_SELECTOR_DISPLAY_LIST,
-      currentDisplay: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key,  // scan
+      currentDisplay: null,  // see mounted
       HTML5_QRCODE_URL: 'https://github.com/mebjas/html5-qrcode',
       HTML5_QRCODE_NAME: 'html5-qrcode'
     }
   },
   computed: {
+    ...mapStores(useAppStore),
     barcodeManualInputRules() {
       return [
         (v) => !!v || '',
       ]
     },
   },
+  watch: {
+    currentDisplay(value) {
+      if (value === constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key) {
+        window.setTimeout(() => this.createQrcodeScanner(), 200)
+      } else {  // type
+        window.setTimeout(() => this.$refs.barcodeManualInput.focus(), 200)
+        if (this.scanner) {
+          this.scanner.stop()
+        }
+      }
+    }
+  },
   mounted() {
-    this.createQrcodeScanner()
     if (this.preFillValue) {
       this.barcodeManualForm.barcode = this.preFillValue
     }
-    // this.$refs.barcodeManualInput.focus()
+    // init tab
+    if (this.appStore.user.barcode_scanner_default_mode === constants.PRODUCT_SELECTOR_DISPLAY_LIST[1].key) {
+      this.currentDisplay = constants.PRODUCT_SELECTOR_DISPLAY_LIST[1].key
+    } else {
+      // default to scan
+      this.currentDisplay = constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key
+    }
   },
   methods: {
     createQrcodeScanner() {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -599,6 +599,8 @@
 		"CountryLabel": "Country",
 		"CurrencyLabel": "Currency",
 		"DisplayTitle": "Display",
+		"BarcodeScanner": "Barcode scanner",
+		"DefaultMode": "Default mode",
 		"FavoriteCurrencies": "Favorite currencies",
 		"CurrencyRequired": "At least one currency is required",
 		"LanguageLabel": "Languages",

--- a/src/store.js
+++ b/src/store.js
@@ -19,7 +19,8 @@ export const useAppStore = defineStore('app', {
       product_display_category_tag: false,
       location_display_osm_id: false,
       drawer_display_experiments: true,
-      preferedTheme: null
+      preferedTheme: null,
+      barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key
     },
   }),
   getters: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <v-card :title="$t('UserSettings.DisplayTitle')" prepend-icon="mdi-laptop">
+      <v-card :title="$t('Common.Display')" prepend-icon="mdi-laptop">
         <v-divider />
         <v-card-text>
           <!-- Theme -->
@@ -65,7 +65,7 @@
 
     <!-- Prices -->
     <v-col cols="12" sm="6">
-      <v-card :title="$t('Common.Prices')" prepend-icon="mdi-tag-multiple-outline">
+      <v-card :title="$t('UserSettings.AddingPrices')" prepend-icon="mdi-tag-multiple-outline">
         <v-divider />
         <v-card-text>
           <h3 class="mb-1">
@@ -79,6 +79,18 @@
             chips
             closable-chips
             multiple
+            hide-details="auto"
+          />
+          <!-- Language -->
+          <h3 class="mt-4 mb-1">
+            {{ $t('UserSettings.BarcodeScanner') }}
+          </h3>
+          <v-select
+            v-model="appStore.user.barcode_scanner_default_mode"
+            :label="$t('UserSettings.DefaultMode')"
+            :items="barcodeScannerModeList"
+            :item-title="item => $t('Common.' + item.valueSmallScreen)"
+            :item-value="item => item.key"
             hide-details="auto"
           />
         </v-card-text>
@@ -159,6 +171,7 @@ export default {
       countryList,
       languageList,
       // currencyList,
+      barcodeScannerModeList: constants.PRODUCT_SELECTOR_DISPLAY_LIST
     }
   },
   computed: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -81,7 +81,7 @@
             multiple
             hide-details="auto"
           />
-          <!-- Language -->
+          <!-- Barcode scanner -->
           <h3 class="mt-4 mb-1">
             {{ $t('UserSettings.BarcodeScanner') }}
           </h3>


### PR DESCRIPTION
### What

Following #1102 where we have a single "Find a product" modal with 2 tabs (scan or type).
New settings to allow setting the default tab.

### Why

On some devices, for instance a laptop, the user will always want to use the "type" mode.

### Screenshot

![image](https://github.com/user-attachments/assets/aae18274-f8a6-41fc-8261-87e94a0d5d1b)
