### PR TITLE
feat(ContributionAssistant): Add support for automatic label detection

### DIFF
--- a/src/components/ContributionAssistantDrawCanvas.vue
+++ b/src/components/ContributionAssistantDrawCanvas.vue
@@ -18,6 +18,10 @@
       image: {
         type: Image,
         default: null
+      },
+      seedCrops: {
+        type: Array,
+        default: null
       }
     },
     emits: ['croppedImages', 'loaded'],
@@ -30,6 +34,13 @@
         rectangles: []
       }
     },
+    watch: {
+      seedCrops() {
+        if (this.seedCrops) {
+          this.init(true)
+        }
+      }
+    },
     mounted() {
       if (this.image.complete) {
         this.init()
@@ -38,7 +49,7 @@
       }
     },
     methods: {
-      init() {
+      init(keepRectangles=false) {
         const canvas = this.$refs.canvas
         const ctx = canvas.getContext("2d")
         canvas.style.width = "100%"
@@ -59,11 +70,25 @@
         
         ctx.drawImage(this.image, 0, 0, newWidth, newHeight)
         
-        this.rectangles = [] // reset rectangles
+        if (!keepRectangles) {
+          this.rectangles = [] // reset rectangles
+        }
+        if (this.seedCrops) {
+          this.rectangles = this.rectangles.concat(this.seedCrops.map(seedCrop => {
+            return {
+              startY: seedCrop[0] * this.image.height,
+              startX: seedCrop[1] * this.image.width,
+              endY: seedCrop[2] * this.image.height,
+              endX: seedCrop[3] * this.image.width
+            }
+          }))
+          this.cropImages()
+        }
         this.drawRectangles(); // Draw previous rectangles after resizing
         this.$emit('loaded')
       },
       startDrawing(event) {
+        if (this.isDrawing) return
         if (event.type == "touchstart") {
           const rect = event.target.getBoundingClientRect()
           event.offsetX = event.targetTouches[0].clientX - rect.left 

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -221,10 +221,10 @@ export default {
       this.croppedBlobs = []
       this.productPriceForms = []
       this.tab = "Crop"
-      this.predictionLoading = true
       // Try to fetch proof right away (predections should be available for proofs previously uploaded)
       await this.loadPredictions(event.id)
       if (!this.seedCrops.length) {
+        this.predictionLoading = true
         // If no predictions are found right away (new proof), try again after 5 seconds
         setTimeout(() => this.loadPredictions(event.id), 5000)
         // If that also fails, user will have to click the button to retry

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -26,13 +26,24 @@
       </v-tabs-window-item>
       <v-tabs-window-item value="Crop">
         <v-container>
+          <v-alert v-if="drawCanvasLoaded && !seedCrops.length && !predictionLoading" type="info" variant="outlined" icon="mdi-alert">
+            No labels could be automatically detected. Please manually draw squares around the labels or press the button below to try again.
+            <br />
+            <v-btn @click="loadPredictions(proofForm.id)">
+              Automatically find labels
+            </v-btn>
+          </v-alert>
+          <v-alert v-if="drawCanvasLoaded && predictionLoading" type="info" variant="outlined" icon="mdi-magnify">
+            Automatic label detection is running. Please wait...
+              <v-progress-circular indeterminate />
+          </v-alert>
           <v-row>
             <v-col cols="12" lg="6">
               <h3 class="mb-4">
                 1. Draw squares around the labels
               </h3>
               <v-progress-circular v-if="!drawCanvasLoaded" indeterminate />
-              <ContributionAssistantDrawCanvas ref="ContributionAssistantdrawCanvas" :image="image" @croppedImages="onCroppedImages($event)" @loaded="drawCanvasLoaded = true" />
+              <ContributionAssistantDrawCanvas ref="ContributionAssistantdrawCanvas" :image="image" :seedCrops="seedCrops" @croppedImages="onCroppedImages($event)" @loaded="drawCanvasLoaded = true" />
             </v-col>
             <v-col cols="12" lg="6">
               <h3 class="mb-4">
@@ -137,6 +148,7 @@ export default {
       tab: 'ProofSelect',
       drawCanvasLoaded: false,
       image: new Image(),
+      seedCrops: [],
       croppedImages: [],
       croppedBlobs: [],
       productPriceForms : [],
@@ -153,6 +165,7 @@ export default {
       },
       processCroppedImagesLoading: false,
       addPricesLoading: false,
+      predictionLoading: false,
       numberOfPricesAdded: 0
     }
   },
@@ -208,6 +221,24 @@ export default {
       this.croppedBlobs = []
       this.productPriceForms = []
       this.tab = "Crop"
+      this.predictionLoading = true
+      // Give the ml some time to run (5 seconds)
+      setTimeout(() => this.loadPredictions(event.id), 5000)
+    },
+    loadPredictions(proofId) {
+      this.predictionLoading = true
+      api.getProofById(proofId).then((proof) => {
+        if (proof.predictions && proof.predictions.length) {
+          for (let prediction of proof.predictions) {
+            if (prediction.type === "OBJECT_DETECTION") {
+              this.seedCrops = prediction.data.objects.map(predictionObject => {
+                return predictionObject.bounding_box
+              })
+            }
+          }
+        }
+        this.predictionLoading = false
+      })
     },
     onCroppedImages(eventData) {
       this.croppedImages = eventData[0]


### PR DESCRIPTION
### What
- Following the new ml detection of price tags bounding boxes https://github.com/openfoodfacts/open-prices/pull/614
- This PR uses this new result to speed up the cropping step

### Screenshot

After adding a proof, an info message is shown.
![](https://github.com/user-attachments/assets/b40a3508-2dce-4fcf-a535-46fa9b50bed1)

Once the bounding boxes are retrieved, images are automatically cropped. Users can still remove or add crops.
![](https://github.com/user-attachments/assets/eeb834fe-daa2-437e-a424-b09c65507cc9)

The assistant tries to fetch bounding boxes twice (using single proof api).
- The first time right after uploading the proof (useful for proof already uploaded beforehand)
- If that fails, a second fetch is done 5 seconds later, giving time for ml to execute

If both tries fail, the following message is shown to the user
![](https://github.com/user-attachments/assets/df25f7bb-64d3-4049-a6a2-66b87763a845)
