### PR TITLE
refactor(Price add): move price_per selector in PriceInputRow

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -15,24 +15,12 @@
       />
       <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingType="true" @filled="productFormFilled = $event" />
       <v-alert
-        v-if="productPriceForm.type === 'PRODUCT'"
+        v-if="productIsTypeProduct"
         type="info"
         variant="outlined"
       >
         {{ $t('ContributionAssistant.DetectedBarcode', { barcode: productPriceForm.detected_product_code }) }}
       </v-alert>
-      <v-row v-if="productPriceForm.type == 'CATEGORY'">
-        <v-col>
-          <v-item-group v-model="productPriceForm.price_per" class="d-inline" mandatory>
-            <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
-              <v-chip class="mr-1" :class="isSelected ? 'border-grey' : 'border-transparent'" @click="toggle">
-                <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                {{ cpp.value }}
-              </v-chip>
-            </v-item>
-          </v-item-group>
-        </v-col>
-      </v-row>
       <PriceInputRow class="mt-0" :priceForm="productPriceForm" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
     </v-card-text>
     <v-divider />
@@ -52,6 +40,7 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
+import constants from '../constants'
 
 export default {
   components: {
@@ -62,6 +51,7 @@ export default {
     productPriceForm: {
       type: Object,
       default: () => ({
+        type: null,
         category_tag: null,
         origins_tags: '',
         labels_tags: [],
@@ -81,10 +71,11 @@ export default {
     return {
       productFormFilled: false,
       pricePriceFormFilled: false,
-      categoryPricePerList: [
-      {key: 'KILOGRAM', value: "per kg", icon: 'mdi-weight-kilogram'},
-      {key: 'UNIT', value: "per unit", icon: 'mdi-numeric-1-circle'}
-      ],
+    }
+  },
+  computed: {
+    productIsTypeProduct() {
+      return this.productPriceForm.type === constants.PRICE_TYPE_PRODUCT
     }
   },
   methods: {

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -93,7 +93,7 @@ export default {
     priceForm: {
       type: Object,
       default: () => ({
-        type: null,  // 'CATEGORY' or 'PRODUCT'
+        type: null,  // 'CATEGORY' or 'PRODUCT'  // transform into productType prop ?
         price: null,
         price_per: null,
         price_is_discounted: false,
@@ -145,7 +145,7 @@ export default {
       ]
     },
     productIsTypeCategory() {
-      return this.priceForm.type === 'CATEGORY'
+      return this.priceForm && this.priceForm.type === constants.PRICE_TYPE_CATEGORY
     },
     proofIsTypeReceipt() {
       return this.proofType === constants.PROOF_TYPE_RECEIPT

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -1,7 +1,19 @@
 <template>
   <v-row>
     <v-col cols="12">
-      <v-row>
+      <v-row v-if="productIsTypeCategory">
+        <v-col>
+          <v-item-group v-model="priceForm.price_per" class="d-inline" mandatory>
+            <v-item v-for="cpp in CATEGORY_PRICE_PER_LIST" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
+              <v-chip class="mr-1" :class="isSelected ? 'border-grey' : 'border-transparent'" @click="toggle">
+                <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
+                {{ cpp.value }}
+              </v-chip>
+            </v-item>
+          </v-item-group>
+        </v-col>
+      </v-row>
+      <v-row class="mt-0">
         <v-col :cols="priceForm.price_is_discounted ? '6' : '12'" class="pb-0">
           <v-text-field
             :model-value="priceForm.price"
@@ -81,7 +93,9 @@ export default {
     priceForm: {
       type: Object,
       default: () => ({
+        type: null,  // 'CATEGORY' or 'PRODUCT'
         price: null,
+        price_per: null,
         price_is_discounted: false,
         price_without_discount: null,
         currency: null,
@@ -106,6 +120,10 @@ export default {
     return {
       // currency selection
       changeCurrencyDialog: false,
+      CATEGORY_PRICE_PER_LIST: [
+        {key: 'KILOGRAM', value: this.$t('AddPriceSingle.CategoryPricePer.PerKg'), icon: 'mdi-weight-kilogram'},
+        {key: 'UNIT', value: this.$t('AddPriceSingle.CategoryPricePer.PerUnit'), icon: 'mdi-numeric-1-circle'}
+      ],
       PROOF_TYPE_RECEIPT_ICON: constants.PROOF_TYPE_RECEIPT_ICON,
     }
   },
@@ -126,12 +144,16 @@ export default {
         value => Number(value) >= 1 || this.$t('PriceRules.Positive'),
       ]
     },
-    priceFormFilled() {
-      let keys = ['price', 'currency']
-      return Object.keys(this.priceForm).filter(k => keys.includes(k)).every(k => !!this.priceForm[k])
+    productIsTypeCategory() {
+      return this.priceForm.type === 'CATEGORY'
     },
     proofIsTypeReceipt() {
       return this.proofType === constants.PROOF_TYPE_RECEIPT
+    },
+    priceFormFilled() {
+      let keysProduct = ['price', 'currency']
+      let keysCategory = ['price_per', 'price', 'currency']
+      return this.productIsTypeCategory ? Object.keys(this.priceForm).filter(k => keysCategory.includes(k)).every(k => !!this.priceForm[k]) : Object.keys(this.priceForm).filter(k => keysProduct.includes(k)).every(k => !!this.priceForm[k])
     },
   },
   watch: {

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -14,7 +14,7 @@
           </v-item-group>
         </v-col>
       </v-row>
-      <v-row v-if="productForm.type === 'PRODUCT'" class="mt-0">
+      <v-row v-if="productIsTypeProduct" class="mt-0">
         <v-col>
           <v-btn class="mb-2" size="small" prepend-icon="mdi-barcode-scan" :class="productForm.product ? 'border-success' : 'border-error'" @click="showBarcodeScannerDialog">
             {{ $t('Common.ProductFind') }}
@@ -22,7 +22,7 @@
           <ProductCard v-if="productForm.product" :product="productForm.product" :hideCategoriesAndLabels="true" :hideProductActions="true" :readonly="true" elevation="1" />
         </v-col>
       </v-row>
-      <v-row v-if="productForm.type === 'CATEGORY'" class="mt-0">
+      <v-row v-else-if="productIsTypeCategory" class="mt-0">
         <v-col cols="6">
           <v-autocomplete
             v-model="productForm.category_tag"
@@ -84,7 +84,14 @@ export default {
   props: {
     productForm: {
       type: Object,
-      default: () => ({ type: '', product: null, product_code: '', category_tag: null, origins_tags: '', labels_tags: [] })
+      default: () => ({
+        type: null,
+        product: null,
+        product_code: '',
+        category_tag: null,
+        origins_tags: '',
+        labels_tags: []
+      })
     },
     disableInitWhenSwitchingType: {
       type: Boolean,
@@ -103,6 +110,12 @@ export default {
   },
   computed: {
     ...mapStores(useAppStore),
+    productIsTypeProduct() {
+      return this.productForm && this.productForm.type === constants.PRICE_TYPE_PRODUCT
+    },
+    productIsTypeCategory() {
+      return this.productForm && this.productForm.type === constants.PRICE_TYPE_CATEGORY
+    },
     productBarcodeFormFilled() {
       let keys = ['product_code']
       return Object.keys(this.productForm).filter(k => keys.includes(k)).every(k => !!this.productForm[k])
@@ -126,11 +139,11 @@ export default {
   mounted() {
     if (this.$route.query.code) {
       if (this.$route.query.code.startsWith('en')) {
-        this.productForm.type = 'CATEGORY'
+        this.productForm.type = constants.PRICE_TYPE_CATEGORY
         this.productForm.category_tag = this.$route.query.code
       }
       else {
-        this.productForm.type = 'PRODUCT'
+        this.productForm.type = constants.PRICE_TYPE_PRODUCT
         this.productForm.product_code = this.$route.query.code
       }
     }
@@ -140,7 +153,7 @@ export default {
     utils.getLocaleOriginTags(this.appStore.getUserLanguage).then((module) => {
       this.originTags = module.default
     })
-    this.productForm.type = this.productForm.type ? this.productForm.type : (this.productForm.product_code ? 'PRODUCT' : this.appStore.user.last_product_product_used)
+    this.productForm.type = this.productForm.type ? this.productForm.type : (this.productForm.product_code ? constants.PRICE_TYPE_PRODUCT : this.appStore.user.last_product_product_used)
     if (this.productForm.product_code) {
       this.getProduct(this.productForm.product_code)
     }

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -157,7 +157,7 @@ export default {
       image: new Image(),
       boundingBoxesFromServer: [],
       extractedLabels: [],
-      productPriceForms : [],
+      productPriceForms: [],
       proofForm: {
         type: constants.PROOF_TYPE_PRICE_TAG,
         id: null,
@@ -221,6 +221,7 @@ export default {
     setProof(event) {
       const image = new Image()
       // image.src = 'https://prices.openfoodfacts.org/img/0024/tM0NEloNU3.webp'
+      // image.src = 'https://prices.openfoodfacts.org/img/0023/f6tJvMcsDk.webp'
       image.src = `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${event.file_path}`
       image.crossOrigin = 'Anonymous'
       this.image = image

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -54,18 +54,6 @@
                 </v-alert>
               </v-col>
             </v-row>
-            <v-row v-if="productPriceForm.type === 'CATEGORY'">
-              <v-col>
-                <v-item-group v-model="productPriceForm.price_per" class="d-inline" mandatory>
-                  <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
-                    <v-chip class="mr-1" :class="isSelected ? 'border-grey' : 'border-transparent'" @click="toggle">
-                      <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                      {{ cpp.value }}
-                    </v-chip>
-                  </v-item>
-                </v-item-group>
-              </v-col>
-            </v-row>
             <PriceInputRow class="mt-0" :priceForm="productPriceForm" :product="productPriceForm.product" :hideCurrencyChoice="true" :proofType="proofObject.type" @filled="pricePriceFormFilled = $event" />
           </v-card-text>
           <v-divider />
@@ -173,10 +161,6 @@ export default {
         currency: null,  // see initNewProductPriceForm
         receipt_quantity: null,
       },
-      categoryPricePerList: [
-        {key: 'KILOGRAM', value: this.$t('AddPriceSingle.CategoryPricePer.PerKg'), icon: 'mdi-weight-kilogram'},
-        {key: 'UNIT', value: this.$t('AddPriceSingle.CategoryPricePer.PerUnit'), icon: 'mdi-numeric-1-circle'}
-      ],
      }
   },
   computed: {
@@ -186,15 +170,8 @@ export default {
       let keysONLINE = Object.keys(this.addPriceMultipleForm).filter(k => !['location_osm_id', 'location_osm_type', 'receipt_price_count', 'receipt_price_total'].includes(k))
       return Object.keys(this.addPriceMultipleForm).filter(k => keysOSM.includes(k)).every(k => !!this.addPriceMultipleForm[k]) || Object.keys(this.addPriceMultipleForm).filter(k => keysONLINE.includes(k)).every(k => !!this.addPriceMultipleForm[k])
     },
-    pricePerFormFilled() {
-      let keys = ['price_per']
-      return Object.keys(this.addPriceMultipleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceMultipleForm[k])
-    },
-    priceFormFilled() {
-      return this.pricePerFormFilled && this.pricePriceFormFilled
-    },
     productPriceFormFilled() {
-      return this.productFormFilled && this.priceFormFilled
+      return this.productFormFilled && this.pricePriceFormFilled
     },
     formFilled() {
       return this.proofFormFilled && !!this.proofPriceUploadedList.length && !Object.keys(this.productPriceForm).length
@@ -249,7 +226,6 @@ export default {
       this.clearProductPriceForm()
       this.productPriceForm = JSON.parse(JSON.stringify(this.productPriceNew))  // deep copy
       this.productPriceForm.type = this.appStore.user.last_product_type_used  // can be overriden in ProductInputRow
-      this.productPriceForm.price_per = this.categoryPricePerList[0].key // init to 'KILOGRAM' because it's the most common use-case
       this.productPriceForm.currency = this.addPriceMultipleForm.currency || this.appStore.getUserLastCurrencyUsed  // get currency from proof first
       if (this.proofObject.type === constants.PROOF_TYPE_RECEIPT) {
         this.productPriceForm.receipt_quantity = 1

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -51,19 +51,7 @@
           </template>
           <v-divider />
           <v-card-text>
-            <v-row v-if="addPriceSingleForm.type === 'CATEGORY'">
-              <v-col>
-                <v-item-group v-model="addPriceSingleForm.price_per" class="d-inline" mandatory>
-                  <v-item v-for="cpp in categoryPricePerList" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
-                    <v-chip class="mr-1" :class="isSelected ? 'border-grey' : 'border-transparent'" @click="toggle">
-                      <v-icon start :icon="isSelected ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline'" />
-                      {{ cpp.value }}
-                    </v-chip>
-                  </v-item>
-                </v-item-group>
-              </v-col>
-            </v-row>
-            <PriceInputRow class="mt-0" :priceForm="addPriceSingleForm" :product="addPriceSingleForm.product" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
+            <PriceInputRow class="mt-0" :priceForm="addPriceSingleForm" :product="addPriceSingleForm.product" :hideCurrencyChoice="true" @filled="priceFormFilled = $event" />
           </v-card-text>
         </v-card>
       </v-col>
@@ -117,7 +105,7 @@ export default {
         origins_tags: '',
         labels_tags: [],
         price: null,
-        price_per: null, // see initPriceSingleForm
+        price_per: null,
         price_is_discounted: false,
         price_without_discount: null,
         currency: null,  // see initPriceSingleForm
@@ -130,15 +118,11 @@ export default {
         receipt_price_total: null,
         proof_id: null,
       },
-      pricePriceFormFilled: false,
+      priceFormFilled: false,
       productFormFilled: false,
       createPriceLoading: false,
       // proof data
       proofDateSuccessMessage: false,
-      categoryPricePerList: [
-        {key: 'KILOGRAM', value: this.$t('AddPriceSingle.CategoryPricePer.PerKg'), icon: 'mdi-weight-kilogram'},
-        {key: 'UNIT', value: this.$t('AddPriceSingle.CategoryPricePer.PerUnit'), icon: 'mdi-numeric-1-circle'}
-      ],
     }
   },
   computed: {
@@ -146,13 +130,6 @@ export default {
     proofFormFilled() {
       let keys = ['proof_id']
       return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
-    },
-    pricePerFormFilled() {
-      let keys = ['price_per']
-      return Object.keys(this.addPriceSingleForm).filter(k => keys.includes(k)).every(k => !!this.addPriceSingleForm[k])
-    },
-    priceFormFilled() {
-      return this.pricePerFormFilled && this.pricePriceFormFilled
     },
     formFilled() {
       return this.productFormFilled && this.proofFormFilled && this.priceFormFilled
@@ -172,7 +149,6 @@ export default {
       /**
        * init form config
        */
-      this.addPriceSingleForm.price_per = this.categoryPricePerList[0].key // init to 'KILOGRAM' because it's the most common use-case
       this.addPriceSingleForm.currency = this.appStore.getUserLastCurrencyUsed
     },
     createPrice() {


### PR DESCRIPTION
### What

Stop duplicating the price_per selector.
Move it to the `PriceInputRow` component.

Impact on `PriceAddSingle`, `PriceAddMultiple` & `ContributionAssistant` pages