### PR TITLE
feat(Settings): new Location selector default mode settings (recent, physical or online)

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -135,12 +135,7 @@ export default {
       this.barcodeManualForm.barcode = this.barcodeManualInputPrefillValue
     }
     // init tab
-    if (this.appStore.user.barcode_scanner_default_mode === constants.PRODUCT_SELECTOR_DISPLAY_LIST[1].key) {
-      this.currentDisplay = constants.PRODUCT_SELECTOR_DISPLAY_LIST[1].key
-    } else {
-      // default to scan
-      this.currentDisplay = constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key
-    }
+    this.currentDisplay = this.appStore.user.barcode_scanner_default_mode
   },
   methods: {
     createQrcodeScanner() {

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -97,6 +97,7 @@
           <v-tabs-window-item value="online">
             <v-form v-model="locationOnlineFormValid" @submit.prevent="createOnline">
               <v-text-field
+                ref="locationOnlineFormInput"
                 v-model="locationOnlineForm.website_url"
                 :label="$t('Common.Website')"
                 :hint="$t('Common.ExampleWithColonAndValue', { value: 'https://www.example.com' })"
@@ -166,7 +167,7 @@ export default {
       // config
       searchProvider: constants.LOCATION_SEARCH_PROVIDER_LIST[1].key,  // photon
       displayItems: constants.LOCATION_SELECTOR_DISPLAY_LIST,
-      currentDisplay: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,  // physical
+      currentDisplay: null,  // see mounted
       OSM_NOMINATIM_URL: constants.OSM_NOMINATIM_URL,
       OSM_NOMINATIM_ATTRIBUTION: constants.OSM_NOMINATIM_ATTRIBUTION,
       OSM_PHOTON_URL: constants.OSM_PHOTON_URL,
@@ -188,8 +189,17 @@ export default {
       ]
     },
   },
+  watch: {
+    currentDisplay(value) {
+      if (value === constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key) {
+        window.setTimeout(() => this.$refs.locationOsmSearchInput.focus(), 200)
+      } else if (value === constants.LOCATION_SELECTOR_DISPLAY_LIST[2].key) {
+        window.setTimeout(() => this.$refs.locationOnlineFormInput.focus(), 200)
+      }
+    }
+  },
   mounted() {
-    this.$refs.locationOsmSearchInput.focus()
+    this.currentDisplay = this.appStore.user.location_finder_default_mode
   },
   methods: {
     fieldRequired(v) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -657,6 +657,7 @@
 		"FavoriteCurrencies": "Favorite currencies",
 		"CurrencyRequired": "At least one currency is required",
 		"LanguageLabel": "Languages",
+		"LocationFinder": "Location finder",
 		"LocationDisplayOSMID": "Display OSM ID",
 		"ProductDisplayBarcode": "Display barcode",
 		"ProductDisplayCategoryTag": "Display category tag",

--- a/src/store.js
+++ b/src/store.js
@@ -20,6 +20,7 @@ export const useAppStore = defineStore('app', {
       location_display_osm_id: false,
       drawer_display_experiments: true,
       preferedTheme: null,
+      location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,
       barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key
     },
   }),

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -81,6 +81,18 @@
             multiple
             hide-details="auto"
           />
+          <!-- Location selector -->
+          <h3 class="mt-4 mb-1">
+            {{ $t('UserSettings.LocationFinder') }}
+          </h3>
+          <v-select
+            v-model="appStore.user.location_finder_default_mode"
+            :label="$t('UserSettings.DefaultMode')"
+            :items="locationSelectorDisplayList"
+            :item-title="item => $t('Common.' + item.value)"
+            :item-value="item => item.key"
+            hide-details="auto"
+          />
           <!-- Barcode scanner -->
           <h3 class="mt-4 mb-1">
             {{ $t('UserSettings.BarcodeScanner') }}
@@ -88,7 +100,7 @@
           <v-select
             v-model="appStore.user.barcode_scanner_default_mode"
             :label="$t('UserSettings.DefaultMode')"
-            :items="barcodeScannerModeList"
+            :items="productSelectorDisplayList"
             :item-title="item => $t('Common.' + item.valueSmallScreen)"
             :item-value="item => item.key"
             hide-details="auto"
@@ -171,7 +183,8 @@ export default {
       countryList,
       languageList,
       // currencyList,
-      barcodeScannerModeList: constants.PRODUCT_SELECTOR_DISPLAY_LIST
+      locationSelectorDisplayList: constants.LOCATION_SELECTOR_DISPLAY_LIST,
+      productSelectorDisplayList: constants.PRODUCT_SELECTOR_DISPLAY_LIST
     }
   },
   computed: {


### PR DESCRIPTION
### What

Following #1095 where we have a single "Find your location" modal with 3 tabs (Recent, Physical & Online).

New settings to allow choosing the default tab.

### Why

Some users want to select their recent shop by default.

### Screenshot

![image](https://github.com/user-attachments/assets/12784717-573b-4686-826e-f95ea5acfdb4)
