### PR TITLE
feat(ContributionAssistant): add support for product name gemini detection

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -15,7 +15,13 @@
         contain
       />
       <ProofImageCropped v-else-if="mode === 'Validation'" class="mb-4" height="200px" :proofImageFilePath="productPriceForm.proofImage" :boundingBox="productPriceForm.bounding_box" />
+      <v-text-field
+        :model-value="productPriceForm.product_name"
+        :label="$t('Common.ProductName')"
+        type="text"
+      />
       <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingType="true" @filled="productFormFilled = $event" />
+
       <v-alert
         v-if="productIsTypeProduct"
         type="info"

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -15,11 +15,16 @@
         contain
       />
       <ProofImageCropped v-else-if="mode === 'Validation'" class="mb-4" height="200px" :proofImageFilePath="productPriceForm.proofImage" :boundingBox="productPriceForm.bounding_box" />
-      <v-text-field
-        :model-value="productPriceForm.product_name"
-        :label="$t('Common.ProductName')"
-        type="text"
-      />
+      <v-row>
+        <v-col>
+          <v-text-field
+            :model-value="productPriceForm.product_name"
+            :label="$t('Common.ProductName')"
+            type="text"
+            hide-details="auto"
+          />
+        </v-col>
+      </v-row>
       <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingType="true" @filled="productFormFilled = $event" />
 
       <v-alert
@@ -102,7 +107,8 @@ export default {
         currency: null,
         proofImage: null,
         processed: null,
-        detected_product_code: null
+        detected_product_code: null,
+        product_name: null,
       })
     },
     mode: {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -153,6 +153,7 @@
 		"Prices": "Prices",
 		"PRODUCT": "Product",
 		"Product": "Product",
+		"ProductName": "Product name",
 		"Products": "Products",
 		"Proof": "Proof",
 		"Proofs": "Proofs",

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -297,7 +297,8 @@ export default {
           currency: this.appStore.getUserLastCurrencyUsed || 'EUR',
           proofImage: this.extractedLabels[i].imageSrc,
           product_code: barcodeString,
-          detected_product_code: barcodeString
+          detected_product_code: barcodeString,
+          product_name: label.product_name
         }
         this.productPriceForms.push(productPriceForm)
       }


### PR DESCRIPTION
### What
- Handles product_name dectection from AI (currently Gemini).
- Display it as an extra form field in the UI, to allow users to correct before upload.

### Screenshot
![Capture](https://github.com/user-attachments/assets/cc15a86a-fa3a-47ac-a73d-e34050ee2c6e)


### Fixes bug(s)
- https://github.com/openfoodfacts/open-prices-frontend/issues/1078

### Requires
- Backend PR: https://github.com/openfoodfacts/open-prices/pull/646
