### PR TITLE
refactor(Price Validation Assistant): display the ProofChip in the ProofFooter

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -39,7 +39,7 @@
     </v-card-text>
     <v-divider v-if="mode === 'Validation'" />
     <v-card-text v-if="mode === 'Validation'">
-      <ProofFooterRow :proof="productPriceForm.proof" :hideProofType="true" :hideProofActions="true" :readonly="true" />
+      <ProofFooterRow :proof="productPriceForm.proof" :showProofChip="true" :hideProofType="true" :hideProofActions="true" :readonly="true" />
     </v-card-text>
     <v-divider />
     <v-card-actions v-if="mode === 'Contribution'">

--- a/src/components/ProofChip.vue
+++ b/src/components/ProofChip.vue
@@ -9,7 +9,7 @@
   >
     <v-icon icon="mdi-image" />
     <v-dialog v-model="dialog" scrollable max-height="80%" min-width="50%" width="auto">
-      <ProofCard :proof="proof" :hideProofActions="true" @close="closeDialog" />
+      <ProofCard :proof="proof" :hideProofActions="true" :readonly="readonly" @close="closeDialog" />
     </v-dialog>
   </v-chip>
 </template>
@@ -26,6 +26,10 @@ export default {
       type: Object,
       default: null
     },
+    readonly: {
+      type: Boolean,
+      default: false,
+    }
   },
   data() {
     return {

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -1,6 +1,7 @@
 <template>
   <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
+      <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" />
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofReceiptPriceCountChip v-if="showReceiptPriceCount" class="mr-1" :totalCount="proof.receipt_price_count" />
       <ProofReceiptPriceTotalChip v-if="showReceiptPriceTotal" class="mr-1" :totalCount="proof.receipt_price_total" :currency="proof.currency" />
@@ -24,6 +25,7 @@ import constants from '../constants'
 
 export default {
   components: {
+    ProofChip: defineAsyncComponent(() => import('../components/ProofChip.vue')),
     ProofTypeChip: defineAsyncComponent(() => import('../components/ProofTypeChip.vue')),
     ProofReceiptPriceCountChip: defineAsyncComponent(() => import('../components/ProofReceiptPriceCountChip.vue')),
     ProofReceiptPriceTotalChip: defineAsyncComponent(() => import('../components/ProofReceiptPriceTotalChip.vue')),
@@ -53,6 +55,10 @@ export default {
       default: true
     },
     hideProofActions: {
+      type: Boolean,
+      default: false,
+    },
+    showProofChip: {
       type: Boolean,
       default: false,
     },

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -1,13 +1,13 @@
 <template>
   <v-row>
     <v-col :cols="userIsProofOwner ? '11' : '12'">
-      <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" />
+      <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" :readonly="true" />
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofReceiptPriceCountChip v-if="showReceiptPriceCount" class="mr-1" :totalCount="proof.receipt_price_count" />
       <ProofReceiptPriceTotalChip v-if="showReceiptPriceTotal" class="mr-1" :totalCount="proof.receipt_price_total" :currency="proof.currency" />
       <PriceCountChip v-if="!hidePriceCount" class="mr-1" :count="proof.price_count" :withLabel="true" @click="goToProof()" />
       <LocationChip class="mr-1" :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
-      <DateChip class="mr-1" :date="proof.date" :showErrorIfDateMissing="true" />
+      <DateChip class="mr-1" :date="proof.date" :showErrorIfDateMissing="true" :readonly="readonly" />
       <CurrencyChip class="mr-1" :currency="proof.currency" :showErrorIfCurrencyMissing="true" />
       <UserChip v-if="!hideProofOwner" class="mr-1" :username="proof.owner" :readonly="readonly" />
       <RelativeDateTimeChip :dateTime="proof.created" />


### PR DESCRIPTION
### What

In the ProofFooterRow component, allow displaying the ProofChip #inception

### Why

To use in the Price Validation Assistant, and allow users to display the full proof (for context)

### Screenshot

||Image|
|---|---|
|Before|![image](https://github.com/user-attachments/assets/509cc4da-86c3-4cfa-8253-0fa4c50eb48d)|
|After|![image](https://github.com/user-attachments/assets/6969a389-564b-4fe6-9bc2-449b29b2674d)|
