### PR TITLE
refactor(Proof upload): rename & upgrade ProofInputRow to ProofUploadCard

### DIFF
--- a/src/components/ProofCard.vue
+++ b/src/components/ProofCard.vue
@@ -1,8 +1,12 @@
 <template>
-  <v-card v-if="proof" :id="'proof_' + proof.id" data-name="proof-card" @click="selectProof">
-    <v-card-title v-if="!hideProofHeader">
-      {{ $t('Common.Proof') }} <v-btn style="float:right;" variant="text" density="compact" icon="mdi-close" @click="close" />
-    </v-card-title>
+  <v-card v-if="proof" :id="'proof_' + proof.id" :class="mode == 'Uploaded' ? 'border-success' : 'border-transparent'" data-name="proof-card" @click="selectProof">
+    <template v-if="!hideProofHeader" #title>
+      {{ $t('Common.Proof') }}
+    </template>
+    <template v-if="!hideProofHeader" #append>
+      <v-icon v-if="mode == 'Display'" icon="mdi-close" @click="close" />
+      <v-icon v-else-if="mode == 'Uploaded'" icon="mdi-checkbox-marked-circle" color="success" />
+    </template>
 
     <v-divider v-if="!hideProofHeader" />
 
@@ -29,6 +33,10 @@ export default {
     proof: {
       type: Object,
       default: null
+    },
+    mode: {
+      type: String,
+      default: 'Display'  // or 'Uploaded'
     },
     hideProofHeader: {
       type: Boolean,

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -1,14 +1,10 @@
 <template>
   <v-card
     v-if="!proofObjectList.length"
-    :class="proofFormFilled ? 'border-success' : 'border-transparent'"
     :title="$t('Common.ProofDetails')"
     :prepend-icon="cardPrependIcon"
     height="100%"
   >
-    <template v-if="proofFormFilled" #append>
-      <v-icon icon="mdi-checkbox-marked-circle" color="success" />
-    </template>
     <v-divider />
     <v-card-text>
       <ProofTypeInputRow :proofTypeForm="proofForm" />
@@ -34,7 +30,7 @@
     </v-card-actions>
   </v-card>
 
-  <ProofCard v-for="(proofObject, index) in proofObjectList" :key="index" :proof="proofObject" :hideProofHeader="true" :hideProofActions="true" :showImageThumb="proofCardShowImageThumb" :readonly="true" />
+  <ProofCard v-for="(proofObject, index) in proofObjectList" :key="index" mode="Uploaded" :proof="proofObject" :hideProofActions="true" :showImageThumb="proofCardShowImageThumb" :readonly="true" />
 
   <v-snackbar
     v-model="proofDateSuccessMessage"

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -1,31 +1,40 @@
 <template>
-  <v-row>
-    <!-- FORM -->
-    <v-col v-if="!proofObjectList.length" cols="12">
+  <v-card
+    v-if="!proofObjectList.length"
+    :class="proofFormFilled ? 'border-success' : 'border-transparent'"
+    :title="$t('Common.ProofDetails')"
+    :prepend-icon="cardPrependIcon"
+    height="100%"
+  >
+    <template v-if="proofFormFilled" #append>
+      <v-icon icon="mdi-checkbox-marked-circle" color="success" />
+    </template>
+    <v-divider />
+    <v-card-text>
       <ProofTypeInputRow :proofTypeForm="proofForm" />
       <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
       <LocationInputRow :locationForm="proofForm" />
       <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" />
-      <v-row>
-        <v-col>
-          <v-btn
-            class="float-right"
-            color="success"
-            :loading="loading"
-            :disabled="!proofFormFilled || loading"
-            @click="uploadProofList"
-          >
-            <span v-if="multiple">{{ $t('Common.UploadMultipleImages', proofImageList.length) }}</span>
-            <span v-else>{{ $t('Common.Upload') }}</span>
-          </v-btn>
-        </v-col>
-      </v-row>
-    </v-col>
-    <!-- CARD -->
-    <v-col v-else>
-      <ProofCard v-for="(proofObject, index) in proofObjectList" :key="index" :proof="proofObject" :hideProofHeader="true" :hideProofActions="true" :showImageThumb="proofCardShowImageThumb" :readonly="true" />
-    </v-col>
-  </v-row>
+    </v-card-text>
+    <v-divider />
+    <v-card-actions>
+      <v-spacer />
+      <v-btn
+        class="float-right"
+        color="success"
+        variant="flat"
+        elevation="1"
+        :loading="loading"
+        :disabled="!proofFormFilled || loading"
+        @click="uploadProofList"
+      >
+        <span v-if="multiple">{{ $t('Common.UploadMultipleImages', proofImageList.length) }}</span>
+        <span v-else>{{ $t('Common.Upload') }}</span>
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+
+  <ProofCard v-for="(proofObject, index) in proofObjectList" :key="index" :proof="proofObject" :hideProofHeader="true" :hideProofActions="true" :showImageThumb="proofCardShowImageThumb" :readonly="true" />
 
   <v-snackbar
     v-model="proofDateSuccessMessage"
@@ -54,6 +63,8 @@
 import Compressor from 'compressorjs'
 import ExifReader from 'exifreader'
 import { defineAsyncComponent } from 'vue'
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
 import api from '../services/api'
 import constants from '../constants'
 import utils from '../utils.js'
@@ -75,20 +86,6 @@ export default {
     LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
   },
   props: {
-    proofForm: {
-      type: Object,
-      default: () => ({
-        type: null,
-        proof_id: null,
-        location_id: null,
-        location_osm_id: null,
-        location_osm_type: null,
-        date: utils.currentDate(),
-        currency: null,
-        receipt_price_count: null,
-        receipt_price_total: null,
-      })
-    },
     hideRecentProofChoice: {
       type: Boolean,
       default: false
@@ -101,6 +98,18 @@ export default {
   emits: ['proof'],
   data() {
     return {
+      proofForm: {
+        type: null,
+        location_id: null,
+        location_osm_id: null,
+        location_osm_type: '',
+        date: utils.currentDate(),
+        currency: null,  // see initProofForm
+        receipt_price_count: null,
+        receipt_price_total: null,
+        proof_id: null
+      },
+      // data
       proofDateSuccessMessage: false,
       proofSelectedSuccessMessage: false,
       proofSuccessMessage: false,
@@ -110,6 +119,10 @@ export default {
     }
   },
   computed: {
+    ...mapStores(useAppStore),
+    cardPrependIcon() {
+      return this.multiple ? 'mdi-image-multiple' : 'mdi-image'
+    },
     proofTypeFormFilled() {
       return !!this.proofForm.type
     },
@@ -141,7 +154,13 @@ export default {
       this.$emit('proof', newProofObjectList[0])
     }
   },
+  mounted() {
+    this.initProofForm()
+  },
   methods: {
+    initProofForm() {
+      this.proofForm.currency = this.appStore.getUserLastCurrencyUsed
+    },
     handleProofSelectedList(proofSelectedList) {
       // can be an existing proof, or a file
       // existing proof: update proofForm + set proofObject

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -109,17 +109,12 @@ export default {
       return this.productFormFilled && this.proofFormFilled && this.priceFormFilled
     },
   },
-  mounted() {
-    this.initPriceSingleForm()
-  },
   methods: {
     fieldRequired(v) {
       return !!v
     },
-    initPriceSingleForm() {
-      // nothing
-    },
     onProofUploaded(proof) {
+      // fill the price form with the proof data
       this.addPriceSingleForm.proof_id = proof.id
       this.addPriceSingleForm.location_id = proof.location_id
       this.addPriceSingleForm.location_osm_id = proof.location_osm_id
@@ -151,7 +146,6 @@ export default {
       api
         .createPrice(this.addPriceSingleForm, this.$route.path)
         .then((data) => {
-          console.log(data)
           if (!data['id']) {
             alert(`Form error: ${JSON.stringify(data)}`)
           } else {

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -21,21 +21,7 @@
 
       <!-- Step 2: proof (image, location, date & currency) -->
       <v-col cols="12" md="6" lg="4">
-        <v-card
-          :class="proofFormFilled ? 'border-success' : 'border-transparent'"
-          :title="$t('Common.ProofDetails')"
-          prepend-icon="mdi-image"
-          height="100%"
-        >
-          <template v-if="proofFormFilled" #append>
-            <v-icon icon="mdi-checkbox-marked-circle" color="success" />
-          </template>
-          <v-divider />
-          <v-card-text>
-            <ProofInputRow :proofForm="addPriceSingleForm" />
-          </v-card-text>
-          <v-overlay v-model="disableProofForm" scrim="#E8F5E9" contained persistent />
-        </v-card>
+        <ProofUploadCard @proof="onProofUploaded($event)" />
       </v-col>
 
       <!-- Step 3: price -->
@@ -63,22 +49,14 @@
           type="submit"
           class="float-right"
           :color="formFilled ? 'success' : ''"
-          :loading="createPriceLoading"
+          :loading="loading"
           :disabled="!formFilled"
         >
-          {{ $t('AddPriceSingle.Create') }}
+          {{ $t('Common.Upload') }}
         </v-btn>
       </v-col>
     </v-row>
   </v-form>
-
-  <v-snackbar
-    v-model="proofDateSuccessMessage"
-    color="info"
-    :timeout="2000"
-  >
-    {{ $t('AddPriceSingle.PriceDetails.ProofDateChanged') }}
-  </v-snackbar>
 </template>
 
 <script>
@@ -91,7 +69,7 @@ import utils from '../utils.js'
 export default {
   components: {
     ProductInputRow: defineAsyncComponent(() => import('../components/ProductInputRow.vue')),
-    ProofInputRow: defineAsyncComponent(() => import('../components/ProofInputRow.vue')),
+    ProofUploadCard: defineAsyncComponent(() => import('../components/ProofUploadCard.vue')),
     PriceInputRow: defineAsyncComponent(() => import('../components/PriceInputRow.vue')),
   },
   data() {
@@ -108,21 +86,17 @@ export default {
         price_per: null,
         price_is_discounted: false,
         price_without_discount: null,
-        currency: null,  // see initPriceSingleForm
+        currency: null,  // see ProofUploadCard
         receipt_quantity: null,
         location_id: null,
         location_osm_id: null,
         location_osm_type: '',
         date: utils.currentDate(),
-        receipt_price_count: null,
-        receipt_price_total: null,
         proof_id: null,
       },
-      priceFormFilled: false,
       productFormFilled: false,
-      createPriceLoading: false,
-      // proof data
-      proofDateSuccessMessage: false,
+      priceFormFilled: false,
+      loading: false,
     }
   },
   computed: {
@@ -134,9 +108,6 @@ export default {
     formFilled() {
       return this.productFormFilled && this.proofFormFilled && this.priceFormFilled
     },
-    disableProofForm() {
-      return this.proofFormFilled
-    },
   },
   mounted() {
     this.initPriceSingleForm()
@@ -146,13 +117,18 @@ export default {
       return !!v
     },
     initPriceSingleForm() {
-      /**
-       * init form config
-       */
-      this.addPriceSingleForm.currency = this.appStore.getUserLastCurrencyUsed
+      // nothing
+    },
+    onProofUploaded(proof) {
+      this.addPriceSingleForm.proof_id = proof.id
+      this.addPriceSingleForm.location_id = proof.location_id
+      this.addPriceSingleForm.location_osm_id = proof.location_osm_id
+      this.addPriceSingleForm.location_osm_type = proof.location_osm_type
+      this.addPriceSingleForm.date = proof.date
+      this.addPriceSingleForm.currency = proof.currency
     },
     createPrice() {
-      this.createPriceLoading = true
+      this.loading = true
       this.appStore.setLastCurrencyUsed(this.addPriceSingleForm.currency)
       // cleanup form
       if (!this.addPriceSingleForm.product_code) {
@@ -175,17 +151,18 @@ export default {
       api
         .createPrice(this.addPriceSingleForm, this.$route.path)
         .then((data) => {
-          if (data['detail']) {
-            alert(`Error: with input ${data['detail'][0]['input']}`)
+          console.log(data)
+          if (!data['id']) {
+            alert(`Form error: ${JSON.stringify(data)}`)
           } else {
             this.done()
           }
-          this.createPriceLoading = false
+          this.loading = false
         })
         .catch((error) => {
           alert('Error: server error')
           console.log(error)
-          this.createPriceLoading = false
+          this.loading = false
         })
     },
     done() {

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" md="6">
-      <ProofUploadCard :hideRecentProofChoice="true" :multiple="true" @proof="uploaded = true" />
+      <ProofUploadCard :hideRecentProofChoice="true" :multiple="true" @proof="proofUploaded = true" />
     </v-col>
   </v-row>
 
@@ -10,8 +10,8 @@
       <v-btn
         class="float-right"
         type="submit"
-        :color="uploaded ? 'success' : ''"
-        :disabled="!uploaded"
+        :color="proofUploaded ? 'success' : ''"
+        :disabled="!proofUploaded"
         @click="done"
       >
         {{ $t('Common.Done') }}
@@ -29,7 +29,7 @@ export default {
   },
   data() {
     return {
-      uploaded: false
+      proofUploaded: false
     }
   },
   methods: {

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -1,21 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" md="6">
-      <v-card
-        :class="proofFormFilled ? 'border-success' : 'border-transparent'"
-        :title="$t('Common.ProofDetails')"
-        prepend-icon="mdi-image-multiple"
-        height="100%"
-      >
-        <template v-if="proofFormFilled" #append>
-          <v-icon icon="mdi-checkbox-marked-circle" color="success" />
-        </template>
-        <v-divider />
-        <v-card-text>
-          <ProofInputRow :proofForm="addProofForm" :hideRecentProofChoice="true" :multiple="true" />
-        </v-card-text>
-        <v-overlay v-model="disableProofForm" scrim="#E8F5E9" contained persistent />
-      </v-card>
+      <ProofUploadCard :hideRecentProofChoice="true" :multiple="true" @proof="uploaded = true" />
     </v-col>
   </v-row>
 
@@ -24,9 +10,8 @@
       <v-btn
         class="float-right"
         type="submit"
-        :color="proofFormFilled ? 'success' : ''"
-        :loading="loading"
-        :disabled="!proofFormFilled"
+        :color="uploaded ? 'success' : ''"
+        :disabled="!uploaded"
         @click="done"
       >
         {{ $t('Common.Done') }}
@@ -37,48 +22,17 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { mapStores } from 'pinia'
-import { useAppStore } from '../store'
-import utils from '../utils.js'
 
 export default {
   components: {
-    ProofInputRow: defineAsyncComponent(() => import('../components/ProofInputRow.vue')),
+    ProofUploadCard: defineAsyncComponent(() => import('../components/ProofUploadCard.vue')),
   },
   data() {
     return {
-      // data
-      addProofForm: {
-        type: null,
-        location_id: null,
-        location_osm_id: null,
-        location_osm_type: '',
-        date: utils.currentDate(),
-        currency: null,  // see initProofForm
-        receipt_price_count: null,
-        receipt_price_total: null,
-        proof_id: null
-      },
-      loading: false,
+      uploaded: false
     }
   },
-  computed: {
-    ...mapStores(useAppStore),
-    proofFormFilled() {
-      let keys = ['proof_id']
-      return Object.keys(this.addProofForm).filter(k => keys.includes(k)).every(k => !!this.addProofForm[k])
-    },
-    disableProofForm() {
-      return this.proofFormFilled
-    },
-  },
-  mounted() {
-    this.initProofForm()
-  },
   methods: {
-    initProofForm() {
-      this.addProofForm.currency = this.appStore.getUserLastCurrencyUsed
-    },
     done() {
       this.$router.push({ path: '/dashboard', query: { proofSingleSuccess: 'true' } })
     }

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -1,21 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" md="6">
-      <v-card
-        :class="proofFormFilled ? 'border-success' : 'border-transparent'"
-        :title="$t('Common.ProofDetails')"
-        prepend-icon="mdi-image"
-        height="100%"
-      >
-        <template v-if="proofFormFilled" #append>
-          <v-icon icon="mdi-checkbox-marked-circle" color="success" />
-        </template>
-        <v-divider />
-        <v-card-text>
-          <ProofInputRow :proofForm="addProofForm" :hideRecentProofChoice="true" />
-        </v-card-text>
-        <v-overlay v-model="disableProofForm" scrim="#E8F5E9" contained persistent />
-      </v-card>
+      <ProofUploadCard :hideRecentProofChoice="true" @proof="uploaded = true" />
     </v-col>
   </v-row>
 
@@ -24,9 +10,8 @@
       <v-btn
         class="float-right"
         type="submit"
-        :color="proofFormFilled ? 'success' : ''"
-        :loading="loading"
-        :disabled="!proofFormFilled"
+        :color="uploaded ? 'success' : ''"
+        :disabled="!uploaded"
         @click="done"
       >
         {{ $t('Common.Done') }}
@@ -37,48 +22,17 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { mapStores } from 'pinia'
-import { useAppStore } from '../store'
-import utils from '../utils.js'
 
 export default {
   components: {
-    ProofInputRow: defineAsyncComponent(() => import('../components/ProofInputRow.vue')),
+    ProofUploadCard: defineAsyncComponent(() => import('../components/ProofUploadCard.vue')),
   },
   data() {
     return {
-      // data
-      addProofForm: {
-        type: null,
-        location_id: null,
-        location_osm_id: null,
-        location_osm_type: '',
-        date: utils.currentDate(),
-        currency: null,  // see initProofForm
-        receipt_price_count: null,
-        receipt_price_total: null,
-        proof_id: null
-      },
-      loading: false,
+      uploaded: false
     }
   },
-  computed: {
-    ...mapStores(useAppStore),
-    proofFormFilled() {
-      let keys = ['proof_id']
-      return Object.keys(this.addProofForm).filter(k => keys.includes(k)).every(k => !!this.addProofForm[k])
-    },
-    disableProofForm() {
-      return this.proofFormFilled
-    },
-  },
-  mounted() {
-    this.initProofForm()
-  },
   methods: {
-    initProofForm() {
-      this.addProofForm.currency = this.appStore.getUserLastCurrencyUsed
-    },
     done() {
       this.$router.push({ path: '/dashboard', query: { proofSingleSuccess: 'true' } })
     }

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" md="6">
-      <ProofUploadCard :hideRecentProofChoice="true" @proof="uploaded = true" />
+      <ProofUploadCard :hideRecentProofChoice="true" @proof="proofUploaded = true" />
     </v-col>
   </v-row>
 
@@ -10,8 +10,8 @@
       <v-btn
         class="float-right"
         type="submit"
-        :color="uploaded ? 'success' : ''"
-        :disabled="!uploaded"
+        :color="proofUploaded ? 'success' : ''"
+        :disabled="!proofUploaded"
         @click="done"
       >
         {{ $t('Common.Done') }}
@@ -29,7 +29,7 @@ export default {
   },
   data() {
     return {
-      uploaded: false
+      proofUploaded: false
     }
   },
   methods: {


### PR DESCRIPTION
### What

Following #1167 

ProofInputRow: rename to ProofUploadCard (to integrate the header & the footer (upload action))
- refactor its usage in different pages (ProofAddSingle, ProofAddMultiple, PriceAddSingle, PriceAddMultiple, ContributionAssistant)
- don't add an overlay after upload (but keep the green border and checkmark !)

### Screenshots

||Before|After|
|---|---|---|
|Proof form|![image](https://github.com/user-attachments/assets/0bd553c9-057b-4a7b-be5f-f1b2c8c18682)|![image](https://github.com/user-attachments/assets/0ae0175f-d64a-4907-914e-9f3ee6ef5cb5)|
|Proof selected|![image](https://github.com/user-attachments/assets/d8c60232-79aa-4134-bf88-71dcbb083a64)|![image](https://github.com/user-attachments/assets/d98e9496-b671-45ea-9fc0-d348a6b5eb7f)|