### PR TITLE
refactor(Multiple proof add): skip type input. Add warning message

### DIFF
--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -7,7 +7,7 @@
   >
     <v-divider />
     <v-card-text>
-      <ProofTypeInputRow :proofTypeForm="proofForm" />
+      <ProofTypeInputRow v-if="!typePriceTagOnly" :proofTypeForm="proofForm" />
       <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
       <LocationInputRow :locationForm="proofForm" />
       <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" />
@@ -82,6 +82,10 @@ export default {
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
   },
   props: {
+    typePriceTagOnly: {
+      type: Boolean,
+      default: false
+    },
     hideRecentProofChoice: {
       type: Boolean,
       default: false
@@ -155,6 +159,9 @@ export default {
   },
   methods: {
     initProofForm() {
+      if (this.typePriceTagOnly) {
+        this.proofForm.type = constants.PROOF_TYPE_PRICE_TAG
+      }
       this.proofForm.currency = this.appStore.getUserLastCurrencyUsed
     },
     handleProofSelectedList(proofSelectedList) {

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -7,6 +7,14 @@
   >
     <v-divider />
     <v-card-text>
+      <v-alert
+        v-if="typePriceTagOnly && multiple"
+        class="mb-4"
+        type="warning"
+        variant="outlined"
+        density="compact"
+        :text="$t('ProofAdd.HowToMultiple')"
+      />
       <ProofTypeInputRow v-if="!typePriceTagOnly" :proofTypeForm="proofForm" />
       <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
       <LocationInputRow :locationForm="proofForm" />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -477,6 +477,9 @@
 		"LoadMore": "Load more",
 		"ProductNotFound": "Product not found in Open Food Facts... Don't hesitate to add it :)"
 	},
+	"ProofAdd": {
+		"HowToMultiple": "All the price tag images you select should share the same shop location, and been taken on the same day."
+	},
 	"ProofCard": {
 		"Proof": "Proof",
 		"PRICE_TAG": "Price tag",

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" md="6">
-      <ProofUploadCard :hideRecentProofChoice="true" :multiple="true" @proof="proofUploaded = true" />
+      <ProofUploadCard :typePriceTagOnly="true" :hideRecentProofChoice="true" :multiple="true" @proof="proofUploaded = true" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

Following #1043 & #1168

Changes on the Multiple proof upload page:
- restrict to only PRICE_TAG
- add a warning/info message (reminder to upload proofs with the same location + date)

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/62b5a260-39f1-45c5-8f58-8282db956cfd)|![image](https://github.com/user-attachments/assets/421a5e41-07cc-4c7f-abad-74359826ebf3)|