### PR TITLE
refactor(Price Validation Assistant): filter only on proofs ready (uploaded via Proof add pages)

### DIFF
--- a/src/views/PriceValidatorAssistant.vue
+++ b/src/views/PriceValidatorAssistant.vue
@@ -67,7 +67,7 @@ export default {
       return this.appStore.user.username
     },
     getPriceTagsParams() {
-      return { proof__owner: this.username, status__isnull: true, order_by: this.currentOrder, page: this.priceTagPage }
+      return { proof__owner: this.username, proof__ready_for_price_tag_validation: true, status__isnull: true, order_by: this.currentOrder, page: this.priceTagPage }
     },
   },
   mounted() {


### PR DESCRIPTION
### What

Thanks to a new Proof.ready_for_price_tag_validation field in the backend - https://github.com/openfoodfacts/open-prices/pull/656.
We can now restrict displayed PriceTags to only a subset of Proofs.

### Why

We consider that proofs added via the "normal" workflow (Price add multiple) will have their prices added normally.
But proofs added via the dedicated "proof upload" pages will be assistant-only for price addition.

This is a v1. To be discussed / improved.
