### PR TITLE
refactor(ContributionAssistant): More pricetags integrations

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -21,17 +21,7 @@
       <ProofFooterRow :proof="productPriceForm.proof" :showProofChip="true" :hideProofType="true" :hideProofActions="true" :readonly="true" />
     </v-card-text>
     <v-divider />
-    <v-card-actions v-if="mode === 'Contribution'">
-      <v-btn
-        color="error"
-        variant="outlined"
-        prepend-icon="mdi-delete"
-        @click="removePriceTag"
-      >
-        {{ $t('Common.Delete') }}
-      </v-btn>
-    </v-card-actions>
-    <v-card-actions v-else-if="mode === 'Validation'">
+    <v-card-actions>
       <v-btn
         color="error"
         variant="outlined"
@@ -48,6 +38,7 @@
       </v-btn>
       <v-spacer />
       <v-btn
+        v-if="mode === 'Validation'"
         color="success"
         variant="flat"
         @click="validatePriceTag"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -337,6 +337,7 @@
 			"SendLabels": "3. Send the labels for automatic processing",
 			"SendLabelsButton": "Send labels"
 		},
+		"PricesAlreadyAdded": "Prices already added",
 		"PriceAddConfirmationMessage": "{numberOfPricesAdded} price(s) will be added to an existing proof on the {date} at {locationName}",
 		"PriceAddProgress": "{numberOfPricesAdded} / {totalNumberOfPrices} prices added",
 		"WaitForUpload": "Please wait for upload",
@@ -344,10 +345,16 @@
 		"GoToProof": "Go to proof",
 		"AddNewProof": "Add a new proof",
 		"NextProof": "Next proof",
+		"ChooseNextProof": "Choose another proof to handle",
 		"AutomaticBoundingBoxSource": "automatic",
 		"ManualBoundingBoxSource": "manual",
 		"DetectedBarcode": "Detected barcode: {barcode}",
-		"LabelProcessingErrorMessage": "Error: label automatic processing failed"
+		"LabelProcessingErrorMessage": "Error: label automatic processing failed",
+		"PriceTagLabels": {
+			"PriceTagWithPrice": "Price tag with a price",
+			"PriceTagWithoutPrice": "Price tag without a price",
+			"NewPriceTag": "New price tag"
+		}
 	},
 	"Community": {
 		"JoinUs": "Join us!",


### PR DESCRIPTION
### What
Following @raphael0202 feedback  (translated, simplified):


- [x] 1. proof_ids=ID1,ID2 parameter is not working

Fixed in https://github.com/openfoodfacts/open-prices-frontend/commit/012b83ff4a07433df436b6a5f4e36c4e21e9927c

- [x] 2. Pricetags status and price id are ignored. "3. Cleanup" phase should ignore (grey out) price tags with non-null status

Status and price_id are no longer ignored, Cleanup step now contains a second list of prices, below the first one, with unmodifiable (disabled) already added prices. These prices are ignored in further steps. (Note that the content is still showing Gemini predictions, now the actual created price, which might be a bit misleading)
![Capture](https://github.com/user-attachments/assets/50c3f4a7-c356-4b27-a1a7-b2bf0059e73e)

- [x] 3. Newly created bounding boxes sometime give API error "Bounding box values should be in the format [y_min, x_min, y_max, x_max]."

Could be happening when max values were greater than min values, e.g. a bouding box drawn from bottom to top. Fixed.

- [ ] 4. Newly created prices tags are sent after pressing the "Send labels" button, we should send them as we go, to give time for gemini process

Not implemented for now. I want to avoid the creation of invalid price tags because of user errors while drawing boxes. Moreover, the price tag creation API takes up to 3 seconds to reply, maybe because it waits for prediction results. Waiting for this breaks the fluidity of drawing successive boxes.

- [x] 5. During "Cleanup", unreadable price tags should be identifiable

The cleanup phase now uses the same buttons as the Price Validator Assistant, and updates price tag status depending on user choice.
![Capture](https://github.com/user-attachments/assets/86cce649-9c9d-4c78-9215-b08458ec16ba)

- [x] 6. During "Labels extractions", we could use different colors depending on price tag status (linked to a price, automatic, manual, unreadable ... )

Boxes inside the canvas now have different colors and a legend.
![Sans titre](https://github.com/user-attachments/assets/02b51137-aa8a-41eb-ae3f-2d138f2ba4da)


- [ ] 7. In "Summary", we should suggest a new proof to handle

UI is done, but the API call isn't correct, currently it fetches all proofs since the proof api doesn't allow for this kind of filtering (proofs with price tags to validate).
![Capture](https://github.com/user-attachments/assets/ad3b3be3-1aa7-44c6-a27e-a40cf9e08a23)

- [ ] 8. In "Labels extraction", we should show existing prices associated to the proof (in case the assistant wasn't used at first)

Existing price tags are shown. However, existing prices without a price tag association aren't shown.

- [ ] 9. In "Labels extraction", we should be able to edit and existing bounding box, instead of removing and adding a new one (using PATCH in API)

 Not really sure how to do this UI-wise, ideally this would mean resizing an existing box, but that is not trivial to implement. Maybe add an "edit" button that allows for redraw and replacement ?

- [x] 10. Empty bounding boxes can still be created

Should be fixed, boxes smaller than a few pixels are ignored.

- [x] 11. Sometimes barcodes detected by Gemini contain a letter, triggering an alert error.

Should be fixed, everything that is not a number is stripped from product_code.
