### PR TITLE
refactor(Price tags): add icons next to Error & Unreadable actions

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -35,6 +35,7 @@
       <v-btn
         color="error"
         variant="outlined"
+        prepend-icon="mdi-crop"
         @click="removePriceTag(3)"
       >
         {{ $t('Common.Error') }}
@@ -42,6 +43,7 @@
       <v-btn
         color="warning"
         variant="outlined"
+        prepend-icon="mdi-eye-off-outline"
         @click="removePriceTag(2)"
       >
         {{ $t('Common.Unreadable') }}


### PR DESCRIPTION
### What

Better differentiate the "Error" & "Unreadable" actions
- error = bad cropping from the AI
- unreadable = good cropping but unreadable by a human

### Screenshot

||Desktop|Mobile|
|---|---|---|
|Before|![image](https://github.com/user-attachments/assets/e730184e-223f-4fb1-9b88-e6b352d32a9f)|![image](https://github.com/user-attachments/assets/65e84ca5-d2db-4f5f-a719-a067c50ce7ab)|
|After|![image](https://github.com/user-attachments/assets/50e998b7-77bf-414d-a0d3-79e14acd1eca)|![image](https://github.com/user-attachments/assets/5217e86b-5005-41ef-a03d-82209c89082f)|