### PR TITLE
refactor(Barcode scanner): display price tag cropped image if available

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -8,6 +8,12 @@
       <v-divider />
 
       <v-card-text>
+        <v-img
+          v-if="barcodeManualInputCroppedImage"
+          :src="barcodeManualInputCroppedImage"
+          contain
+          max-height="50%"
+        />
         <v-tabs v-model="currentDisplay">
           <v-tab v-for="item in displayItems" :key="item.key" :value="item.key">
             <v-icon start>
@@ -97,7 +103,11 @@ export default {
     barcodeManualInputPrefillValue: {
       type: String,
       default: ''
-    }
+    },
+    barcodeManualInputCroppedImage: {
+      type: String,
+      default: ''
+    },
   },
   emits: ['barcode', 'close'],
   data() {

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -2,7 +2,7 @@
 <template>
   <v-card height="100%">
     <v-card-text>
-      <ProofImageCropped class="mb-4" height="200px" :proofImageFilePath="productPriceForm.proofImage" :boundingBox="productPriceForm.bounding_box" />
+      <ProofImageCropped class="mb-4" height="200px" :proofImageFilePath="productPriceForm.proofImage" :boundingBox="productPriceForm.bounding_box" @croppedImage="setCroppedImage($event)" />
       <v-row v-if="showProductNameField">
         <v-col>
           <v-text-field
@@ -105,6 +105,9 @@ export default {
     }
   },
   methods: {
+    setCroppedImage(croppedImage) {
+      this.productPriceForm.croppedImage = croppedImage
+    },
     removePriceTag(status=null) {
       this.$emit('removePriceTag', status)
     },

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -63,6 +63,7 @@
     v-model="barcodeScannerDialog"
     :hideBarcodeScannerTab="hideBarcodeScannerTab"
     :barcodeManualInputPrefillValue="productForm.product_code"
+    :barcodeManualInputCroppedImage="productForm.croppedImage"
     @barcode="setProductCode($event)"
     @close="barcodeScannerDialog = false"
   />

--- a/src/components/ProofImageCropped.vue
+++ b/src/components/ProofImageCropped.vue
@@ -17,6 +17,7 @@ export default {
       default: () => []
     }
   },
+  emits: ['croppedImage'],
   data() {
     return {
       canvas: null,
@@ -56,6 +57,7 @@ export default {
       this.canvas.height = height
       this.ctx.drawImage(this.proofImage, Math.min(startX, endX), Math.min(startY, endY), width, height, 0, 0, width, height)
       this.croppedImage = this.canvas.toDataURL()
+      this.$emit('croppedImage', this.croppedImage)
     }
   }
 }


### PR DESCRIPTION
### What

When validating prices, and fixing the barcode, we now display the cropped image :tada: 

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/694432e1-8714-4011-b0be-5b6f73c68523)|![image](https://github.com/user-attachments/assets/b17ed233-b9e1-4c7a-be08-0af80b1f4578)|