### PR TITLE
refactor(Proofs): display the proof action menu to everyone

### DIFF
--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="userIsProofOwner ? '11' : '12'">
+    <v-col cols="11">
       <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" :readonly="true" />
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofReceiptPriceCountChip v-if="showReceiptPriceCount" class="mr-1" :totalCount="proof.receipt_price_count" />
@@ -14,7 +14,7 @@
     </v-col>
   </v-row>
 
-  <ProofActionMenuButton v-if="!hideProofActions && userIsProofOwner" :proof="proof" />
+  <ProofActionMenuButton v-if="!hideProofActions" :proof="proof" />
 </template>
 
 <script>
@@ -87,7 +87,7 @@ export default {
   },
   methods: {
     goToProof() {
-      if (this.readonly || !this.userIsProofOwner) {
+      if (this.readonly) {
         return
       }
       this.$router.push({ path: `/proofs/${this.proof.id}` })

--- a/src/views/ProofList.vue
+++ b/src/views/ProofList.vue
@@ -11,7 +11,7 @@
 
   <v-row class="mt-0">
     <v-col v-for="proof in proofList" :key="proof" cols="12" sm="6" md="4" xl="3">
-      <ProofCard :proof="proof" :hideProofHeader="true" :hideProofActions="true" :showImageThumb="true" elevation="1" height="100%" />
+      <ProofCard :proof="proof" :hideProofHeader="true" :showImageThumb="true" elevation="1" height="100%" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

Following #1118 we now made it easy to view all proofs to everyone.

This PR adds the bottom-right menu to all proofs (but actions are limited if not the owner)

### Screenshot

/proofs page

|Before|After (not proof owner)|After (proof owner)
|---|---|---|
|![image](https://github.com/user-attachments/assets/76489e9b-30f4-4b93-b8f8-d26f0ac64438)|![image](https://github.com/user-attachments/assets/bc85dd20-f24c-4198-92fd-c428344c5b8b)|![image](https://github.com/user-attachments/assets/edbee5ea-a951-4214-bac2-21f635f5e549)|