### PR TITLE
refactor(Assistants): barcode pre-cleaning rules to improve matching

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -65,9 +65,7 @@ function isValidBarcode(value) {
 }
 
 function cleanBarcode(value) {
-  // remove spaces
-  value = value.replace(/\s/g, '')
-  // keep only digits
+  // keep only digits (remove letters, spaces, special characters)
   value = value.replace(/\D/g, '')
   // special case: 22 digits could be Carrefour
   // 182492/3119789831280/051 -> 1824923119789831280051 -> 3119789831280

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,21 @@ function isValidBarcode(value) {
   return ((10 - (result % 10)) % 10) === parseInt(paddedValue.charAt(13), 10)
 }
 
+function cleanBarcode(value) {
+  // remove spaces
+  value = value.replace(/\s/g, '')
+  // keep only digits
+  value = value.replace(/\D/g, '')
+  // special case: 22 digits could be Carrefour
+  // 182492/3119789831280/051 -> 1824923119789831280051 -> 3119789831280
+  if (value.length === 22) {
+    value = value.substring(6, 6+13)
+  }
+  // remove leading zeros
+  value = value.replace(/^0+/, '')
+  return value
+}
+
 function addObjectToArray(arr, obj, unshift=false, avoidDuplicates=true) {
   // look for duplicate
   let duplicateItemIndex = arr.findIndex(item => JSON.stringify(item) === JSON.stringify(obj))
@@ -414,6 +429,7 @@ export default {
   isURL,
   getURLOrigin,
   isValidBarcode,
+  cleanBarcode,
   addObjectToArray,
   removeObjectFromArray,
   currentStartOfDay,

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -357,10 +357,10 @@ export default {
       this.priceTags.forEach(priceTag => {
         const label = priceTag['predictions'][0]['data']
         // remove anything that is not a number from label.barcode
-        const barcodeString = label.barcode ? label.barcode.toString().replace(/\D/g, '') : ''
+        const barcodeString = label.barcode ? utils.cleanBarcode(label.barcode.toString()) : ''
         const productPriceForm = {
           id: priceTag.id,
-          type: barcodeString.length > 10 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY,
+          type: barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY,
           category_tag: label.product,
           origins_tags: [label.origin],
           labels_tags: label.organic ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : [],

--- a/src/views/PriceValidatorAssistant.vue
+++ b/src/views/PriceValidatorAssistant.vue
@@ -121,11 +121,11 @@ export default {
           this.loading = false
           for (let i = 0; i < data.items.length; i++) {
             const label = data.items[i]['predictions'][0]['data']
-            const barcodeString = label.barcode ? label.barcode.toString().replace(/\s/g, '') : ''
+            const barcodeString = label.barcode ? utils.cleanBarcode(label.barcode.toString()) : ''
             // TODO: some of these will be None if gemini did not give a proper reply, so detection and error handling is needed
             const productPriceForm = {
               id: data.items[i].id,
-              type: barcodeString.length > 10 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY,
+              type: barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY,
               category_tag: label.product,
               origins_tags: [label.origin],
               labels_tags: label.organic ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : [],
@@ -136,6 +136,7 @@ export default {
               proof: data.items[i]['proof'],
               proofImage: data.items[i]['proof'].file_path,
               // proofImage: 'https://prices.openfoodfacts.org/img/0024/2NToLMxOgN.webp',
+              croppedImage: null,
               product_code: barcodeString,
               detected_product_code: barcodeString,
               product_name: label.product_name,


### PR DESCRIPTION
### What

Some quick rules to cleanup the barcode string returned by the prediction.
- keep only digits
- remove leading 0s
- special rule for Carrefour (linked to https://github.com/openfoodfacts/open-prices/pull/660)
- also, valid barcodes start at 8 (EAN8)

### Why

To increase product matching

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/a4bdee08-0cc5-43ab-9bb1-9f499c0d8b35)|![image](https://github.com/user-attachments/assets/c98f8e7d-3ff7-4887-bef8-3ebbbad13459)|