### PR TITLE
feat(User recent proofs): Add proof filters in dialog header

### DIFF
--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -55,7 +55,6 @@
   <UserRecentProofsDialog
     v-if="userRecentProofsDialog"
     v-model="userRecentProofsDialog"
-    :filterType="proofImageForm.type"
     @recentProofSelected="recentProofSelected($event)"
     @close="userRecentProofsDialog = false"
   />


### PR DESCRIPTION
### What

Improve the UserRecentProofsDialog with a new subheader containing info & filters

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/07f78298-aa1e-424c-8816-c7ac27d191fa)|![image](https://github.com/user-attachments/assets/d08c3acc-c292-4951-a6fc-79dbd6dedced)|
