### PR TITLE
feat(l10n): translate label list in price add form depending on user locale

### DIFF
--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -45,7 +45,7 @@
         </v-col>
         <v-col class="pt-0" cols="6">
           <v-checkbox
-            v-for="lt in labelsTags"
+            v-for="lt in labelTags"
             :key="lt.id"
             v-model="productForm.labels_tags"
             density="compact"
@@ -76,7 +76,6 @@ import { useAppStore } from '../store'
 import api from '../services/api'
 import constants from '../constants'
 import utils from '../utils.js'
-import LabelsTags from '../data/labels-tags.json'
 
 export default {
   components: {
@@ -114,7 +113,7 @@ export default {
       productTypeList: constants.PRICE_TYPE_LIST,
       categoryTags: [],  // list of category tags for autocomplete  // see initPriceMultipleForm
       originTags: [],  // list of origins tags for autocomplete  // see initPriceMultipleForm
-      labelsTags: LabelsTags,
+      labelTags: [],  // list of labels tags for checkboxes  // see initPriceMultipleForm
       barcodeScannerDialog: false,
     }
   },
@@ -162,6 +161,9 @@ export default {
     })
     utils.getLocaleOriginTags(this.appStore.getUserLanguage).then((module) => {
       this.originTags = module.default
+    })
+    utils.getLocaleLabelTags(this.appStore.getUserLanguage).then((module) => {
+      this.labelTags = module.default
     })
     this.productForm.type = this.productForm.type ? this.productForm.type : (this.productForm.product_code ? constants.PRICE_TYPE_PRODUCT : this.appStore.user.last_product_product_used)
     if (this.productForm.product_code) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -233,6 +233,10 @@ function getLocaleOriginTags(locale) {
   return import(`./data/origins/${locale}.json`)
 }
 
+function getLocaleLabelTags(locale) {
+  return import(`./data/labels/${locale}.json`)
+}
+
 function getPriceTypeIcon(priceType) {
   return constants[`PRICE_TYPE_${priceType}_ICON`] || constants.PRICE_ICON
 }
@@ -444,6 +448,7 @@ export default {
   getLocaleCategoryTag,
   getLocaleCategoryTagName,
   getLocaleOriginTags,
+  getLocaleLabelTags,
   getPriceTypeIcon,
   getProofTypeIcon,
   getCountryEmojiFromName,


### PR DESCRIPTION
### What

Following #1215 (and similar to #275 & #322)
- we now have the translated labels
- we can display the corresponding origin list depending on the user locale

### Screenshot

example with the French locale (Organic -> Bio)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/3eebe445-abbc-4747-8342-4278e29f210a)|![image](https://github.com/user-attachments/assets/ff13fc4d-5583-409e-be37-b79dcb57b830)|