### PR TITLE
refactor(Price label chip): translate chip content depending on user locale

### DIFF
--- a/src/components/PriceLabels.vue
+++ b/src/components/PriceLabels.vue
@@ -1,14 +1,16 @@
 <template>
   <span v-if="priceLabels">
-    <v-chip v-for="label in priceLabelsTagsList" :key="label" label size="small" density="comfortable" class="mr-1">
-      {{ label.name }}
-      <v-icon v-if="label.icon" end :icon="label.icon" />
+    <v-chip v-for="label in priceLabels" :key="label" class="mr-1" label size="small" density="comfortable">
+      {{ getPriceLabelTagName(label) }}
+      <v-icon v-if="label == 'en:organic'" icon="mdi-leaf-circle-outline" end />
     </v-chip>
   </span>
 </template>
 
 <script>
-import LabelTags from '../data/labels-tags.json'
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import utils from '../utils.js'
 
 export default {
   props: {
@@ -17,10 +19,24 @@ export default {
       default: () => []
     }
   },
+  data() {
+    return {
+      labelTags: [],  // see mounted
+    }
+  },
   computed: {
-    priceLabelsTagsList() {
-      return LabelTags.filter(lt => this.priceLabels.includes(lt.id))
-    },
+    ...mapStores(useAppStore),
+  },
+  mounted() {
+    utils.getLocaleLabelTags(this.appStore.getUserLanguage).then((module) => {
+      this.labelTags = module.default
+    })
+  },
+  methods: {
+    getPriceLabelTagName(labelId) {
+      if (this.labelTags.length === 0) return ''
+      return this.labelTags.find(lt => lt.id === labelId).name
+    }
   }
 }
 </script>

--- a/src/utils.js
+++ b/src/utils.js
@@ -237,6 +237,13 @@ function getLocaleLabelTags(locale) {
   return import(`./data/labels/${locale}.json`)
 }
 
+function getLocaleLabelTagName(locale, labelId) {
+  return getLocaleLabelTags(locale).then((module) => {
+    let label = module.default.find(ct => ct.id === labelId)
+    return label ? label.name : labelId
+  })
+}
+
 function getPriceTypeIcon(priceType) {
   return constants[`PRICE_TYPE_${priceType}_ICON`] || constants.PRICE_ICON
 }
@@ -449,6 +456,7 @@ export default {
   getLocaleCategoryTagName,
   getLocaleOriginTags,
   getLocaleLabelTags,
+  getLocaleLabelTagName,
   getPriceTypeIcon,
   getProofTypeIcon,
   getCountryEmojiFromName,


### PR DESCRIPTION
### What

Following #1215 & #1216

Translate price label chip depending on user locale

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/f600c5b6-9689-4f12-9c1f-57cee9f45a49)|![image](https://github.com/user-attachments/assets/a70bb701-5b6c-40cc-b0ef-fec936554cbc)|
