### PR TITLE
feat(Price Validation Assistant): open price validation to all proofs (not just owned)

### DIFF
--- a/src/components/FilterMenu.vue
+++ b/src/components/FilterMenu.vue
@@ -68,7 +68,7 @@ export default {
     kind: {
       type: String,
       default: 'product',
-      examples: ['product', 'price', 'proof', 'location', 'user']
+      examples: ['product', 'price', 'proof', 'priceTag', 'location', 'user']
     },
     currentFilter: {
       type: String,
@@ -98,6 +98,7 @@ export default {
       productFilterList: constants.PRODUCT_FILTER_LIST,
       priceFilterList: constants.PRICE_FILTER_LIST,
       proofFilterList: constants.PROOF_FILTER_LIST,
+      priceTagFilterList: constants.PRICE_TAG_FILTER_LIST,
       locationFilterList: constants.LOCATION_FILTER_LIST,
       userFilterList: constants.USER_FILTER_LIST,
       // other filters

--- a/src/constants.js
+++ b/src/constants.js
@@ -119,7 +119,7 @@ export default {
     { key: 'hide_price_count_gte_1', value: 'FilterProofWithPriceCountHide' },
   ],
   PRICE_TAG_FILTER_LIST: [
-    { key: 'show_proof_owner', value: 'FilterPriceTagWithProofOwner' },
+    { key: 'proof__owner', value: 'FilterPriceTagWithProofOwner' },
   ],
   LOCATION_FILTER_LIST: [
     { key: 'hide_price_count_gte_1', value: 'FilterLocationWithPriceCountHide' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -118,6 +118,9 @@ export default {
   PROOF_FILTER_LIST: [
     { key: 'hide_price_count_gte_1', value: 'FilterProofWithPriceCountHide' },
   ],
+  PRICE_TAG_FILTER_LIST: [
+    { key: 'show_proof_owner', value: 'FilterPriceTagWithProofOwner' },
+  ],
   LOCATION_FILTER_LIST: [
     { key: 'hide_price_count_gte_1', value: 'FilterLocationWithPriceCountHide' },
   ],

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -246,6 +246,7 @@
 		"FilterProductWithoutPriceCount": "Without prices",
 		"FilterPriceMoreThan30DaysHide": "Hide prices older than 30 days",
 		"FilterProofWithPriceCountHide": "Hide proofs with prices",
+		"FilterPriceTagWithProofOwner": "Show only my proofs",
 		"FilterLocationWithPriceCountHide": "Hide locations with prices",
 		"FilterUserWithPriceCountHide": "Hide contributors with prices",
 		"Fix": "Fix",

--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -4,6 +4,7 @@
       <v-chip label variant="text" prepend-icon="mdi-checkbox-marked-circle-plus-outline">
         {{ $t('Common.PriceToValidateCount', { count: priceTagTotal }) }}
       </v-chip>
+      <FilterMenu kind="priceTag" :currentFilter="currentFilter" @update:currentFilter="togglePriceTagFilter($event)" />
     </v-col>
   </v-row>
 
@@ -45,6 +46,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     ContributionAssistantPriceFormCard: defineAsyncComponent(() => import('../components/ContributionAssistantPriceFormCard.vue')),
   },
   data() {
@@ -57,6 +59,7 @@ export default {
       loading: false,
       productPriceForms: [],
       // filter & order
+      currentFilter: '',
       currentOrder: '-proof_id',  // order by most recent proof
       // feedback
       priceRemovedMessage: false,
@@ -74,7 +77,7 @@ export default {
       return 6
     },
     getPriceTagsParams() {
-      return {
+      let defaultParams = {
         proof__ready_for_price_tag_validation: true,
         status__isnull: true,
         created__lte: this.currentDateTime,
@@ -82,9 +85,21 @@ export default {
         size: this.getApiSize,
         page: this.priceTagPage
       }
+      if (this.currentFilter === 'show_proof_owner') {
+        defaultParams['proof__owner'] = this.username
+      }
+      return defaultParams
     },
   },
+  watch: {
+    $route (newRoute, oldRoute) {  // only called when query changes to avoid having an API call when the path changes
+      if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
+        this.initPriceTags()
+      }
+    }
+  },
   mounted() {
+    this.currentFilter = this.$route.query[constants.FILTER_PARAM] || this.currentFilter
     this.getPriceTags()
     // load more
     this.handleDebouncedScroll = utils.debounce(this.handleScroll, 100)
@@ -94,6 +109,13 @@ export default {
     window.removeEventListener('scroll', this.handleDebouncedScroll)
   },
   methods: {
+    initPriceTags() {
+      this.locationId = this.$route.params.id
+      this.priceTagList = []
+      this.priceTagTotal = null
+      this.priceTagPage = 0
+      this.getPriceTags()
+    },
     removePriceTag(index, status) {
       /**
        * - update the price_tag (API)
@@ -210,6 +232,11 @@ export default {
           console.log(error)
           this.createPriceLoading = false
         })
+    },
+    togglePriceTagFilter(filterKey) {
+      this.currentFilter = this.currentFilter ? '' : filterKey
+      this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.currentFilter } })
+      // this.initPriceTags() will be called in watch $route
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars
       if (utils.getDocumentScrollPercentage() > 90) {

--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -85,7 +85,7 @@ export default {
         size: this.getApiSize,
         page: this.priceTagPage
       }
-      if (this.currentFilter === 'show_proof_owner') {
+      if (this.currentFilter === 'proof__owner') {
         defaultParams['proof__owner'] = this.username
       }
       return defaultParams

--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -74,7 +74,14 @@ export default {
       return 6
     },
     getPriceTagsParams() {
-      return { proof__owner: this.username, proof__ready_for_price_tag_validation: true, status__isnull: true, created__lte: this.currentDateTime, order_by: this.currentOrder, size: this.getApiSize, page: this.priceTagPage }
+      return {
+        proof__ready_for_price_tag_validation: true,
+        status__isnull: true,
+        created__lte: this.currentDateTime,
+        order_by: this.currentOrder,
+        size: this.getApiSize,
+        page: this.priceTagPage
+      }
     },
   },
   mounted() {


### PR DESCRIPTION
### What

Price Validation Assistant: 
- allow any user to validate any price tag (not just the ones coming from owned proofs)
- add a filter to toggle to only price tags coming from owned proofs

### Screenshot

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/fb6bbfd5-9f42-4afb-be04-0b61b2510d62)|![image](https://github.com/user-attachments/assets/8771d4f5-0ca3-455e-8b8d-29a6e314709c)|
