### PR TITLE
refactor(Contribution Assistant): make labels linked to prices readonly

### DIFF
--- a/src/components/ContributionAssistantLabelList.vue
+++ b/src/components/ContributionAssistantLabelList.vue
@@ -10,12 +10,16 @@
       <v-card>
         <v-card-text>
           <v-img style="height:150px" :src="label.imageSrc" />
-          <v-chip label size="small" density="comfortable">
-            {{ $t('Common.Source') }} {{ label.boundingSource }}
-          </v-chip>
         </v-card-text>
         <v-divider />
-        <v-card-actions>
+        <v-card-text>
+          <v-chip class="mr-1" label size="small" density="comfortable">
+            {{ $t('Common.Source') }} {{ label.boundingSource }}
+          </v-chip>
+          <PriceCountChip v-if="labelHasPrice(label)" :count="1" :withLabel="true" source="proof" />
+        </v-card-text>
+        <v-divider v-if="!labelHasPrice(label)" />
+        <v-card-actions v-if="!labelHasPrice(label)">
           <v-btn
             color="error"
             variant="outlined"
@@ -31,18 +35,26 @@
 </template>
 
 <script>
-  export default {
-    props: {
-      labels: {
-        type: Array,
-        default: () => []
-      }
+import { defineAsyncComponent } from 'vue'
+
+export default {
+  components: {
+    PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue'))
+  },
+  props: {
+    labels: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['removeLabel'],
+  methods: {
+    labelHasPrice(label) {
+      return label.status === 1
     },
-    emits: ['removeLabel'],
-    methods: {
-      removeLabel(index) {
-        this.$emit('removeLabel', index)
-      }
+    removeLabel(index) {
+      this.$emit('removeLabel', index)
     }
   }
+}
 </script>

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -59,9 +59,9 @@ import constants from '../constants'
 export default {
   components: {
     ProofImageCropped: defineAsyncComponent(() => import('../components/ProofImageCropped.vue')),
-  ProductInputRow: defineAsyncComponent(() => import('../components/ProductInputRow.vue')),
-  PriceInputRow: defineAsyncComponent(() => import('../components/PriceInputRow.vue')),
-  ProofFooterRow: defineAsyncComponent(() => import('../components/ProofFooterRow.vue')),
+    ProductInputRow: defineAsyncComponent(() => import('../components/ProductInputRow.vue')),
+    PriceInputRow: defineAsyncComponent(() => import('../components/PriceInputRow.vue')),
+    ProofFooterRow: defineAsyncComponent(() => import('../components/ProofFooterRow.vue')),
   },
   props: {
     productPriceForm: {


### PR DESCRIPTION
### What

Contribution assistant: small improvements on the label step
- move "Source" chip in a dedicated section to add margin with label image
- hide "Delete" button if label already has a linked price

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/04468222-db60-49f6-b8cf-94d536c880d9)|![image](https://github.com/user-attachments/assets/fdd1443b-a573-4ad7-80cb-beaa112c6729)|
