### PR TITLE
refactor(Contribution Assistant): cleanup: small improvements for prices already added

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -20,8 +20,8 @@
     <v-card-text v-if="mode === 'Validation'">
       <ProofFooterRow :proof="productPriceForm.proof" :showProofChip="true" :hideProofType="true" :hideProofActions="true" :readonly="true" />
     </v-card-text>
-    <v-divider />
-    <v-card-actions>
+    <v-divider v-if="!hideActions" />
+    <v-card-actions v-if="!hideActions">
       <v-btn
         color="error"
         variant="outlined"
@@ -88,6 +88,10 @@ export default {
       default: 'Contribution'  // or 'Validation'
     },
     showProductNameField: {
+      type: Boolean,
+      default: false
+    },
+    hideActions: {
       type: Boolean,
       default: false
     }

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -85,7 +85,7 @@
               md="6"
               xl="4"
             >
-              <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" :disabled="!!productPriceForm.price_id" />
+              <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" :hideActions="true" :disabled="true" />
             </v-col>
           </v-row>
           <v-row>

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -74,11 +74,9 @@
               <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" @removePriceTag="removePriceTag($event, productPriceForm)" />
             </v-col>
           </v-row>
-          <v-row v-if="productPriceFormsWithPriceId.length">
-            <h3 class="mb-4">
-              {{ $t('ContributionAssistant.PricesAlreadyAdded') }}
-            </h3>
-          </v-row>
+          <h3 v-if="productPriceFormsWithPriceId.length" class="mt-4 mb-4">
+            {{ $t('ContributionAssistant.PricesAlreadyAdded') }}
+          </h3>
           <v-row v-if="productPriceFormsWithPriceId.length">
             <v-col
               v-for="(productPriceForm, index) in productPriceFormsWithPriceId"


### PR DESCRIPTION
### What

Contribution assistant: small improvements on the cleanup step
- hide the price tag actions for prices already added
  (a better alternative would be to display only the image + price card (not the price form))
- add a bit of padding above the title

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/6abdcb89-ef16-477e-9a09-157a80f406e0)|![image](https://github.com/user-attachments/assets/24687276-2832-455b-9284-dc9274950c98)|