### PR TITLE
fix(Price Validation Assistant): avoid duplicate prices tags during pagination

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -121,6 +121,13 @@ function currentDate() {
 }
 
 /**
+ * output: '2023-12-25T17:08:19.021410+01:00'
+ */
+function currentDateTime() {
+  return new Date().toISOString()
+}
+
+/**
  * output: '2023-12-25T00:00:00.000Z'
  */
 function currentStartOfDay() {
@@ -443,9 +450,10 @@ export default {
   cleanBarcode,
   addObjectToArray,
   removeObjectFromArray,
-  currentStartOfDay,
   prettyPrice,
   currentDate,
+  currentDateTime,
+  currentStartOfDay,
   prettyDate,
   prettyDateTime,
   offDateTime,

--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -49,6 +49,8 @@ export default {
   },
   data() {
     return {
+      currentDateTime: utils.currentDateTime(),  // usefull to avoid fetching duplicates during pagination
+      // data
       priceTagList: [],
       priceTagTotal: null,
       priceTagPage: 0,  // issue with pagination once the user starts removing/validating price tags...
@@ -72,7 +74,7 @@ export default {
       return 6
     },
     getPriceTagsParams() {
-      return { proof__owner: this.username, proof__ready_for_price_tag_validation: true, status__isnull: true, order_by: this.currentOrder, size: this.getApiSize, page: this.priceTagPage }
+      return { proof__owner: this.username, proof__ready_for_price_tag_validation: true, status__isnull: true, created__lte: this.currentDateTime, order_by: this.currentOrder, size: this.getApiSize, page: this.priceTagPage }
     },
   },
   mounted() {


### PR DESCRIPTION
### What

When fetching new price tags, and if the user had at the same time proofs that are being processed, there were cases of duplicate price tags popping up.

Here we add a filter on the price tag creation date. When starting a PVA "session", only price tags already generated will show up.

Up to the user to refresh the whole page if he wants to load the latest generated price tags.
