### PR TITLE
fix(Price Validation Assistant): only show price tags with a prediction

### DIFF
--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -129,29 +129,32 @@ export default {
           this.priceTagTotal = data.total
           this.loading = false
           for (let i = 0; i < data.items.length; i++) {
-            const label = data.items[i]['predictions'][0]['data']
-            const barcodeString = label.barcode ? utils.cleanBarcode(label.barcode.toString()) : ''
-            // TODO: some of these will be None if gemini did not give a proper reply, so detection and error handling is needed
-            const productPriceForm = {
-              id: data.items[i].id,
-              type: barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY,
-              category_tag: label.product,
-              origins_tags: [label.origin],
-              labels_tags: label.organic ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : [],
-              price: label.price.toString(),
-              price_per: label.unit,
-              price_is_discounted: false,
-              currency: data.items[i]['proof'].currency || this.appStore.getUserLastCurrencyUsed,
-              proof: data.items[i]['proof'],
-              proofImage: data.items[i]['proof'].file_path,
-              // proofImage: 'https://prices.openfoodfacts.org/img/0024/2NToLMxOgN.webp',
-              croppedImage: null,
-              product_code: barcodeString,
-              detected_product_code: barcodeString,
-              product_name: label.product_name,
-              bounding_box: data.items[i].bounding_box
+            // only validate price tags with predictions
+            if (data.items[i]['predictions'].length > 0) {
+              const label = data.items[i]['predictions'][0]['data']
+              const barcodeString = label.barcode ? utils.cleanBarcode(label.barcode.toString()) : ''
+              // TODO: some of these will be None if gemini did not give a proper reply, so detection and error handling is needed
+              const productPriceForm = {
+                id: data.items[i].id,
+                type: barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY,
+                category_tag: label.product,
+                origins_tags: [label.origin],
+                labels_tags: label.organic ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : [],
+                price: label.price.toString(),
+                price_per: label.unit,
+                price_is_discounted: false,
+                currency: data.items[i]['proof'].currency || this.appStore.getUserLastCurrencyUsed,
+                proof: data.items[i]['proof'],
+                proofImage: data.items[i]['proof'].file_path,
+                // proofImage: 'https://prices.openfoodfacts.org/img/0024/2NToLMxOgN.webp',
+                croppedImage: null,
+                product_code: barcodeString,
+                detected_product_code: barcodeString,
+                product_name: label.product_name,
+                bounding_box: data.items[i].bounding_box
+              }
+              this.productPriceForms.push(productPriceForm)
             }
-            this.productPriceForms.push(productPriceForm)
           }
         })
     },


### PR DESCRIPTION
### What

To avoid errors when displaying price tags to validate, only display price tags that have a prediction.

When a proof is JUST uploaded, it can happen that the prediction has not had time to run, resulting in an error loading the PVA page.