### PR TITLE
refactor(Breadcrumbs): homogenize display and padding

### DIFF
--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row v-if="breadcrumbs">
     <v-col class="py-0">
-      <v-breadcrumbs class="text-h6 pa-0" density="compact" :items="breadcrumbs">
+      <v-breadcrumbs class="text-h6 px-0 pt-2 pb-0" density="compact" :items="breadcrumbs">
         <template #item="{ item }">
           <v-breadcrumbs-item
             class="pa-0"

--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -1,16 +1,25 @@
 <template>
-  <v-breadcrumbs v-if="breadcrumbs" class="text-h6 pa-0" density="compact" :items="breadcrumbs">
-    <template #title="{ item }">
-      {{ $t(`Router.${item.title}.Title`) }}
-    </template>
-  </v-breadcrumbs>
+  <v-row v-if="breadcrumbs">
+    <v-col class="py-0">
+      <v-breadcrumbs class="text-h6 pa-0" density="compact" :items="breadcrumbs">
+        <template #item="{ item }">
+          <v-breadcrumbs-item
+            class="pa-0"
+            :title="$t(`Router.${item.title}.Title`)"
+            :to="item.to"
+            :disabled="item.disabled"
+          />
+        </template>
+      </v-breadcrumbs>
+    </v-col>
+  </v-row>
 </template>
   
 <script>
 export default {
   computed: {
     breadcrumbs() {
-      return this.$route.meta.breadcrumbs;
+      return this.$route.meta.breadcrumbs
     }
   },
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,7 @@ export default {
   APP_GITHUB_REUSE_DISCUSSION_URL: 'https://github.com/openfoodfacts/open-prices/discussions/562',
   APP_HUGGING_FACE_URL: 'https://huggingface.co/datasets/openfoodfacts/open-prices',
   APP_DATA_GOUV_URL: 'https://www.data.gouv.fr/fr/datasets/open-prices/',
+  APP_HOME_ICONS: '🏷🍊💲',
   // OFF
   OFF_NAME: OFF_NAME,
   OFF_URL: 'https://world.openfoodfacts.org',

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col class="pt-0">
+    <v-col class="pt-2 pb-0">
       <h2 class="text-h6">
         {{ $t('Common.TaglineAlt1') }} {{ APP_HOME_ICONS }}
       </h2>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,9 +1,11 @@
 <template>
-  <h2 class="text-h6">
-    {{ $t('Common.TaglineAlt1') }} 🏷🍊💲
-  </h2>
-
-  <br>
+  <v-row>
+    <v-col class="pt-0">
+      <h2 class="text-h6">
+        {{ $t('Common.TaglineAlt1') }} {{ APP_HOME_ICONS }}
+      </h2>
+    </v-col>
+  </v-row>
 
   <v-row>
     <v-col cols="6" sm="4" md="3" lg="2">
@@ -46,6 +48,7 @@ export default {
   data() {
     return {
       APP_NAME: constants.APP_NAME,
+      APP_HOME_ICONS: constants.APP_HOME_ICONS,
       // data
       latestPriceList: [],
       todayPriceCount: null,


### PR DESCRIPTION
### What

Tweak a bit the Breadcrumb style to bette display it at the top of the web pages.
- same top & bottom padding
- remove left & right padding
- homogenize with the home page title

### Screenshot

|Page|Before|After|
|---|---|---|
|Settings|![image](https://github.com/user-attachments/assets/e968f84b-ba88-4cec-9f17-b195b3b62d3d)|![image](https://github.com/user-attachments/assets/50552ea8-44aa-408b-8e48-8a736c44e22f)|
|PVA|![image](https://github.com/user-attachments/assets/43562a04-2995-4d8c-ba42-04ba094386c7)|![image](https://github.com/user-attachments/assets/77b62f25-d4c9-4e28-8341-269cb3fb6021)|
|Dashboard > My proofs|![image](https://github.com/user-attachments/assets/1dc0e0a6-671b-438e-bfe2-ccf5bb924462)|![image](https://github.com/user-attachments/assets/595fb7cc-c599-4408-9c59-eb6d3ad045a5)|
|Home|![image](https://github.com/user-attachments/assets/e9edb33b-86df-4991-818a-e83a90c0f592)|![image](https://github.com/user-attachments/assets/1d3b1459-78a6-4f2a-b290-a47109f82cd0)|
