### PR TITLE
refactor(Breadcrumbs): homogenize display and padding (better)

### DIFF
--- a/src/components/Breadcrumbs.vue
+++ b/src/components/Breadcrumbs.vue
@@ -1,7 +1,12 @@
 <template>
-  <v-breadcrumbs v-if="breadcrumbs" class="text-h6 pa-0" density="compact" :items="breadcrumbs">
-    <template #title="{ item }">
-      {{ $t(`Router.${item.title}.Title`) }}
+  <v-breadcrumbs v-if="breadcrumbs" class="text-h6 px-0 pt-0 pb-4" density="compact" :items="breadcrumbs">
+    <template #item="{ item }">
+      <v-breadcrumbs-item
+        class="pa-0"
+        :title="$t(`Router.${item.title}.Title`)"
+        :to="item.to"
+        :disabled="item.disabled"
+      />
     </template>
   </v-breadcrumbs>
 </template>
@@ -10,7 +15,7 @@
 export default {
   computed: {
     breadcrumbs() {
-      return this.$route.meta.breadcrumbs;
+      return this.$route.meta.breadcrumbs
     }
   },
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,6 +29,7 @@ export default {
   APP_URL: import.meta.env.VITE_OPEN_PRICES_APP_URL,
   APP_API_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/api/docs`,
   APP_USER_AGENT: 'Open Prices Web App',
+  APP_HOME_ICONS: '🏷🍊💲',
   APP_DUMP_PRICES_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/data/prices.jsonl.gz`,
   APP_DUMP_PROOFS_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/data/proofs.jsonl.gz`,
   APP_DUMP_LOCATIONS_URL: `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/data/locations.jsonl.gz`,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,9 +1,7 @@
 <template>
-  <h2 class="text-h6">
-    {{ $t('Common.TaglineAlt1') }} 🏷🍊💲
+  <h2 class="text-h6 pb-4">
+    {{ $t('Common.TaglineAlt1') }} {{ APP_HOME_ICONS }}
   </h2>
-
-  <br>
 
   <v-row>
     <v-col cols="6" sm="4" md="3" lg="2">
@@ -46,6 +44,7 @@ export default {
   data() {
     return {
       APP_NAME: constants.APP_NAME,
+      APP_HOME_ICONS: constants.APP_HOME_ICONS,
       // data
       latestPriceList: [],
       todayPriceCount: null,


### PR DESCRIPTION
### What

Tweak a bit the Breadcrumb style to bette display it at the top of the web pages.
- same top & bottom padding
- remove left & right padding
- homogenize with the home page title

Note : will need an extra PR to improve the "middle" content padding (stats & filters row)

### Screenshot

|Page|Before|After|
|---|---|---|
|Settings|![image](https://github.com/user-attachments/assets/e968f84b-ba88-4cec-9f17-b195b3b62d3d)|![image](https://github.com/user-attachments/assets/ac2a5977-933e-4033-90a5-963cc76cc338)|
|PVA|![image](https://github.com/user-attachments/assets/43562a04-2995-4d8c-ba42-04ba094386c7)|![image](https://github.com/user-attachments/assets/0865c94c-1c43-4929-807f-d79e811da571)|
|Dashboard > My proofs|![image](https://github.com/user-attachments/assets/1dc0e0a6-671b-438e-bfe2-ccf5bb924462)|![image](https://github.com/user-attachments/assets/77a1e901-9147-4b2a-93a7-dc6d5e7e1b38)|
|Home|![image](https://github.com/user-attachments/assets/e9edb33b-86df-4991-818a-e83a90c0f592)|![image](https://github.com/user-attachments/assets/27e6235b-b16a-4a49-ac75-201e0c568f1a)|
