### PR TITLE
refactor(Price card): Move the proof chip to the left (first)

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -33,7 +33,7 @@
         </v-col>
       </v-row>
 
-      <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceProof="hidePriceProof" :hidePriceCreated="hidePriceCreated" :hideProductDetails="hideProductDetails" :readonly="readonly" />
+      <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceProof="hidePriceProof" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceCreated="hidePriceCreated" :hideProductDetails="hideProductDetails" :readonly="readonly" />
     </v-container>
   </v-card>
 </template>

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -1,10 +1,10 @@
 <template>
   <v-row style="margin-top:0;">
     <v-col cols="11">
+      <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
       <LocationChip v-if="!hidePriceLocation" class="mr-1" :location="price.location" :locationId="price.location_id" :readonly="readonly" />
       <UserChip v-if="!hidePriceOwner" class="mr-1" :username="price.owner" :readonly="readonly" />
       <DateChip v-if="!hidePriceDate" class="mr-1" :date="price.date" :readonly="readonly" />
-      <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
       <RelativeDateTimeChip v-if="!hidePriceCreated" :dateTime="price.created" />
     </v-col>
   </v-row>
@@ -17,10 +17,10 @@ import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    ProofChip: defineAsyncComponent(() => import('../components/ProofChip.vue')),
     LocationChip: defineAsyncComponent(() => import('../components/LocationChip.vue')),
     UserChip: defineAsyncComponent(() => import('../components/UserChip.vue')),
     DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
-    ProofChip: defineAsyncComponent(() => import('../components/ProofChip.vue')),
     RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
     PriceActionMenuButton: defineAsyncComponent(() => import('../components/PriceActionMenuButton.vue')),
   },

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row style="margin-top:0;">
     <v-col cols="11">
-      <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
+      <ProofChip v-if="price.proof && !hidePriceProof" class="mr-1" :proof="price.proof" />
       <LocationChip v-if="!hidePriceLocation" class="mr-1" :location="price.location" :locationId="price.location_id" :readonly="readonly" />
       <UserChip v-if="!hidePriceOwner" class="mr-1" :username="price.owner" :readonly="readonly" />
       <DateChip v-if="!hidePriceDate" class="mr-1" :date="price.date" :readonly="readonly" />
@@ -29,6 +29,10 @@ export default {
       type: Object,
       default: null
     },
+    hidePriceProof: {
+      type: Boolean,
+      default: false
+    },
     hidePriceLocation: {
       type: Boolean,
       default: false
@@ -38,10 +42,6 @@ export default {
       default: true
     },
     hidePriceDate: {
-      type: Boolean,
-      default: false
-    },
-    hidePriceProof: {
       type: Boolean,
       default: false
     },


### PR DESCRIPTION
### What

In #1158 we started showing in some places the Proof chip in the Proof footer row.
So users are getting used to seeing the Proof chip at the far left.
But in the Price footer the proof is somewhere on the right.

This PR homogenizes this by moving the Proof chip in the Price footer row to the far left as well.

This also gives/shows a bit more importance to proofs (over the rest of the metadata).

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/b8b14edd-fbc4-40e5-ab5e-d3596fad5ef0)|![image](https://github.com/user-attachments/assets/6dd6d27d-59fd-4d24-897c-d8209c94b033)|