### PR TITLE
feat(Theme): change most CTA button colors to primary (instead of success)

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -46,7 +46,7 @@
                 persistent-hint
               >
                 <template #append-inner>
-                  <v-btn :icon="barcodeManualInputMode === 'search' ? 'mdi-magnify' : 'mdi-plus'" :disabled="!barcodeManualFormValid" @click="barcodeSearchOrSend" />
+                  <v-btn color="primary" :icon="barcodeManualInputMode === 'search' ? 'mdi-magnify' : 'mdi-plus'" :disabled="!barcodeManualFormValid" @click="barcodeSearchOrSend" />
                 </template>
               </v-text-field>
             </v-form>

--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -17,7 +17,7 @@
         <v-col>
           <v-btn 
             class="float-right"
-            color="success"
+            color="primary"
             variant="flat"
             to="/proofs/add/multiple"
           >

--- a/src/components/ChallengeValidateCard.vue
+++ b/src/components/ChallengeValidateCard.vue
@@ -22,7 +22,7 @@
         <v-col>
           <v-btn
             class="float-right"
-            color="success"
+            color="primary"
             variant="flat"
             to="/experiments/price-validation-assistant"
           >

--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -41,7 +41,7 @@
       <v-spacer />
       <v-btn
         v-if="mode === 'Validation'"
-        color="success"
+        color="primary"
         variant="flat"
         @click="validatePriceTag"
       >

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -46,7 +46,7 @@
                 persistent-hint
               >
                 <template #append-inner>
-                  <v-btn icon="mdi-magnify" :disabled="!locationOsmSearchForm.q" @click="locationOsmSearch" />
+                  <v-btn color="primary" icon="mdi-magnify" :disabled="!locationOsmSearchForm.q" @click="locationOsmSearch" />
                 </template>
               </v-text-field>
             </v-form>
@@ -106,7 +106,7 @@
                 persistent-hint
               >
                 <template #append-inner>
-                  <v-btn icon="mdi-plus" :disabled="!locationOnlineFormValid" @click="createOnline" />
+                  <v-btn color="primary" icon="mdi-plus" :disabled="!locationOnlineFormValid" @click="createOnline" />
                 </template>
               </v-text-field>
             </v-form>

--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -43,7 +43,7 @@
       <v-card-actions>
         <v-btn
           class="float-right"
-          color="success"
+          color="primary"
           variant="flat"
           elevation="1"
           :loading="loading"

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -23,7 +23,7 @@
       <v-card-actions>
         <v-btn
           class="float-right"
-          color="success"
+          color="primary"
           variant="flat"
           elevation="1"
           :disabled="!formFilled"

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -39,7 +39,7 @@
     <v-card-actions>
       <v-spacer />
       <v-btn
-        color="success"
+        color="primary"
         variant="flat"
         :loading="loading || step === 2"
         :disabled="!proofFormFilled || loading || step === 2"

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -61,7 +61,7 @@
               <h3 class="mb-4">
                 {{ $t('ContributionAssistant.LabelsExtractionSteps.SendLabels') }}
               </h3>
-              <v-btn color="success" :disabled="!extractedLabels.length" :loading="processLabelsLoading" @click="processLabels">
+              <v-btn color="primary" :disabled="!extractedLabels.length" :loading="processLabelsLoading" @click="processLabels">
                 {{ $t('ContributionAssistant.LabelsExtractionSteps.SendLabelsButton') }}
               </v-btn>
             </v-col>
@@ -106,7 +106,7 @@
                   {{ $t('ContributionAssistant.PriceAddConfirmationMessage', { numberOfPricesAdded: productPriceFormsWithoutPriceId.length, date: proofObject.date, locationName: locationName }) }}
                 </p>
               </v-alert>
-              <v-btn class="float-right mt-4" color="success" :loading="loading" @click="addPrices">
+              <v-btn class="float-right mt-4" color="primary" :loading="loading" @click="addPrices">
                 {{ $t('Common.UploadMultiplePrices', productPriceFormsWithoutPriceId.length) }}
               </v-btn>
             </v-col>
@@ -129,16 +129,16 @@
               >
                 <strong>{{ $t('ContributionAssistant.PriceAddProgress', { numberOfPricesAdded: numberOfPricesAdded, totalNumberOfPrices: productPriceFormsWithoutPriceId.length }) }}</strong>
               </v-progress-linear>
-              <v-btn to="/dashboard" class="mt-4" :aria-label="$t('Common.Dashboard')" :disabled="!allDone">
+              <v-btn class="mt-4" color="primary" :aria-label="$t('Common.Dashboard')" to="/dashboard" :disabled="!allDone">
                 {{ $t('ContributionAssistant.GoToDashboard') }}
               </v-btn>
-              <v-btn :to="'/proofs/' + proofObject.id" class="mt-4 ml-4" :disabled="!allDone">
+              <v-btn class="mt-4 ml-4" color="primary" :to="'/proofs/' + proofObject.id" :disabled="!allDone">
                 {{ $t('ContributionAssistant.GoToProof') }}
               </v-btn>
-              <v-btn class="mt-4 ml-4" :disabled="!allDone" @click="reloadPage">
+              <v-btn class="mt-4 ml-4" color="primary" :disabled="!allDone" @click="reloadPage">
                 {{ $t('ContributionAssistant.AddNewProof') }}
               </v-btn>
-              <v-btn v-if="proofIdsFromQueryParam" class="mt-4 ml-4" :disabled="!allDone" @click="nextProof">
+              <v-btn v-if="proofIdsFromQueryParam" class="mt-4 ml-4" color="primary" :disabled="!allDone" @click="nextProof">
                 {{ $t('ContributionAssistant.NextProof') }}
               </v-btn>
             </v-col>

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -75,7 +75,7 @@
               <v-col>
                 <v-btn
                   class="float-right"
-                  color="success"
+                  color="primary"
                   variant="flat"
                   type="submit"
                   :loading="loading"
@@ -117,7 +117,6 @@
             <v-col cols="12" md="6">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-tag-plus-outline"
                 @click="reloadPage"
               >
@@ -127,7 +126,6 @@
             <v-col cols="12" md="6">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-account-circle"
                 @click="goToDashboard"
               >

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -48,7 +48,7 @@
         <v-btn
           type="submit"
           class="float-right"
-          :color="formFilled ? 'success' : ''"
+          color="primary"
           :loading="loading"
           :disabled="!formFilled"
         >

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -33,7 +33,6 @@
             <v-col cols="12" md="4">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-image-plus"
                 @click="reloadPage"
               >
@@ -43,7 +42,6 @@
             <v-col cols="12" md="4">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-checkbox-marked-circle-plus-outline"
                 @click="goToPriceValidation"
               >
@@ -53,7 +51,6 @@
             <v-col cols="12" md="4">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-account-circle"
                 @click="goToDashboard"
               >

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -29,7 +29,6 @@
             <v-col cols="12" md="6">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-image-plus"
                 @click="reloadPage"
               >
@@ -39,7 +38,6 @@
             <v-col cols="12" md="6">
               <v-btn
                 color="primary"
-                variant="outlined"
                 prepend-icon="mdi-account-circle"
                 @click="goToDashboard"
               >

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -18,7 +18,7 @@
             <v-icon :icon="formFilled ? 'mdi-barcode' : 'mdi-barcode-scan'" @click="showBarcodeScannerDialog" />
           </template>
           <template #append-inner>
-            <v-btn icon="mdi-magnify" @click="search" />
+            <v-btn color="primary" icon="mdi-magnify" @click="search" />
           </template>
         </v-text-field>
       </v-form>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -10,7 +10,7 @@
           </h3>
           <v-switch
             v-model="appStore.user.preferedTheme"
-            color="success"
+            color="primary"
             false-value="light"
             true-value="dark"
             density="compact"
@@ -119,7 +119,7 @@
           </h3>
           <v-switch
             v-model="appStore.user.drawer_display_experiments"
-            color="success"
+            color="primary"
             :label="$t('UserSettings.SideMenuExperimentsDisplay')"
             density="compact"
             hide-details="auto"
@@ -131,7 +131,7 @@
           <v-switch
             v-model="appStore.user.product_display_barcode"
             class="mb-4"
-            color="success"
+            color="primary"
             :label="$t('UserSettings.ProductDisplayBarcode')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: '1234567890123' })"
             density="compact"
@@ -140,7 +140,7 @@
           />
           <v-switch
             v-model="appStore.user.product_display_category_tag"
-            color="success"
+            color="primary"
             :label="$t('UserSettings.ProductDisplayCategoryTag')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'en:oranges' })"
             density="compact"
@@ -153,7 +153,7 @@
           </h3>
           <v-switch
             v-model="appStore.user.location_display_osm_id"
-            color="success"
+            color="primary"
             :label="$t('UserSettings.LocationDisplayOSMID')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'N652825274' })"
             density="compact"

--- a/src/views/UserSettings.vue
+++ b/src/views/UserSettings.vue
@@ -70,7 +70,7 @@
 
     <v-row>
       <v-col>
-        <v-btn type="submit" :color="formFilled ? 'success' : ''" :disabled="!formFilled">
+        <v-btn type="submit" color="primary" :disabled="!formFilled">
           {{ $t('UserSettings.Save') }}
         </v-btn>
       </v-col>


### PR DESCRIPTION
### What

Following #1268

Change most of the green (success) CTAs to the new OFF color (primary).
Success color is kept for success messages/notifications/forms (vs error).

### Screenshot

|Page|Before|After|
|-|-|-|
|Proof add multiple|![image](https://github.com/user-attachments/assets/fa5df09b-4153-49f6-af8b-6376dec888d5)|![image](https://github.com/user-attachments/assets/4fb28488-3c85-431e-9b3e-c943c4d21601)|
|Settings|![image](https://github.com/user-attachments/assets/d88fc3bb-d296-4ff2-b4ad-081b71bce72e)|![image](https://github.com/user-attachments/assets/f63107eb-6e00-44f1-b801-484ae6b6940d)|
