### PR TITLE
feat(Mobile): have full-width (block) CTAs on mobile

### DIFF
--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -12,19 +12,17 @@
         {{ $t('Challenge.StepTakePictures.line2') }}
       </p>
     </v-card-text>
+    <v-divider />
     <v-card-actions>
-      <v-row>
-        <v-col>
-          <v-btn 
-            class="float-right"
-            color="primary"
-            variant="flat"
-            to="/proofs/add/multiple"
-          >
-            {{ $t('Challenge.StepTakePictures.AddPictures') }}
-          </v-btn>
-        </v-col>
-      </v-row>
+      <v-spacer v-if="$vuetify.display.smAndUp" />
+      <v-btn
+        color="primary"
+        variant="flat"
+        :block="!$vuetify.display.smAndUp"
+        to="/proofs/add/multiple"
+      >
+        {{ $t('Challenge.StepTakePictures.AddPictures') }}
+      </v-btn>
     </v-card-actions>
   </v-card>
 </template>

--- a/src/components/ChallengeValidateCard.vue
+++ b/src/components/ChallengeValidateCard.vue
@@ -17,19 +17,17 @@
         {{ $t('Challenge.StepValidate.line4') }}
       </p>
     </v-card-text>
+    <v-divider />
     <v-card-actions>
-      <v-row>
-        <v-col>
-          <v-btn
-            class="float-right"
-            color="primary"
-            variant="flat"
-            to="/experiments/price-validation-assistant"
-          >
-            {{ $t('Challenge.StepValidate.ValidatePrices') }}
-          </v-btn>
-        </v-col>
-      </v-row>
+      <v-spacer v-if="$vuetify.display.smAndUp" />
+      <v-btn
+        color="primary"
+        variant="flat"
+        :block="!$vuetify.display.smAndUp"
+        to="/experiments/price-validation-assistant"
+      >
+        {{ $t('Challenge.StepValidate.ValidatePrices') }}
+      </v-btn>
     </v-card-actions>
   </v-card>
 </template>

--- a/src/components/PriceDeleteConfirmationDialog.vue
+++ b/src/components/PriceDeleteConfirmationDialog.vue
@@ -21,10 +21,11 @@
       <v-divider />
 
       <v-card-actions>
+        <v-spacer v-if="$vuetify.display.smAndUp" />
         <v-btn
           color="error"
           variant="flat"
-          elevation="1"
+          :block="!$vuetify.display.smAndUp"
           prepend-icon="mdi-delete"
           :loading="loading"
           @click="deletePrice"

--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -41,11 +41,11 @@
       <v-divider />
 
       <v-card-actions>
+        <v-spacer v-if="$vuetify.display.smAndUp" />
         <v-btn
-          class="float-right"
           color="primary"
           variant="flat"
-          elevation="1"
+          :block="!$vuetify.display.smAndUp"
           :loading="loading"
           @click="updatePrice"
         >

--- a/src/components/ProofDeleteConfirmationDialog.vue
+++ b/src/components/ProofDeleteConfirmationDialog.vue
@@ -17,10 +17,11 @@
       <v-divider />
 
       <v-card-actions>
+        <v-spacer v-if="$vuetify.display.smAndUp" />
         <v-btn
           color="error"
           variant="flat"
-          elevation="1"
+          :block="!$vuetify.display.smAndUp"
           prepend-icon="mdi-delete"
           :loading="loading"
           @click="deleteProof"

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -21,11 +21,11 @@
       <v-divider />
 
       <v-card-actions>
+        <v-spacer v-if="$vuetify.display.smAndUp" />
         <v-btn
-          class="float-right"
           color="primary"
           variant="flat"
-          elevation="1"
+          :block="!$vuetify.display.smAndUp"
           :disabled="!formFilled"
           :loading="loading"
           @click="updateProof"

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -37,10 +37,12 @@
     </v-card-text>
     <v-divider />
     <v-card-actions>
-      <v-spacer />
+      <v-spacer v-if="$vuetify.display.smAndUp" />
       <v-btn
+        class="float-right"
         color="primary"
         variant="flat"
+        :block="!$vuetify.display.smAndUp"
         :loading="loading || step === 2"
         :disabled="!proofFormFilled || loading || step === 2"
         @click="uploadProofList"

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -112,20 +112,22 @@
           <v-icon icon="mdi-checkbox-marked-circle" color="success" />
         </template>
         <v-divider />
-        <v-card-text :class="$vuetify.display.smAndUp ? 'text-center' : 'text-right'">
+        <v-card-text class="text-center">
           <v-row>
-            <v-col cols="12" md="6">
+            <v-col cols="12" sm="6">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-tag-plus-outline"
                 @click="reloadPage"
               >
                 {{ $t('Common.AddNewPrices') }}
               </v-btn>
             </v-col>
-            <v-col cols="12" md="6">
+            <v-col cols="12" sm="6">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-account-circle"
                 @click="goToDashboard"
               >

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -28,29 +28,32 @@
           <v-icon icon="mdi-checkbox-marked-circle" color="success" />
         </template>
         <v-divider />
-        <v-card-text :class="$vuetify.display.smAndUp ? 'text-center' : 'text-right'">
+        <v-card-text class="text-center">
           <v-row>
-            <v-col cols="12" md="4">
+            <v-col cols="12" sm="4">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-image-plus"
                 @click="reloadPage"
               >
                 {{ $t('Common.AddNewProofs') }}
               </v-btn>
             </v-col>
-            <v-col cols="12" md="4">
+            <v-col cols="12" sm="4">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-checkbox-marked-circle-plus-outline"
                 @click="goToPriceValidation"
               >
                 {{ $t('Common.ValidatePrices') }} 🤖
               </v-btn>
             </v-col>
-            <v-col cols="12" md="4">
+            <v-col cols="12" sm="4">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-account-circle"
                 @click="goToDashboard"
               >
@@ -73,7 +76,7 @@ export default {
   },
   data() {
     return {
-      step: 1,
+      step: 2,
       stepItemList: [
         {
           title: this.$t('Common.Upload'),

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -24,20 +24,22 @@
         prepend-icon="mdi-image-check"
       >
         <v-divider />
-        <v-card-text :class="$vuetify.display.smAndUp ? 'text-center' : 'text-right'">
+        <v-card-text class="text-center">
           <v-row>
-            <v-col cols="12" md="6">
+            <v-col cols="12" sm="6">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-image-plus"
                 @click="reloadPage"
               >
                 {{ $t('Common.AddNewProof') }}
               </v-btn>
             </v-col>
-            <v-col cols="12" md="6">
+            <v-col cols="12" sm="6">
               <v-btn
                 color="primary"
+                :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-account-circle"
                 @click="goToDashboard"
               >


### PR DESCRIPTION
### What

On mobile, transform CTAs into full-width block buttons

### Screenshot

|Page|Before|After|
|-|-|--|
|Proof add multiple|![image](https://github.com/user-attachments/assets/086fd8b5-0c04-4145-bbee-f8dc9783f8c8)|![image](https://github.com/user-attachments/assets/2e987285-5dd9-4ed5-9da1-0b58474298d5)|
|Proof add multiple : done|![image](https://github.com/user-attachments/assets/d07c1f16-fb75-42c6-889a-8bcf329fe3f2)|![image](https://github.com/user-attachments/assets/39914272-e6b8-41b9-87c3-6aeae9e97c20)|