### PR TITLE
fix(Price add): Allow 'quantity bought' field to be decimal

### DIFF
--- a/src/components/PriceAlreadyUploadedListCard.vue
+++ b/src/components/PriceAlreadyUploadedListCard.vue
@@ -77,7 +77,7 @@ export default {
     },
     proofPriceUploadedListSum() {
       return this.proofPriceUploadedList.reduce((acc, priceUploaded) => {
-        return acc + parseFloat(priceUploaded.price)*parseInt(priceUploaded.receipt_quantity)
+        return acc + parseFloat(priceUploaded.price)*parseFloat(priceUploaded.receipt_quantity)
       }, 0)
     }
   },

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -64,7 +64,7 @@
             density="compact"
             :label="$t('Common.QuantityBought')"
             type="text"
-            inputmode="numeric"
+            inputmode="decimal"
             :rules="receiptQuantityRules"
             :prepend-inner-icon="PROOF_TYPE_RECEIPT_ICON"
             hide-details="auto"
@@ -143,7 +143,7 @@ export default {
       if (!this.priceForm.receipt_quantity) return [() => true]  // optional field
       return [
         value => !isNaN(value) || this.$t('PriceRules.Number'),
-        value => Number(value) >= 1 || this.$t('PriceRules.Positive'),
+        value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
       ]
     },
     productIsTypeCategory() {

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -144,6 +144,7 @@ export default {
       return [
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
+        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
       ]
     },
     productIsTypeCategory() {

--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -9,7 +9,7 @@
           <v-tooltip v-if="price.price_without_discount" activator="parent" open-on-click location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(price.price_without_discount) }}</v-tooltip>
         </v-chip>
       </span>
-      <span v-if="!hidePriceReceiptQuantity && price.receipt_quantity && price.receipt_quantity > 1" class="mr-1">
+      <span v-if="!hidePriceReceiptQuantity && price.receipt_quantity" class="mr-1">
         <v-chip class="ml-1" variant="outlined" size="small" density="comfortable">
           x{{ price.receipt_quantity }}
         </v-chip>


### PR DESCRIPTION
### What

Following #1128 we display the "quantity bought' when adding prices for a receipt.
But sometimes (for "category" prices especially), we buy only a given quantity of the product, so a decimal should be allowed (500 g = 0,5 kg for instance).

### Screenshot

![image](https://github.com/user-attachments/assets/2e043c2e-824c-478e-8b51-b15acde4f8a1)
