### PR TITLE
feat(SignIn): proper redirect when sign-in is required

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -61,7 +61,9 @@ const router = createRouter({
 
 /**
  * On each page change, check if it needs authentication.
- * If required, but the user is not authenticated (token unknown), then redirect to 'sign-in'
+ * If required, but the user is not authenticated (token unknown):
+ * - then redirect to 'sign-in'
+ * - the initial url is passed as query parameter ?next=, in order to redirect back after login
  */
  router.beforeEach(async (to, from, next) => {
   const store = useAppStore()
@@ -70,7 +72,7 @@ const router = createRouter({
     await localeManager.changeLanguage(locale)
   }
   if (to.meta.requiresAuth && !store.user.token) {
-    return next({ name: 'sign-in', query: { redirect: to.fullPath } })
+    return next({ name: 'sign-in', query: { next: to.fullPath } })
   }
 
   next()

--- a/src/router.js
+++ b/src/router.js
@@ -70,7 +70,7 @@ const router = createRouter({
     await localeManager.changeLanguage(locale)
   }
   if (to.meta.requiresAuth && !store.user.token) {
-    return next({ name: 'sign-in' })
+    return next({ name: 'sign-in', query: { redirect: to.fullPath } })
   }
 
   next()

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -105,7 +105,7 @@ export default {
         })
     },
     done() {
-      const path = this.$route.query.redirect || '/dashboard'
+      const path = this.$route.query.next || '/dashboard'
       this.$router.push({ path: path, query: { signinSuccess: 'true' } })
     }
   },

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -105,7 +105,8 @@ export default {
         })
     },
     done() {
-      this.$router.push({ path: '/dashboard', query: { signinSuccess: 'true' } })
+      const path = this.$route.query.redirect || '/dashboard'
+      this.$router.push({ path: path, query: { signinSuccess: 'true' } })
     }
   },
 };


### PR DESCRIPTION
### What
Currently:
- When users try to access a page that requires login, they are redirected to the sign-in page
- After signing in, they are redirected to their dashboard

With this PR:
- We keep track of the page they wanted to access
- After signing in, they are redirected to said page
- Users that pressed the regular sign in button are still sent to their dashboard


