### PR TITLE
refactor(Proof chip): new withLabel prop to display the label next to the icon

### DIFF
--- a/src/components/ProofChip.vue
+++ b/src/components/ProofChip.vue
@@ -1,14 +1,15 @@
 <template>
   <v-chip
     :class="class"
-    :style="style"
+    :style="getStyle"
     label
     size="small"
     density="comfortable"
     :title="$t('Common.Proof')"
     @click="dialog = true"
   >
-    <v-icon icon="mdi-image" />
+    <v-icon :start="withLabel" icon="mdi-image" />
+    <span v-if="withLabel">{{ $t('Common.Proof') }}</span>
   </v-chip>
 
   <ProofDialog
@@ -32,6 +33,10 @@ export default {
       type: Object,
       default: null
     },
+    withLabel: {
+      type: Boolean,
+      default: false
+    },
     readonly: {
       type: Boolean,
       default: false,
@@ -48,6 +53,12 @@ export default {
   data() {
     return {
       dialog: false
+    }
+  },
+  computed: {
+    getStyle() {
+      if (this.withLabel) return null
+      return this.style
     }
   }
 }

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="11">
-      <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" :readonly="true" />
+      <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" :withLabel="showProofChip" :readonly="true" />
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofReceiptPriceCountChip v-if="showReceiptPriceCount" class="mr-1" :totalCount="proof.receipt_price_count" />
       <ProofReceiptPriceTotalChip v-if="showReceiptPriceTotal" class="mr-1" :totalCount="proof.receipt_price_total" :currency="proof.currency" />


### PR DESCRIPTION
### What

Give more info to the user by adding a label next to the icon.
Hidden by default, will be displayed in the `ConributionAssistantPriceFormCard` component

### Screenshot

||Image|
|-|-|
|Before|![image](https://github.com/user-attachments/assets/2e45af2f-76e3-49c6-aa1c-ec4361ce8d98)|
|After|![image](https://github.com/user-attachments/assets/b30e80c8-6dcc-49be-b6ed-fdc75612c09e)|