### PR TITLE
refactor(Price input row): new 'mode' prop to display the data in readonly

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -29,7 +29,7 @@
             </span>
           </p>
 
-          <PricePriceRow v-if="price" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" :hidePriceReceiptQuantity="hidePriceReceiptQuantity" />
+          <PricePriceRow v-if="price" class="mt-0" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" :hidePriceReceiptQuantity="hidePriceReceiptQuantity" />
         </v-col>
       </v-row>
 

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row>
+  <v-row v-if="mode === 'Edit'">
     <v-col cols="12">
       <v-row v-if="productIsTypeCategory">
         <v-col>
@@ -80,6 +80,16 @@
       @close="changeCurrencyDialog = false"
     />
   </v-row>
+  <v-row v-else-if="mode === 'Display'">
+    <v-col cols="12">
+      <v-alert
+        icon="mdi-currency-usd"
+        density="compact"
+      >
+        <PricePriceRow :price="priceForm" />
+      </v-alert>
+    </v-col>
+  </v-row>
 </template>
 
 <script>
@@ -89,6 +99,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    PricePriceRow: defineAsyncComponent(() => import('../components/PricePriceRow.vue')),
     ChangeCurrencyDialog: defineAsyncComponent(() => import('../components/ChangeCurrencyDialog.vue')),
   },
   props: {
@@ -103,6 +114,10 @@ export default {
         currency: null,
         receipt_quantity: null,
       })
+    },
+    mode: {
+      type: String,
+      default: 'Edit'  // or 'Display'
     },
     hideCurrencyChoice: {
       type: Boolean,
@@ -130,6 +145,12 @@ export default {
     }
   },
   computed: {
+    categoryTag() {
+      return this.priceForm.category_tag
+    },
+    hasCategoryTag() {
+      return !!this.categoryTag
+    },
     priceRules() {
       return [
         value => !!value && !!value.trim() || this.$t('PriceRules.AmountRequired'),
@@ -191,6 +212,16 @@ export default {
           }
           return this.$t('PriceCard.PriceValueDisplayKilogram', [this.getPriceValue(pricePerUnit, this.priceForm.currency)])
         }
+      }
+      return null
+    },
+    getPriceValueDisplay(price) {
+      if (price) {
+        price = parseFloat(price)
+        if (this.hasCategoryTag) {
+          return this.getPricePerUnit(price)
+        }
+        return this.getPriceValue(price, this.priceForm.currency)
       }
       return null
     },

--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row style="margin-top:0;">
+  <v-row>
     <v-col cols="12" class="pt-2 pb-2">
       <span class="mr-1">{{ getPriceValueDisplay(price.price) }}</span>
       <span v-if="hasProductQuantity" class="mr-1">({{ getPricePerUnit(price.price) }})</span>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -33,7 +33,7 @@
     <v-divider v-if="latestPrice" />
     <v-container v-if="latestPrice" class="pa-2">
       <h4>{{ $t('ProductCard.LatestPrice') }}</h4>
-      <PricePriceRow :price="latestPrice" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit" />
+      <PricePriceRow class="mt-0" :price="latestPrice" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit" />
       <PriceFooterRow :price="latestPrice" />
     </v-container>
   </v-card>


### PR DESCRIPTION
### What

Changes to the `PriceInputRow` component : new "mode" prop.
If set to `Display`, then use the `PricePriceRow` component to display the price data.

### Screenshot

|mode "Edit"|mode "Display"|
|--|--|
|![Screenshot from 2025-01-20 01-38-40](https://github.com/user-attachments/assets/439fef54-19b4-469d-a255-82bfff821332)|![image](https://github.com/user-attachments/assets/58a341d1-14aa-4b75-a2e8-c41879a53897)|
