### PR TITLE
refactor(Price tag): move Fix button to toggle Product & Price modes

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -13,8 +13,8 @@
           />
         </v-col>
       </v-row>
-      <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingType="true" :hideProductBarcode="false" :hideBarcodeScannerTab="true" @filled="productFormFilled = $event" />
-      <PriceInputRow class="mt-0" :priceForm="productPriceForm" :product="productPriceForm.product" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
+      <ProductInputRow :productForm="productPriceForm" :mode="mode" :disableInitWhenSwitchingType="true" :hideProductBarcode="false" :hideBarcodeScannerTab="true" @filled="productFormFilled = $event" />
+      <PriceInputRow class="mt-0" :priceForm="productPriceForm" :product="productPriceForm.product" :mode="mode" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
     </v-card-text>
     <v-divider v-if="!hideProofDetails" />
     <v-card-text v-if="!hideProofDetails">
@@ -38,6 +38,16 @@
           </v-list-item>
         </v-list>
       </v-menu>
+      <v-spacer />
+      <v-btn
+        v-if="mode === 'Display'"
+        color="warning"
+        variant="outlined"
+        prepend-icon="mdi-pencil"
+        @click="mode = 'Edit'"
+      >
+        {{ $t('Common.Fix') }}
+      </v-btn>
       <v-spacer />
       <v-btn
         v-if="!hideUploadAction"
@@ -103,6 +113,7 @@ export default {
   emits: ['removePriceTag', 'validatePriceTag'],
   data() {
     return {
+      mode: 'Display',  // 'Edit'
       productFormFilled: false,
       pricePriceFormFilled: false,
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -248,6 +248,7 @@
 		"FilterProofWithPriceCountHide": "Hide proofs with prices",
 		"FilterLocationWithPriceCountHide": "Hide locations with prices",
 		"FilterUserWithPriceCountHide": "Hide contributors with prices",
+		"Fix": "Fix",
 		"FAQ": "FAQ",
 		"FrequentlyAskedQuestions": "Frequently asked questions",
 		"Help": "Help",


### PR DESCRIPTION
### What

Following #1290 & #1291.
We now display Price tags as "readonly" by default, with a new "Fix" button to toggle to edit mode.

### Screenshot

|mode "Display" (default)|mode "Edit"|
|-|-|
|![image](https://github.com/user-attachments/assets/82500ba6-dc81-4278-8aed-f0efc00a3233)|![image](https://github.com/user-attachments/assets/11cbbb46-b0ef-4ee1-a6f2-d064848e69db)|
