### PR TITLE
refactor(Product missing): remove warning icon to scare less users

### DIFF
--- a/src/components/ProductMissingChip.vue
+++ b/src/components/ProductMissingChip.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chip label size="small" density="comfortable" prepend-icon="mdi-alert" color="error" data-name="product-missing-chip">
+  <v-chip label size="small" density="comfortable" color="error" data-name="product-missing-chip">
     {{ $t('PriceCard.UnknownProduct') }}
   </v-chip>
 </template>

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -23,7 +23,7 @@
   
   <v-row v-if="step === 2">
     <v-col cols="12">
-      <v-alert v-if="drawCanvasLoaded && !boundingBoxesFromServer.length && !proofWithBoundingBoxesLoading" class="mb-2" type="info" variant="outlined" icon="mdi-alert">
+      <v-alert v-if="drawCanvasLoaded && !boundingBoxesFromServer.length && !proofWithBoundingBoxesLoading" class="mb-2" type="warning" variant="outlined">
         {{ $t('ContributionAssistant.BoundingBoxesFromServerWarning') }}
       </v-alert>
       <v-alert v-if="drawCanvasLoaded && proofWithBoundingBoxesLoading" class="mb-2" type="info" variant="outlined" icon="mdi-magnify">

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -7,7 +7,7 @@
 
   <v-row v-if="!locationFound" class="mt-0">
     <v-col cols="12">
-      <v-alert v-if="!loading" type="error" variant="outlined" icon="mdi-alert">
+      <v-alert v-if="!loading" type="error" variant="outlined">
         <i>{{ $t('LocationDetail.LocationNotFound') }}</i>
       </v-alert>
     </v-col>

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -51,7 +51,7 @@
             <ProductInputRow :productForm="productPriceForm" @filled="productFormFilled = $event" />
             <v-row v-if="productFormFilled && existingProductFound" class="mt-0">
               <v-col>
-                <v-alert data-name="existing-product-alert" type="warning" variant="outlined" icon="mdi-alert">
+                <v-alert data-name="existing-product-alert" type="warning" variant="outlined">
                   <p>
                     <i>{{ $t('AddPriceMultiple.ProductPriceDetails.ExistingProductFound') }}</i>
                   </p>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -8,7 +8,7 @@
 
   <v-row v-if="productOrCategoryNotFound" class="mt-0">
     <v-col cols="12" sm="6">
-      <v-alert v-if="productNotFound" data-name="product-not-found-alert" type="error" variant="outlined" icon="mdi-alert">
+      <v-alert v-if="productNotFound" data-name="product-not-found-alert" type="error" variant="outlined">
         <p>
           <i18n-t keypath="ProductDetail.ProductNotFound" tag="i">
             <template #name>
@@ -18,7 +18,7 @@
         </p>
         <OpenFoodFactsAddMenu :productCode="productId" />
       </v-alert>
-      <v-alert v-else-if="categoryNotFound" data-name="category-not-found-alert" type="error" variant="outlined" icon="mdi-alert">
+      <v-alert v-else-if="categoryNotFound" data-name="category-not-found-alert" type="error" variant="outlined">
         <i>{{ $t('ProductDetail.CategoryNotFound') }}</i>
       </v-alert>
     </v-col>


### PR DESCRIPTION
### What

Remove the `mdi-alert` everywhere in the app.
- Product missing: the chip is already red, no need to add an extra info
- Elsewhere: use the default `v-alert` icon

### Screenshot

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/f55a4213-fa05-4bad-b630-1e91cc12e2af)|![image](https://github.com/user-attachments/assets/10d72f64-03ea-4c65-b4a8-4b3c34b4a3b2)|
