### PR TITLE
refactor(Product input row): new PriceCategoryChip to display the category_tag localized

### DIFF
--- a/src/components/PriceCategoryChip.vue
+++ b/src/components/PriceCategoryChip.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-chip class="mr-1" label size="small" density="comfortable">
+    {{ getPriceCategoryTagName(priceCategory) }}
+  </v-chip>
+</template>
+
+<script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import utils from '../utils.js'
+
+export default {
+  props: {
+    priceCategory: {
+      type: String,
+      default: null
+    }
+  },
+  data() {
+    return {
+      categoryTags: [],  // see mounted
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+  },
+  mounted() {
+    utils.getLocaleCategoryTags(this.appStore.getUserLanguage).then((module) => {
+      this.categoryTags = module.default
+    })
+  },
+  methods: {
+    getPriceCategoryTagName(categoryId) {
+      if (!categoryId || this.categoryTags.length === 0) return ''
+      return this.categoryTags.find(lt => lt.id === categoryId).name
+    }
+  }
+}
+</script>

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -76,9 +76,7 @@
         icon="mdi-basket-outline"
         density="compact"
       >
-        <v-chip label class="mr-1" size="small" density="comfortable">
-          {{ productForm.category_tag }}
-        </v-chip>
+        <PriceCategoryChip :priceCategory="productForm.category_tag" />
         <PriceOrigins :priceOrigins="productForm.origins_tags" />
         <PriceLabels :priceLabels="productForm.labels_tags" />
       </v-alert>
@@ -107,6 +105,7 @@ import utils from '../utils.js'
 export default {
   components: {
     ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
+    PriceCategoryChip: defineAsyncComponent(() => import('../components/PriceCategoryChip.vue')),
     PriceOrigins: defineAsyncComponent(() => import('../components/PriceOrigins.vue')),
     PriceLabels: defineAsyncComponent(() => import('../components/PriceLabels.vue')),
     BarcodeScannerDialog: defineAsyncComponent(() => import('../components/BarcodeScannerDialog.vue')),


### PR DESCRIPTION
### What

Following changes in #1291 we can now display the price's product data as readonly.
But there was an issue when displaying the `category_tag` label (for a raw product price), we were missing a translation mecanism (similar to the existing `PriceOrigins` & `PriceLabels` components).

Fixes this by creating a new `PriceCategoryChip`

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/4785a530-3ca0-44b0-86f7-7ead2b23ffbb)|![image](https://github.com/user-attachments/assets/6a9de20e-36bb-4235-a67d-3768ac44888a)|

### Extra notes

Todo in the future: 
- improve `PriceOrigins` & `PriceLabels` to avoid having the v-if at the top
- rename `PriceOrigins` & `PriceLabels` to add "Chip" in their name