### PR TITLE
refactor(Proofs): wording: replace 'Image' with 'Picture'

### DIFF
--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -13,7 +13,7 @@
           {{ $t('Common.Details') }}
         </v-list-item>
         <v-list-item :slim="true" prepend-icon="mdi-open-in-new" :href="getProofFullUrl" target="_blank">
-          {{ $t('Common.ImageFull') }}
+          {{ $t('Common.PictureFull') }}
         </v-list-item>
         <v-list-item v-if="userIsProofOwner" :slim="true" prepend-icon="mdi-pencil" :disabled="!userCanEditProof" @click="openEditDialog">
           {{ $t('Common.Edit') }}

--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -14,9 +14,9 @@
       <v-menu scroll-strategy="close" :disabled="loading">
         <template #activator="{ props }">
           <v-btn v-bind="props" size="small" prepend-icon="mdi-image" append-icon="mdi-menu-down" :class="hasProofImageSelected ? 'border-success' : 'border-error'">
-            <span v-if="hasProofImageSelected">{{ $t('Common.ImageSelectedCount', { count: proofImagePreviewList.length }) }}</span>
-            <span v-else-if="multiple">{{ $t('Common.ImageSelectMultiple') }}</span>
-            <span v-else>{{ $t('Common.ImageSelect') }}</span>
+            <span v-if="hasProofImageSelected">{{ $t('Common.PictureSelectedCount', { count: proofImagePreviewList.length }) }}</span>
+            <span v-else-if="multiple">{{ $t('Common.PictureSelectMultiple') }}</span>
+            <span v-else>{{ $t('Common.PictureSelect') }}</span>
           </v-btn>
         </template>
         <v-list>

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -18,7 +18,7 @@
           type="warning"
           variant="outlined"
           density="compact"
-          :text="$t('ProofAdd.HowToMultiple')"
+          :text="$t('ProofAdd.HowToMultipleShort')"
         />
         <ProofTypeInputRow :proofTypeForm="proofForm" :hideProofTypeReceiptChoice="typePriceTagOnly" />
         <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -290,6 +290,11 @@
 		"Physical": "Physical",
 		"Picture": "Picture",
 		"Pictures": "Pictures",
+		"PictureSelect": "Select a picture",
+		"PictureSelectMultiple": "Select pictures",
+		"PictureSelected": "Picture selected!",
+		"PictureSelectedCount": "{count} pictures selected | {count} picture selected | {count} pictures selected",
+		"PictureFull": "Full-size picture",
 		"PicturesByYou": "Pictures by you",
 		"PicturesAdded": "Pictures added",
 		"PicturesAddedByYou": "Pictures added by you",
@@ -360,6 +365,7 @@
 		"Unreadable": "Unreadable",
 		"Upload": "Upload",
 		"UploadMultipleImages": "Upload {count} image | Upload {count} images",
+		"UploadMultiplePictures": "Upload {count} picture | Upload {count} pictures",
 		"UploadMultipleProofs": "Upload {count} proof | Upload {count} proofs",
 		"UploadMultiplePrices": "Upload {count} price | Upload {count} prices",
 		"URL": "URL",
@@ -548,7 +554,8 @@
 		"ProductNotFound": "Product not found in Open Food Facts... Don't hesitate to add it :)"
 	},
 	"ProofAdd": {
-		"HowToMultiple": "All the price tag images you select should share the same shop location, and been taken on the same day."
+		"HowToMultiple": "All the price tag images you select should share the same shop location, and been taken on the same day.",
+		"HowToMultipleShort": "Pictures should share the same shop location and date."
 	},
 	"ProofCard": {
 		"Proof": "Proof",


### PR DESCRIPTION
### What

We recently introduced the word "Picture" to talk about Proofs.
To avoid having 3 terms - Proofs, Images, Pictures - we replace "Image" with "Picture".
