### PR TITLE
fix(Price tag): fix price tag vertical responsiveness

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/no-mutating-props -->
 <template>
-  <v-card height="100%">
-    <v-card-text>
+  <v-card class="d-flex flex-column">
+    <v-card-text class="flex-grow-1">
       <ProofImageCropped class="mb-4" height="200px" :proofImageFilePath="productPriceForm.proofImage" :boundingBox="productPriceForm.bounding_box" @croppedImage="setCroppedImage($event)" />
       <v-row v-if="showProductNameField">
         <v-col>
@@ -17,7 +17,7 @@
       <PriceInputRow class="mt-0" :priceForm="productPriceForm" :product="productPriceForm.product" :mode="mode" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
     </v-card-text>
     <v-divider v-if="!hideProofDetails" />
-    <v-card-text v-if="!hideProofDetails">
+    <v-card-text v-if="!hideProofDetails" class="flex-grow-0">
       <ProofFooterRow :proof="productPriceForm.proof" :showProofChip="true" :hideProofType="true" :hideProofActions="true" :readonly="true" />
     </v-card-text>
     <v-divider v-if="!hideActions" />

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -72,7 +72,7 @@
           md="6"
           xl="4"
         >
-          <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" :hideProofDetails="true" :hideUploadAction="true" @removePriceTag="removePriceTag($event, productPriceForm)" />
+          <ContributionAssistantPriceFormCard height="100%" :productPriceForm="productPriceForm" :hideProofDetails="true" :hideUploadAction="true" @removePriceTag="removePriceTag($event, productPriceForm)" />
         </v-col>
       </v-row>
       <h3 v-if="productPriceFormsWithPriceId.length" class="mt-4 mb-4">
@@ -86,7 +86,7 @@
           md="6"
           xl="4"
         >
-          <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" :hideProofDetails="true" :hideActions="true" :disabled="true" />
+          <ContributionAssistantPriceFormCard height="100%" :productPriceForm="productPriceForm" :hideProofDetails="true" :hideActions="true" :disabled="true" />
         </v-col>
       </v-row>
       <v-row>

--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -10,7 +10,7 @@
 
   <v-row class="mt-0">
     <v-col v-for="(productPriceForm, index) in productPriceForms" :key="index" cols="12" md="6" xl="4">
-      <ContributionAssistantPriceFormCard :productPriceForm="productPriceForm" @removePriceTag="removePriceTag(index, $event)" @validatePriceTag="validatePriceTag(index)" />
+      <ContributionAssistantPriceFormCard height="100%" :productPriceForm="productPriceForm" @removePriceTag="removePriceTag(index, $event)" @validatePriceTag="validatePriceTag(index)" />
     </v-col>
   </v-row>
 


### PR DESCRIPTION
### What

Sometimes price tag cards next to each other don't have the same content, and are misaligned.
Add flex to re-align.

### Screenshot

||Image|
|-|-|
|Before|![image](https://github.com/user-attachments/assets/27ffebea-c257-4c96-91f2-da0e615588f9)|
|After|![image](https://github.com/user-attachments/assets/4ca83ee7-423b-4ec8-8cd3-45d71ce5e5c4)|
