### PR TITLE
refactor(CommunityChallenge): reorganise a bit the 2 instruction cards (move stats at the bottom, add divider below title)

### DIFF
--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -1,17 +1,10 @@
 <template>
-  <v-card>
-    <v-card-title>
-      {{ $t('Challenge.StepTakePictures.Title') }}
-    </v-card-title>
-    <v-card-text>
-      <v-row class="mb-2">
-        <v-col cols="6">
-          <StatCard :value="challenge.numberOfProofs" :subtitle="statSubtitleProofCount" />
-        </v-col>
-        <v-col cols="6">
-          <StatCard :value="challenge.userProofContributions" :subtitle="statSubtitleProofOwnerCount" />
-        </v-col>
-      </v-row>
+  <v-card
+    :title="$t('Challenge.StepTakePictures.Title')"
+    prepend-icon="mdi-image-plus"
+  >
+    <v-divider />
+    <v-card-text class="pb-0">
       <p class="mb-2">
         {{ $t('Challenge.StepTakePictures.line1') }}
       </p>
@@ -21,6 +14,16 @@
       <p class="mb-2 mt-2">
         {{ $t('Challenge.StepTakePictures.line2') }}
       </p>
+    </v-card-text>
+    <v-card-text>
+      <v-row>
+        <v-col cols="6">
+          <StatCard :value="challenge.numberOfProofs" :subtitle="statSubtitleProofCount" />
+        </v-col>
+        <v-col cols="6">
+          <StatCard :value="challenge.userProofContributions" :subtitle="statSubtitleProofOwnerCount" />
+        </v-col>
+      </v-row>
     </v-card-text>
     <v-divider />
     <v-card-actions>

--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-card
-    :title="$t('Challenge.StepTakePictures.Title')"
-    prepend-icon="mdi-image-plus"
-  >
+  <v-card :title="$t('Challenge.StepTakePictures.Title')">
     <v-divider />
     <v-card-text class="pb-0">
       <p class="mb-2">

--- a/src/components/ChallengeValidateCard.vue
+++ b/src/components/ChallengeValidateCard.vue
@@ -1,17 +1,11 @@
 <template>
-  <v-card class="d-flex flex-column">
-    <v-card-title>
-      {{ $t('Challenge.StepValidate.Title') }}
-    </v-card-title>
-    <v-card-text class="flex-grow-1">
-      <v-row class="mb-2">
-        <v-col cols="6">
-          <StatCard :value="challenge.numberOfContributions" :subtitle="statSubtitlePriceCount" />
-        </v-col>
-        <v-col cols="6">
-          <StatCard :value="challenge.userContributions" :subtitle="statSubtitlePriceOwnerCount" />
-        </v-col>
-      </v-row>
+  <v-card
+    class="d-flex flex-column"
+    :title="$t('Challenge.StepValidate.Title')"
+    prepend-icon="mdi-checkbox-marked-circle-plus-outline"
+  >
+    <v-divider />
+    <v-card-text class="flex-grow-1 pb-0">
       <p class="mb-2">
         {{ $t('Challenge.StepValidate.line1') }}
       </p>
@@ -24,6 +18,16 @@
       <p class="mb-2">
         {{ $t('Challenge.StepValidate.line4') }}
       </p>
+    </v-card-text>
+    <v-card-text class="flex-grow-0">
+      <v-row>
+        <v-col cols="6">
+          <StatCard :value="challenge.numberOfContributions" :subtitle="statSubtitlePriceCount" />
+        </v-col>
+        <v-col cols="6">
+          <StatCard :value="challenge.userContributions" :subtitle="statSubtitlePriceOwnerCount" />
+        </v-col>
+      </v-row>
     </v-card-text>
     <v-divider />
     <v-card-actions>

--- a/src/components/ChallengeValidateCard.vue
+++ b/src/components/ChallengeValidateCard.vue
@@ -2,7 +2,6 @@
   <v-card
     class="d-flex flex-column"
     :title="$t('Challenge.StepValidate.Title')"
-    prepend-icon="mdi-checkbox-marked-circle-plus-outline"
   >
     <v-divider />
     <v-card-text class="flex-grow-1 pb-0">


### PR DESCRIPTION
### What

Small tweaks on the current challenge page instruction cards:
- title: ~add icon on the left~, add divider
- move stats at the bottom

### Screenshot

|Before|Intermediate (with icons)|After (without icons)|
|-|-|-|
|![image](https://github.com/user-attachments/assets/e82ab47f-1f9f-4ac8-b93a-ffbcd3952a41)|![image](https://github.com/user-attachments/assets/1533bf7c-ba62-4903-907a-07206167851b)|![image](https://github.com/user-attachments/assets/0aab28df-09b9-4458-b57a-bc1b015d1852)|