### PR TITLE
refactor(Proof add): change look & feel of input fields

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -7,17 +7,33 @@
     color: #F44336;  /* red */
 }
 
-.border-error {
-    border: 1px solid #F44336 !important;  /* red */
-}
 .border-success {
     border: 1px solid #4CAF50 !important;  /* green */
+}
+.border-error {
+    border: 1px solid #F44336 !important;  /* red */
 }
 .border-grey {
     border: 1px solid #9E9E9E !important;  /* grey */
 }
 .border-transparent {
     border: 1px solid transparent !important;
+}
+.outline-border-success .v-field__outline > .v-field__outline__start {
+    border: 1px solid #4CAF50 !important;  /* green */
+    border-right: 0 none !important;
+}
+.outline-border-success .v-field__outline > .v-field__outline__end {
+    border: 1px solid #4CAF50 !important;  /* green */
+    border-left: 0 none !important;
+}
+.outline-border-error .v-field__outline > .v-field__outline__start {
+    border: 1px solid #F44336 !important;  /* red */
+    border-right: 0 none !important;
+}
+.outline-border-error .v-field__outline > .v-field__outline__end {
+    border: 1px solid #F44336 !important;  /* red */
+    border-left: 0 none !important;
 }
 
 .v-btn-group--density-compact.v-btn-group {

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -30,26 +30,30 @@
   </v-row>
   <v-row v-if="proofIsTypeReceipt">
     <v-col cols="6">
+      <div class="text-subtitle-2">
+        <v-icon :icon="PROOF_TYPE_RECEIPT_ICON" /> {{ $t('Common.ReceiptPriceCount') }}
+      </div>
       <v-text-field
         v-model="proofMetadataForm.receipt_price_count"
         density="compact"
-        :label="$t('Common.ReceiptPriceCount')"
+        variant="outlined"
         type="text"
         inputmode="numeric"
         :rules="priceCountRules"
-        :prepend-inner-icon="PROOF_TYPE_RECEIPT_ICON"
         hide-details="auto"
       />
     </v-col>
     <v-col cols="6">
+      <div class="text-subtitle-2">
+        <v-icon :icon="PROOF_TYPE_RECEIPT_ICON" /> {{ $t('Common.ReceiptPriceTotal') }}
+      </div>
       <v-text-field
         v-model="proofMetadataForm.receipt_price_total"
         density="compact"
-        :label="$t('Common.ReceiptPriceTotal')"
+        variant="outlined"
         type="text"
         inputmode="decimal"
         :rules="priceTotalRules"
-        :prepend-inner-icon="PROOF_TYPE_RECEIPT_ICON"
         :suffix="proofMetadataForm.currency"
         hide-details="auto"
         @update:modelValue="newValue => proofMetadataForm.receipt_price_total = fixComma(newValue)"

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -1,20 +1,28 @@
 <template>
   <v-row>
     <v-col cols="6">
+      <div class="text-subtitle-2">
+        {{ $t('Common.Date') }}
+      </div>
       <v-text-field
         v-model="proofMetadataForm.date"
-        density="comfortable"
-        :label="$t('Common.Date')"
+        :class="proofMetadataForm.date ? 'outline-border-success' : 'outline-border-error'"
+        density="compact"
+        variant="outlined"
         type="date"
         :max="currentDate"
         hide-details="auto"
       />
     </v-col>
     <v-col cols="6">
+      <div class="text-subtitle-2">
+        {{ $t('Common.Currency') }}
+      </div>
       <v-select
         v-model="proofMetadataForm.currency"
-        density="comfortable"
-        :label="$t('Common.Currency')"
+        :class="proofMetadataForm.date ? 'outline-border-success' : 'outline-border-error'"
+        density="compact"
+        variant="outlined"
         :items="userFavoriteCurrencies"
         hide-details="auto"
       />


### PR DESCRIPTION
### What

Revamp the proof input fields
- outlined
- label at the top

### Screenshot

[|Before|After|
|-|-|-|
|Multiple proofs|![image](https://github.com/user-attachments/assets/75a53884-8a08-4033-98fe-981d42874c0d)|![Screenshot from 2025-01-26 11-11-36](https://github.com/user-attachments/assets/1c87a4f3-d42c-45a7-84b3-e32d1348143e)|
|Receipt|![image](https://github.com/user-attachments/assets/70eb577d-58f7-4999-a266-7bb7e3970e7a)|![image](https://github.com/user-attachments/assets/1bccb309-24f8-4048-8de8-9b4b52b57123)|
