### PR TITLE
refactor(Contribution assistant): improve the label card delete & chips display

### DIFF
--- a/src/components/ContributionAssistantLabelList.vue
+++ b/src/components/ContributionAssistantLabelList.vue
@@ -12,22 +12,22 @@
           <v-img style="height:150px" :src="label.imageSrc" />
         </v-card-text>
         <v-divider />
-        <v-card-text>
-          <v-chip class="mr-1" label size="small" density="comfortable">
-            {{ $t('Common.Source') }} {{ label.boundingSource }}
-          </v-chip>
-          <PriceCountChip v-if="labelHasPrice(label)" :count="1" :withLabel="true" source="proof" />
-        </v-card-text>
-        <v-divider v-if="!labelHasPrice(label)" />
-        <v-card-actions v-if="!labelHasPrice(label)">
+        <v-card-actions>
+          <v-btn v-if="!$vuetify.display.smAndUp && !labelHasPrice(label)" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Delete')" @click="removeLabel(index)" />
           <v-btn
+            v-else-if="!labelHasPrice(label)"
             color="error"
             variant="outlined"
             prepend-icon="mdi-delete"
+            size="small"
             @click="removeLabel(index)"
           >
             {{ $t('Common.Delete') }}
           </v-btn>
+          <v-chip class="mr-1" label size="small" density="comfortable" prepend-icon="mdi-information-outline">
+            {{ label.boundingSource }}
+          </v-chip>
+          <PriceCountChip v-if="labelHasPrice(label)" :count="1" :withLabel="true" source="proof" />
         </v-card-actions>
       </v-card>
     </v-col>

--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -57,7 +57,7 @@
         </v-card-text>
         <v-divider />
         <v-card-actions>
-          <v-btn v-if="!$vuetify.display.smAndUp" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Search')" @click="removeImage(index)" />
+          <v-btn v-if="!$vuetify.display.smAndUp" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Delete')" @click="removeImage(index)" />
           <v-btn
             v-else
             color="error"


### PR DESCRIPTION
### What

Following changes in #1334, do similar improvements in the Contribution assistant.
Also removed the "Source" word and replaced with an :information_source: icon

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/8b1367f4-a8c6-48ca-9c02-6db12548fd3b)|![image](https://github.com/user-attachments/assets/d30cceec-768a-4722-aa9b-6f152a4fb968)|
