### PR TITLE
refactor(User detail): fetch full user object from backend

### DIFF
--- a/src/components/UserActionMenuButton.vue
+++ b/src/components/UserActionMenuButton.vue
@@ -8,9 +8,6 @@
         </v-list-subheader>
         <v-divider />
         <ShareLink :overrideUrl="getShareLinkUrl" display="list-item" />
-        <v-list-item :slim="true" prepend-icon="mdi-image" :to="getUserProofListUrl">
-          {{ $t('Common.Proofs') }}
-        </v-list-item>
         <OpenFoodFactsLink facet="editor" :value="user.user_id" display="list-item" />
       </v-list>
     </v-menu>
@@ -53,9 +50,6 @@ export default {
     },
     getShareLinkUrl() {
       return `/users/${this.user.user_id}`
-    },
-    getUserProofListUrl() {
-      return `/users/${this.user.user_id}/proofs`
     }
   }
 }

--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -15,7 +15,7 @@
         <v-icon start icon="mdi-database-outline" />
         <span id="product-count">{{ $t('Common.ProductCount', { count: user.product_count }) }}</span>
       </v-chip>
-      <v-chip v-if="user.proof_count" label size="small" density="comfortable">
+      <v-chip v-if="user.proof_count" label size="small" density="comfortable" :to="getUserProofListUrl">
         <v-icon start icon="mdi-image" />
         <span id="proof-count">{{ $t('Common.ProofCount', { count: user.proof_count }) }}</span>
       </v-chip>
@@ -40,6 +40,11 @@ export default {
     readonly: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    getUserProofListUrl() {
+      return `/users/${this.user.user_id}/proofs`
     }
   },
   methods: {

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <UserCard :user="{user_id: username, price_count: userPriceTotal}" readonly />
+      <UserCard :user="user" readonly />
     </v-col>
   </v-row>
 
@@ -47,6 +47,7 @@ export default {
     return {
       username: this.$route.params.username,
       // data
+      user: null,
       userPriceList: [],
       userPriceTotal: null,
       userPricePage: 0,
@@ -77,6 +78,7 @@ export default {
   mounted() {
     this.currentFilter = this.$route.query[constants.FILTER_PARAM] || this.currentFilter
     this.currentOrder = this.$route.query[constants.ORDER_PARAM] || this.currentOrder
+    this.getUser()
     this.getUserPrices()
     // load more
     this.handleDebouncedScroll = utils.debounce(this.handleScroll, 100)
@@ -92,6 +94,13 @@ export default {
       this.userPriceTotal = null
       this.userPricePage = 0
       this.getUserPrices()
+    },
+    getUser() {
+      return api.getUserById(this.username)
+        .then((data) => {
+          this.user = data
+          this.loading = false
+        })
     },
     getUserPrices() {
       if ((this.userPriceTotal != null) && (this.userPriceList.length >= this.userPriceTotal)) return

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <UserCard :user="user" readonly />
+      <UserCard v-if="user" :user="user" readonly />
     </v-col>
   </v-row>
 
@@ -99,7 +99,6 @@ export default {
       return api.getUserById(this.username)
         .then((data) => {
           this.user = data
-          this.loading = false
         })
     },
     getUserPrices() {


### PR DESCRIPTION
### What

Changes thanks to https://github.com/openfoodfacts/open-prices/pull/689

Allows to display all of the user's stats in the user card at the top (same stats as the list view).
Also made the "proof count chip" cliquable (and removed the link in the action menu, introduced in #1256)