### PR TITLE
refactor(Proof add): Currency field: add basic help icon + tooltip

### DIFF
--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -17,6 +17,10 @@
     <v-col cols="6">
       <div class="text-subtitle-2">
         {{ $t('Common.Currency') }}
+        <v-icon class="float-right" size="small" icon="mdi-information-outline" />
+        <v-tooltip activator="parent" open-on-click location="top">
+          {{ $t('ChangeCurrencyDialog.AddCurrencies') }}
+        </v-tooltip>
       </div>
       <v-select
         v-model="proofMetadataForm.currency"


### PR DESCRIPTION
### What

Following the input field revamp in #1329
We now have room to add a help icon. And inform users on how to change their currency config.

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/ce8f6048-5199-4b8e-bf7d-db81244a7a17)|![image](https://github.com/user-attachments/assets/28a9ce17-9ca6-4a35-aef0-5da72efc3943)|