### PR TITLE
refactor(Price validation): only show Price tags with a prediction

### DIFF
--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -80,6 +80,7 @@ export default {
       let defaultParams = {
         proof__ready_for_price_tag_validation: true,
         status__isnull: true,
+        prediction_count__gte: 1,
         created__lte: this.currentDateTime,
         order_by: this.currentOrder,
         size: this.getApiSize,


### PR DESCRIPTION
### What

In the Price Validation Assistant, thanks to changes in the backend - see https://github.com/openfoodfacts/open-prices/pull/695 - we can now filter on the new `prediction_count` field, and return only Price tags with at least 1 prediction.

This will solve some (border case) issues, when the backend is processing new proof/price tags, and the price tags returned do not have any predictions (yet).

