### PR TITLE
refactor(Product): new warning if the barcode is too long (> 13 characters)

### DIFF
--- a/src/components/ProductBarcodeTooLongChip.vue
+++ b/src/components/ProductBarcodeTooLongChip.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-chip label size="small" density="comfortable" prepend-icon="mdi-help" color="warning" data-name="product-barcode-too-long-chip">
+    {{ $t('ProductCard.BarcodeLength', { length: barcode.length }) }}
+  </v-chip>
+</template>
+
+<script>
+export default {
+  props: {
+    barcode: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -20,9 +20,10 @@
               <ProductCategoriesChip v-if="!hideCategoriesAndLabels" class="mr-1" :productCategories="product.categories_tags" />
               <ProductLabelsChip v-if="!hideCategoriesAndLabels" :productLabels="product.labels_tags" />
             </span>
-            <ProductMissingChip v-else />
+            <ProductMissingChip v-else class="mr-1" />
             <br v-if="showProductBarcode">
             <ProductBarcodeChip v-if="showProductBarcode" :product="product" />
+            <ProductBarcodeTooLongChip v-if="barcodeTooLong" :barcode="product.code" class="mr-1" />
             <ProductBarcodeInvalidChip v-if="barcodeInvalid" />
             <ProductActionMenuButton v-if="hasProductSource && !hideActionMenuButton" :product="product" />
           </p>
@@ -54,6 +55,7 @@ export default {
     ProductLabelsChip: defineAsyncComponent(() => import('../components/ProductLabelsChip.vue')),
     ProductMissingChip: defineAsyncComponent(() => import('../components/ProductMissingChip.vue')),
     ProductBarcodeChip: defineAsyncComponent(() => import('../components/ProductBarcodeChip.vue')),
+    ProductBarcodeTooLongChip: defineAsyncComponent(() => import('../components/ProductBarcodeTooLongChip.vue')),
     ProductBarcodeInvalidChip: defineAsyncComponent(() => import('../components/ProductBarcodeInvalidChip.vue')),
     ProductActionMenuButton: defineAsyncComponent(() => import('../components/ProductActionMenuButton.vue')),
     PricePriceRow: defineAsyncComponent(() => import('../components/PricePriceRow.vue')),
@@ -107,9 +109,12 @@ export default {
     showProductBarcode() {
       return !this.hideProductBarcode || this.appStore.user.username && this.appStore.user.product_display_barcode
     },
+    barcodeTooLong() {
+      return this.product.code && utils.isBarcodeTooLong(this.product.code)
+    },
     barcodeInvalid() {
-      return this.product.code && !utils.isValidBarcode(this.product.code)
-    }
+      return this.product.code && !utils.isBarcodeValid(this.product.code)
+    },
   },
   methods: {
     getProductTitle() {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -534,6 +534,7 @@
 		"TwoDecimals": "Only two decimals allowed"
 	},
 	"ProductCard": {
+		"BarcodeLength": "Barcode length: {length}",
 		"Brands": "Brands",
 		"BrandLower": "brand",
 		"BrandMissing": "Brand missing",
@@ -547,6 +548,7 @@
 		"LabelTotal": "{count} labels",
 		"LatestPrice": "Latest price",
 		"InvalidBarcode": "Invalid barcode",
+		"InvalidBarcodeLength": "Invalid barcode length",
 		"ProductBrandMissing": "Product brand missing",
 		"ProductCategoriesMissing": "Product categories missing",
 		"ProductQuantityGram": "{0} g",

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ function getURLOrigin(value) {
 /**
  * https://stackoverflow.com/a/67933747/4293684
  */
-function isValidBarcode(value) {
+function isBarcodeValid(value) {
   // We only allow correct length barcodes
   if (!value.match(/^(\d{8}|\d{12,14})$/)) {
     return false;
@@ -62,6 +62,10 @@ function isValidBarcode(value) {
   }
 
   return ((10 - (result % 10)) % 10) === parseInt(paddedValue.charAt(13), 10)
+}
+
+function isBarcodeTooLong(value) {
+  return value.length > 13
 }
 
 function cleanBarcode(value) {
@@ -446,7 +450,8 @@ export default {
   isNumber,
   isURL,
   getURLOrigin,
-  isValidBarcode,
+  isBarcodeValid,
+  isBarcodeTooLong,
   cleanBarcode,
   addObjectToArray,
   removeObjectFromArray,


### PR DESCRIPTION
### What

Similar to the "invalid barcode" warning introduced in #622.

We add a new warning for barcodes that a length longer than the usual EAN13 (or EAN8).
(only a warning, doesn't prevent product/price creation, but will help users be more cautious of typos, especially in the Price Validation Assistant)

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/13a1babe-7855-48b4-9f9d-3d94c7ad9a1a)|![image](https://github.com/user-attachments/assets/18bdb5d6-e799-43c7-bc9e-c7166cfd1298)|
