### PR TITLE
refactor(Price tag): add a new error choice 'Not a price'

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -29,12 +29,16 @@
           </v-btn>
         </template>
         <v-list>
+          <v-list-item :slim="true" prepend-icon="mdi-eye-off-outline" @click="removePriceTag(2)">
+            {{ $t('Common.Unreadable') }}
+          </v-list-item>
+          <v-divider class="mt-2 mb-2" />
           <v-list-item :slim="true" prepend-icon="mdi-crop" @click="removePriceTag(3)">
             {{ $t('Common.Truncated') }}
           </v-list-item>
           <v-divider class="mt-2 mb-2" />
-          <v-list-item :slim="true" prepend-icon="mdi-eye-off-outline" @click="removePriceTag(2)">
-            {{ $t('Common.Unreadable') }}
+          <v-list-item :slim="true" prepend-icon="mdi-currency-usd-off" @click="removePriceTag(4)">
+            {{ $t('Common.NotAPrice') }}
           </v-list-item>
         </v-list>
       </v-menu>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -278,6 +278,7 @@
 		"MyPrices": "My prices",
 		"MyProofs": "My proofs",
 		"MyStats": "My stats",
+		"NotAPrice": "Not a price",
 		"Offline": "Offline",
 		"Online": "Online",
 		"Order": "Order",


### PR DESCRIPTION
### What

Following changes in the backend: https://github.com/openfoodfacts/open-prices/issues/702
- add a new "Not a price" error option
- move up the "Unreadable" option (used more often than "Truncated")

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/c912dacd-3cda-4e4d-bec3-c5a706b54af1)|![image](https://github.com/user-attachments/assets/4e538186-aa64-4e0e-9176-71f3460a9ed8)|