### PR TITLE
feat(Settings): user setting to display product source

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -21,10 +21,11 @@
               <ProductLabelsChip v-if="!hideCategoriesAndLabels" :productLabels="product.labels_tags" />
             </span>
             <ProductMissingChip v-else class="mr-1" />
-            <br v-if="showProductBarcode">
+            <br v-if="showProductBarcode || barcodeTooLong || barcodeInvalid || showProductSource">
             <ProductBarcodeChip v-if="showProductBarcode" :product="product" />
             <ProductBarcodeTooLongChip v-if="barcodeTooLong" :barcode="product.code" class="mr-1" />
-            <ProductBarcodeInvalidChip v-if="barcodeInvalid" />
+            <ProductBarcodeInvalidChip v-if="barcodeInvalid" class="mr-1" />
+            <ProductSourceChip v-if="showProductSource" :product="product" />
             <ProductActionMenuButton v-if="hasProductSource && !hideActionMenuButton" :product="product" />
           </p>
         </v-col>
@@ -57,6 +58,7 @@ export default {
     ProductBarcodeChip: defineAsyncComponent(() => import('../components/ProductBarcodeChip.vue')),
     ProductBarcodeTooLongChip: defineAsyncComponent(() => import('../components/ProductBarcodeTooLongChip.vue')),
     ProductBarcodeInvalidChip: defineAsyncComponent(() => import('../components/ProductBarcodeInvalidChip.vue')),
+    ProductSourceChip: defineAsyncComponent(() => import('../components/ProductSourceChip.vue')),
     ProductActionMenuButton: defineAsyncComponent(() => import('../components/ProductActionMenuButton.vue')),
     PricePriceRow: defineAsyncComponent(() => import('../components/PricePriceRow.vue')),
     PriceFooterRow: defineAsyncComponent(() => import('../components/PriceFooterRow.vue')),
@@ -114,6 +116,9 @@ export default {
     },
     barcodeInvalid() {
       return this.product.code && !utils.isBarcodeValid(this.product.code)
+    },
+    showProductSource() {
+      return this.appStore.user.username && this.appStore.user.product_display_source
     },
   },
   methods: {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -802,6 +802,7 @@
 		"PriceValidation": "Price validation",
 		"ProductDisplayBarcode": "Display barcode",
 		"ProductDisplayCategoryTag": "Display category tag",
+		"ProductDisplaySource": "Display source",
 		"SideMenuExperimentsDisplay": "Display 'Experiments'",
 		"Save": "Save",
 		"Title": "Settings",

--- a/src/store.js
+++ b/src/store.js
@@ -17,6 +17,7 @@ export const useAppStore = defineStore('app', {
       proofTotal: null,
       product_display_barcode: false,
       product_display_category_tag: false,
+      product_display_source: false,
       location_display_osm_id: false,
       drawer_display_experiments: true,
       preferedTheme: null,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -152,9 +152,19 @@
           />
           <v-switch
             v-model="appStore.user.product_display_category_tag"
+            class="mb-4"
             color="primary"
             :label="$t('UserSettings.ProductDisplayCategoryTag')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'en:oranges' })"
+            density="compact"
+            persistent-hint
+            hide-details="auto"
+          />
+          <v-switch
+            v-model="appStore.user.product_display_source"
+            color="primary"
+            :label="$t('UserSettings.ProductDisplaySource')"
+            :hint="$t('Common.ExampleWithColonAndValue', { value: 'OBF' })"
             density="compact"
             persistent-hint
             hide-details="auto"


### PR DESCRIPTION
### What

Following #1363 (`ProductSourceChip`), and similar to #559.
New settings to display the product source in the `ProductCard`

### Screenshot

|Hidden (default)|Display|
|-|-|
|![image](https://github.com/user-attachments/assets/8e948ce0-4d74-4853-94a8-53766374c1aa)|![image](https://github.com/user-attachments/assets/cb9247db-00a2-41c7-bc8a-9ae252a01d7f)|
