### PR TITLE
feat(LocationMap): Display tooltips as cards and allow selection

### DIFF
--- a/src/components/LeafletMap.vue
+++ b/src/components/LeafletMap.vue
@@ -3,11 +3,31 @@
     <l-tile-layer :url="tiles" layer-type="base" name="OpenStreetMap" :attribution="attribution" />
     <l-marker v-for="location in locations" :key="getLocationUniqueID(location)" :lat-lng="getLocationLatLng(location)">
       <l-popup>
-        <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
-        {{ getLocationTitle(location, false, true, true) }}<br>
-        <v-chip label size="small" density="comfortable">
-          {{ getLocationTag(location) }}
-        </v-chip>
+        <v-card>
+          <v-card-title>
+            <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
+          </v-card-title>
+          <v-card-subtitle>
+            {{ getLocationTitle(location, false, true, true) }}<br>
+          </v-card-subtitle>
+          <v-card-text>
+            <v-chip label size="small" density="comfortable">
+              {{ getLocationTag(location) }}
+            </v-chip>
+          </v-card-text>
+          <v-card-actions v-if="showActions">
+            <v-spacer v-if="$vuetify.display.smAndUp" />
+            <v-btn
+              class="float-right"
+              color="primary"
+              variant="flat"
+              :block="!$vuetify.display.smAndUp"
+              @click="locationSelected(location)"
+            >
+              {{ $t('LocationSelector.Select') }}
+            </v-btn>
+          </v-card-actions>
+        </v-card>
       </l-popup>
     </l-marker>
   </l-map>
@@ -31,7 +51,12 @@ export default {
       type: Array,
       required: true
     },
+    showActions: {
+      type: Boolean,
+      default: false
+    }
   },
+  emits: ['locationSelected'],
   data() {
     return {
       map: null,
@@ -71,6 +96,17 @@ export default {
     getLocationLatLng(location) {
       return utils.getLocationLatLng(location)
     },
+    locationSelected(location) {
+      this.$emit('locationSelected', location)
+    }
   }
 }
 </script>
+<style>
+.leaflet-popup-content {
+  margin: 0;
+}
+.leaflet-popup-content-wrapper {
+  padding: 0;
+}
+</style>

--- a/src/components/LeafletMap.vue
+++ b/src/components/LeafletMap.vue
@@ -5,7 +5,7 @@
       <l-popup>
         <v-card>
           <v-card-title>
-            <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
+            {{ getLocationTitle(location, true, false, false) }}
           </v-card-title>
           <v-card-subtitle>
             {{ getLocationTitle(location, false, true, true) }}<br>
@@ -24,7 +24,7 @@
               :block="!$vuetify.display.smAndUp"
               @click="locationSelected(location)"
             >
-              {{ $t('LocationSelector.Select') }}
+              {{ $t('Common.Select') }}
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -36,8 +36,8 @@
 <script>
 import 'leaflet/dist/leaflet.css'
 import { LMap, LTileLayer, LMarker, LPopup } from '@vue-leaflet/vue-leaflet'
-import utils from '../utils.js'
 import { useTheme } from 'vuetify'
+import utils from '../utils.js'
 
 export default {
   components: {
@@ -102,6 +102,7 @@ export default {
   }
 }
 </script>
+
 <style>
 .leaflet-popup-content {
   margin: 0;

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -82,7 +82,7 @@
                   </v-card>
                 </v-col>
                 <v-col cols="12" sm="6" style="min-height:400px">
-                  <LeafletMap :locations="results" />
+                  <LeafletMap :locations="results" :showActions="true" @locationSelected="selectLocation" />
                 </v-col>
               </v-row>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -344,6 +344,7 @@
 		"Reuses": "Reuses",
 		"ReusesKnown": "Known reuses",
 		"Search": "Search",
+		"Select": "Select",
 		"Settings": "Settings",
 		"SignInOFFAccount": "Sign in with your {url} account",
 		"SignedIn": "Signed in!",
@@ -493,7 +494,6 @@
 		"RecentLocations": "No recent locations | Recent location {recentLocationNumber}| Recent locations {recentLocationNumber}",
 		"Result": "Result {resultNumber} | Results {resultNumber}",
 		"SearchByName": "Search for your shop by name and city",
-		"Select": "Select location",
 		"Title": "Find your shop location",
 		"Warning": "The search engine to find a shop is currently not very precise.{newline}Don't hesitate to add the street name to narrow down the results.{newline}Examples: Carrefour City 15e Paris ; Sainsbury's camden London"
 	},

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -493,6 +493,7 @@
 		"RecentLocations": "No recent locations | Recent location {recentLocationNumber}| Recent locations {recentLocationNumber}",
 		"Result": "Result {resultNumber} | Results {resultNumber}",
 		"SearchByName": "Search for your shop by name and city",
+		"Select": "Select location",
 		"Title": "Find your shop location",
 		"Warning": "The search engine to find a shop is currently not very precise.{newline}Don't hesitate to add the street name to narrow down the results.{newline}Examples: Carrefour City 15e Paris ; Sainsbury's camden London"
 	},


### PR DESCRIPTION
### What
- Prettier tooltips as cards, with theme support
- Added an optional (hidden by default) select location button in tooltip, so users do not have to look in the list

### Screenshot
| Before | After |
| ------- | ----- |
| ![Screenshot 2025-02-08 at 17-07-06 Open Prices](https://github.com/user-attachments/assets/2579b5aa-9e72-427b-b56d-9e646a60eeb5) | ![Screenshot 2025-02-08 at 16-59-19 Open Prices](https://github.com/user-attachments/assets/722f1c59-b13c-469c-9c34-d1d6683b877b) |

