### PR TITLE
feat(Proof upload): allow to opt-out from price tag validation

### DIFF
--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -29,7 +29,7 @@
             <v-checkbox
               v-model="proofForm.ready_for_price_tag_validation"
               density="compact"
-              :label="$t('Common.ValidatePricesWithAI')"
+              :label="$t('ProofAdd.PriceValidationAllow')"
               :true-value="true"
               hide-details="auto"
             />

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -24,6 +24,17 @@
         <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
         <LocationInputRow :locationForm="proofForm" />
         <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" />
+        <v-row v-if="typePriceTagOnly && multiple" class="mt-0">
+          <v-col cols="12" class="pb-0">
+            <v-checkbox
+              v-model="proofForm.ready_for_price_tag_validation"
+              density="compact"
+              :label="$t('Common.ValidatePricesWithAI')"
+              :true-value="true"
+              hide-details="auto"
+            />
+          </v-col>
+        </v-row>
       </v-sheet>
       <v-sheet v-else-if="step === 2">
         <v-progress-linear
@@ -124,7 +135,7 @@ export default {
       step: 1,  // 1: form; 2: uploading; 3: done
       // form
       proofForm: {
-        type: null,
+        type: null,  // see initProofForm
         location_id: null,
         location_osm_id: null,
         location_osm_type: '',
@@ -132,6 +143,7 @@ export default {
         currency: null,  // see initProofForm
         receipt_price_count: null,
         receipt_price_total: null,
+        ready_for_price_tag_validation: null,  // see initProofForm
         proof_id: null
       },
       // data
@@ -192,6 +204,9 @@ export default {
     initProofForm() {
       if (this.typePriceTagOnly) {
         this.proofForm.type = constants.PROOF_TYPE_PRICE_TAG
+        if (this.multiple) {
+          this.proofForm.ready_for_price_tag_validation = true
+        }
       }
       this.proofForm.currency = this.appStore.getUserLastCurrencyUsed
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -576,7 +576,8 @@
 	},
 	"ProofAdd": {
 		"HowToMultiple": "All the price tag images you select should share the same shop location, and been taken on the same day.",
-		"HowToMultipleShort": "Pictures should share the same shop location and date."
+		"HowToMultipleShort": "Pictures should share the same shop location and date.",
+		"PriceValidationAllow": "Allow my pictures' prices to be extracted and validated by the community"
 	},
 	"ProofCard": {
 		"Proof": "Proof",

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -130,6 +130,11 @@ export default {
         formData.append('receipt_price_total', data.receipt_price_total)
       }
     }
+    else if (data.type === constants.PROOF_TYPE_PRICE_TAG) {
+      if (data.ready_for_price_tag_validation) {
+        formData.append('ready_for_price_tag_validation', data.ready_for_price_tag_validation)
+      }
+    }
     const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/upload?${buildURLParams({'app_page': source})}`
     return fetch(url, {
       method: 'POST',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,7 +4,7 @@ import constants from '../constants'
 
 const PRICE_UPDATE_FIELDS = ['type', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'price_per', 'currency', 'receipt_quantity', 'date']
 const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['product_code', 'product_name', 'location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
-const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total']
+const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'ready_for_price_tag_validation']
 const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat(['location_id', 'location_osm_id', 'location_osm_type'])  // 'file'
 const LOCATION_ONLINE_CREATE_FIELDS = ['type', 'website_url']
 const LOCATION_SEARCH_LIMIT = 10


### PR DESCRIPTION
### What

Following changes in the backend - https://github.com/openfoodfacts/open-prices/pull/710 - we now give users the possibility to opt-out from price validation.

When uploading multiple proofs, users can uncheck the field, and their proof's price tags will not appear in the Price validation page.

### Screenshot

|Before|After v1|After v2|
|-|-|-|
|![image](https://github.com/user-attachments/assets/2e33ac37-44a1-43b1-86f8-7459ecb647d2)|![Screenshot from 2025-02-12 20-11-43](https://github.com/user-attachments/assets/4b7a041c-7633-4c47-ab7a-80e22bd5bbb4)|![image](https://github.com/user-attachments/assets/647ff5ec-4394-44dd-ac85-f316c01a002b)|
