### PR TITLE
refactor(ContributionAssistant): display correct values for existing prices

### DIFF
--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -224,7 +224,7 @@ export default {
       labelProcessingErrorMessage: false,
       nextProofSuggestions: [],
       lastUpdatedPriceTagId: null,
-      existingProofPrices: []
+      proofPriceExistingList: []
     }
   },
   computed: {
@@ -310,7 +310,7 @@ export default {
     },
     getExistingProofPrices(proofId) {
       api.getPrices({proof_id: proofId}).then(data => {
-        this.existingProofPrices = data.items
+        this.proofPriceExistingList = data.items
       })
     },
     onProofUploaded(proof) {
@@ -449,9 +449,9 @@ export default {
           price_id: priceTag.price_id
         }
         if (productPriceForm.price_id) {
-          const existingProofPrice = this.existingProofPrices.find(existingProofPrice => existingProofPrice.id === productPriceForm.price_id)
-          if (existingProofPrice) {
-            productPriceForm = Object.assign(productPriceForm, existingProofPrice)
+          const proofPriceExisting = this.proofPriceExistingList.find(price => price.id === productPriceForm.price_id)
+          if (proofPriceExisting) {
+            productPriceForm = Object.assign(productPriceForm, proofPriceExisting)
           }
         }
         this.productPriceForms.push(productPriceForm)

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -223,7 +223,8 @@ export default {
       numberOfPricesAdded: 0,
       labelProcessingErrorMessage: false,
       nextProofSuggestions: [],
-      lastUpdatedPriceTagId: null
+      lastUpdatedPriceTagId: null,
+      existingProofPrices: []
     }
   },
   computed: {
@@ -307,6 +308,11 @@ export default {
         })
       }
     },
+    getExistingProofPrices(proofId) {
+      api.getPrices({proof_id: proofId}).then(data => {
+        this.existingProofPrices = data.items
+      })
+    },
     onProofUploaded(proof) {
       // A new proof was selected by the user, or loaded from the query param
       this.extractedLabels = []
@@ -347,6 +353,7 @@ export default {
           this.proofWithBoundingBoxesLoading = false
         })
       }
+      this.getExistingProofPrices(this.proofObject.id)
     },
     loadPriceTagsWithPredictions(minNumberOfPriceTagWithPredictions, maxTries, callback) {
       // Call price tag API every 3 seconds until we have at least minNumberOfPriceTagWithPredictions, max 6 times
@@ -422,7 +429,7 @@ export default {
         // remove anything that is not a number from label.barcode
         const barcodeString = label.barcode ? utils.cleanBarcode(label.barcode.toString()) : ''
         const priceType = barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY
-        const productPriceForm = {
+        let productPriceForm = {
           id: priceTag.id,
           type: priceType,
           category_tag: (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.product)) ? label.product : null,
@@ -440,6 +447,12 @@ export default {
           bounding_box: priceTag.bounding_box,
           status: priceTag.status,
           price_id: priceTag.price_id
+        }
+        if (productPriceForm.price_id) {
+          const existingProofPrice = this.existingProofPrices.find(existingProofPrice => existingProofPrice.id === productPriceForm.price_id)
+          if (existingProofPrice) {
+            productPriceForm = Object.assign(productPriceForm, existingProofPrice)
+          }
         }
         this.productPriceForms.push(productPriceForm)
       })

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -260,14 +260,14 @@ export default {
       // load existing proof prices
       this.proofPriceExistingList = []
       if (this.proofObject.price_count) {
-        this.getProofPrices()
+        this.getExistingProofPrices()
       }
       // get ready to add prices: init product price form
       this.initNewProductPriceForm()
       // move to step 2
       this.step = 2
     },
-    getProofPrices() {
+    getExistingProofPrices() {
       this.loading = true
       return api.getPrices({ proof_id: this.proofObject.id, size: this.proofObject.price_count, order_by: 'created' })
         .then((data) => {


### PR DESCRIPTION
### What
- In the 3rd step of the assistant, we display price tags with prices already added in a greyed-out way (disabled)
- While not being editable, these cards kept the same behavior as the other ones, meaning they also displayed the predicted content, instead of the actual added price
- This PR shows the actual added prices instead
