### PR TITLE
feat(Barcode search): allow wildcard search thanks to search-a-licious

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -49,6 +49,7 @@ export default {
   OFF_WIKI_APP_URL: 'https://wiki.openfoodfacts.org/Project:Open-Prices',
   OFF_WIKI_GDPR_REQUEST_URL: 'https://wiki.openfoodfacts.org/GDPR_request',
   OFF_API_URL: 'https://world.openfoodfacts.org/api/v2/product',
+  OFF_SEARCHALICIOUS_API_URL: 'https://search.openfoodfacts.org',
   OFF_CROWDIN_URL: 'https://translate.openfoodfacts.org',
   OBF_NAME: OBF_NAME,
   OBF_URL: 'https://world.openbeautyfacts.org',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -415,6 +415,15 @@ export default {
     .then((response) => response.json())
   },
 
+  searchaliciousProductSearch(code) {
+    const url = `${constants.OFF_SEARCHALICIOUS_API_URL}/search?q=code:${code}`
+    return fetch(url, {
+      method: 'GET',
+      headers: OP_DEFAULT_HEADERS
+    })
+    .then((response) => response.json())
+  },
+
 
   /**
    * OPENSTREETMAP API


### PR DESCRIPTION
### What

Allow users to search for barcodes with wildcard.
"Hidden" feature, not advertised.

The product data format is slightly different, did some super quick hacks in the meantime.

### Screenshot

|Regular search|With wildcard|With 2 wildcards|
|-|-|-|
|![image](https://github.com/user-attachments/assets/2d15156b-9a47-48e2-8676-82f3ce4e87a4)|![image](https://github.com/user-attachments/assets/abf02ff0-3ebc-4288-825a-0ae72a76f3a4)|![image](https://github.com/user-attachments/assets/d455923f-2246-400a-9cec-f875ed1e4bd1)|