### PR TITLE
fix(Challenge): Timeline: fix off-by-one end date error

### DIFF
--- a/src/components/ChallengeTimeline.vue
+++ b/src/components/ChallengeTimeline.vue
@@ -41,7 +41,9 @@ export default {
       return Math.round((new Date(this.challenge.endDate) - new Date(this.challenge.startDate)) / (1000 * 60 * 60 * 24))
     },
     todayIndex() {
-      return Math.round((new Date() - new Date(this.challenge.startDate)) / (1000 * 60 * 60 * 24))
+      let today = new Date()
+      today.setHours(0, 0, 0, 0)
+      return Math.round((today - new Date(this.challenge.startDate)) / (1000 * 60 * 60 * 24))
     },
     daysLeftText() {
       const daysLeft = this.nbDays - this.todayIndex

--- a/src/components/ChallengeTimeline.vue
+++ b/src/components/ChallengeTimeline.vue
@@ -47,9 +47,10 @@ export default {
     },
     daysLeftText() {
       const daysLeft = this.nbDays - this.todayIndex
-      if (daysLeft <= 0) return "Challenge over"
+      if (daysLeft < 0) return "Challenge over"
+      if (daysLeft === 0) return "Last day"
       if (daysLeft >= this.nbDays) return "Not started"
-      return `${daysLeft} days left`
+      return `${daysLeft} day${daysLeft > 1 ? 's' : ''} left`
     },
     progress() {
       return Math.min(100, this.todayIndex * 100 / this.nbDays)


### PR DESCRIPTION
### What
- After mid-day, challenge timeline shows that the challenge ended, when there's still a day left.
- It was only a visual bug, with no effects on stats, as far as I can tell.
- This fixes it
