### PR TITLE
feat(Stats): display price count per product source (OxF flavors)

### DIFF
--- a/src/components/StatCard.vue
+++ b/src/components/StatCard.vue
@@ -19,7 +19,7 @@
 export default {
   props: {
     value: {
-      type: Number,
+      type: [Number, String],
       default: 0
     },
     subtitle: {

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -28,10 +28,24 @@
 
   <v-row>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.product_with_price_count" :subtitle="$t('Stats.WithPrice')" to="/products" />
+      <StatCard :value="stats.product_count" :subtitle="$t('Stats.Total')" to="/products" />
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.product_count" :subtitle="$t('Stats.Total')" />
+      <StatCard :value="stats.product_with_price_count" :subtitle="$t('Stats.WithPrice')" />
+    </v-col>
+  </v-row>
+  <v-row>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.product_source_off_with_price_count.toString() + ' / ' + stats.product_source_off_count.toString()" :subtitle="$t('Common.Food')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.product_source_obf_with_price_count.toString() + ' / ' + stats.product_source_obf_count.toString()" :subtitle="$t('Common.Beauty')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.product_source_opf_with_price_count.toString() + ' / ' + stats.product_source_opf_count.toString()" :subtitle="$t('Common.Products')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.product_source_opff_with_price_count.toString() + ' / ' + stats.product_source_opff_count.toString()" :subtitle="$t('Common.PetFood')" />
     </v-col>
   </v-row>
 
@@ -140,7 +154,15 @@ export default {
         price_type_category_tag_count: 0,
         price_currency_count: 0,
         product_count: 0,
+        product_source_off_count: 0,
+        product_source_obf_count: 0,
+        product_source_opf_count: 0,
+        product_source_opff_count: 0,
         product_with_price_count: 0,
+        product_source_off_with_price_count: 0,
+        product_source_obf_with_price_count: 0,
+        product_source_opf_with_price_count: 0,
+        product_source_opff_with_price_count: 0,
         location_count: 0,
         location_with_price_count: 0,
         location_type_osm_count: 0,


### PR DESCRIPTION
### What

Following new stats in the backend: https://github.com/openfoodfacts/open-prices/pull/708

Changes in the stats page:
- add detailed stats per flavor

### Screenshot

||Image|
|-|-|
|Before|![image](https://github.com/user-attachments/assets/017cd768-c7a0-4b15-aa55-7126d70d2527)|
|After|![image](https://github.com/user-attachments/assets/3ce0e4de-0af8-408f-a72f-5e61556bec08)|
