### PR TITLE
refactor(History): show the price & proof source info

### DIFF
--- a/src/components/HistoryCard.vue
+++ b/src/components/HistoryCard.vue
@@ -4,6 +4,7 @@
       {{ getDateTimeFormatted(price.created) }} ({{ getRelativeDateTimeFormatted(price.created) }})
       <span>- </span>
       <a :href="getUserDetailUrl">{{ price.owner }}</a>
+      <span>({{ price.source }})</span>
     </v-card-text>
   </v-card>
 </template>


### PR DESCRIPTION
### What

Following a change in the backend, we now return the Price/Proof/Location source field: https://github.com/openfoodfacts/open-prices/pull/719

We can display this info in the `HistoryCard` in the `PriceDetail` & `ProofDetail` pages

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/2809fe7c-658d-492a-ba9b-b296c018cf84)|![image](https://github.com/user-attachments/assets/d4790838-a620-4438-bdce-3894336d8ca3)|
