### PR TITLE
refactor(Stats): new Misc section. Show prices & proofs count per source

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -284,6 +284,8 @@
 		"LocationCount": "{count} locations | {count} location | {count} locations",
 		"LocationNotFound": "Location not found",
 		"Map": "Map",
+		"Miscellaneous": "Miscellaneous",
+		"MobileApp": "Mobile app",
 		"MyDashboard": "My dashboard",
 		"MyPrices": "My prices",
 		"MyProofs": "My proofs",
@@ -305,6 +307,7 @@
 		"OrderProofCreatedDESC": "Addition date",
 		"OrderProofDateDESC": "Proof date",
 		"OrderUserCountDESC": "User count",
+		"Other": "Other",
 		"PersonalInfo": "Personal information",
 		"Physical": "Physical",
 		"Picture": "Picture",
@@ -780,6 +783,7 @@
 		"WithoutProduct": "Without a product",
 		"WithBarcode": "With a barcode",
 		"WithCategory": "With a category",
+		"PricesProofsPerSource": "Prices and proofs per source",
 		"LastUpdated": "Last updated on {date}"
 	},
 	"UserDashboard": {

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -25,9 +25,6 @@
     <v-col cols="6" sm="4" md="3" lg="2">
       <StatCard :value="stats.price_type_group_consumption_count" :subtitle="$t('Common.Consumption')" />
     </v-col>
-    <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.price_currency_count" :subtitle="$t('Common.Currencies')" />
-    </v-col>
   </v-row>
 
   <br>
@@ -136,6 +133,41 @@
     </v-col>
   </v-row>
 
+  <br>
+
+  <h2 class="text-h6 mb-1">
+    <v-icon size="x-small" icon="mdi-tune-vertical" />
+    {{ $t('Common.Miscellaneous') }}
+  </h2>
+
+  <v-row>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_currency_count" :subtitle="$t('Common.Currencies')" />
+    </v-col>
+  </v-row>
+
+  <p class="mt-2 mb-1">
+    <v-icon size="x-small" icon="mdi-circle-small" />
+    {{ $t('Stats.PricesProofsPerSource') }}
+  </p>
+
+  <v-row>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_source_web_count.toString() + ' | ' + stats.proof_source_web_count.toString()" :subtitle="$t('Common.Website')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_source_mobile_count.toString() + ' | ' + stats.proof_source_mobile_count.toString()" :subtitle="$t('Common.MobileApp')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_source_api_count.toString() + ' | ' + stats.proof_source_api_count.toString()" subtitle="API" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_source_other_count.toString() + ' | ' + stats.proof_source_other_count.toString()" :subtitle="$t('Common.Other')" />
+    </v-col>
+  </v-row>
+
+  <br>
+
   <v-row>
     <v-col cols="12">
       <i18n-t keypath="Stats.LastUpdated" tag="span" :title="getRelativeDateTimeFormatted(stats.updated)">
@@ -166,6 +198,10 @@ export default {
         price_with_discount_count: 0,
         price_type_group_community_count: 0,
         price_type_group_consumption_count: 0,
+        price_source_web_count: 0,
+        price_source_mobile_count: 0,
+        price_source_api_count: 0,
+        price_source_other_count: 0,
         price_currency_count: 0,
         product_count: 0,
         product_source_off_count: 0,
@@ -188,6 +224,10 @@ export default {
         proof_type_receipt_count: 0,
         proof_type_gdpr_request_count: 0,
         proof_type_shop_import_count: 0,
+        proof_source_web_count: 0,
+        proof_source_mobile_count: 0,
+        proof_source_api_count: 0,
+        proof_source_other_count: 0,
         user_count: 0,
         user_with_price_count: 0,
         challenge_count: 1,  // hardcoded


### PR DESCRIPTION
### What

2 changes in the stats page:
- new Miscellaneous section at the bottom
- show prices & proofs count per source - thanks to https://github.com/openfoodfacts/open-prices/pull/736

### Screenshot

![image](https://github.com/user-attachments/assets/63bfea26-d6c6-4482-831c-c2540b8b9612)
