### PR TITLE
build: rename main branch from 'master' to 'main'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy project
 on:
   push:
     branches:
-      - master
+      - main
       - deploy-*
     tags:
       - v*.*.*

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Run release-please
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release-please:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Works with an Open Prices server, see https://github.com/openfoodfacts/open-pric
 
 ## Contribute
 
-See [CONTRIBUTING.md](https://github.com/openfoodfacts/open-prices-frontend/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/openfoodfacts/open-prices-frontend/blob/main/CONTRIBUTING.md)
 
 <details><summary><h2>Weekly meetings</h2></summary>
 * see https://github.com/openfoodfacts/open-prices#weekly-meetings


### PR DESCRIPTION
### What

Renamed the main branch's name from `master` to `main`
- to match with the backend repo: https://github.com/openfoodfacts/open-prices
- to match with most of OFF's repos

https://github.com/github/renaming#renaming-existing-branches

Additional changes to reflect this renaming.