### PR TITLE
feat(Proofs): Display the new receipt_online_delivery_costs field in the form

### DIFF
--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -62,6 +62,7 @@ export default {
         currency: null,
         receipt_price_count: null,
         receipt_price_total: null,
+        receipt_online_delivery_costs: null,
       },
       loading: false
     }

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -5,6 +5,7 @@
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofReceiptPriceCountChip v-if="showReceiptPriceCount" class="mr-1" :totalCount="proof.receipt_price_count" />
       <ProofReceiptPriceTotalChip v-if="showReceiptPriceTotal" class="mr-1" :totalCount="proof.receipt_price_total" :currency="proof.currency" />
+      <ProofReceiptOnlineDeliveryCostsChip v-if="showReceiptOnlineDeliveryCosts" class="mr-1" :price="proof.receipt_online_delivery_costs" :currency="proof.currency" />
       <PriceCountChip v-if="!hidePriceCount" class="mr-1" :count="proof.price_count" :withLabel="true" source="proof" @click="goToProof()" />
       <LocationChip class="mr-1" :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
       <DateChip class="mr-1" :date="proof.date" :showErrorIfDateMissing="true" :readonly="readonly" />
@@ -29,6 +30,7 @@ export default {
     ProofTypeChip: defineAsyncComponent(() => import('../components/ProofTypeChip.vue')),
     ProofReceiptPriceCountChip: defineAsyncComponent(() => import('../components/ProofReceiptPriceCountChip.vue')),
     ProofReceiptPriceTotalChip: defineAsyncComponent(() => import('../components/ProofReceiptPriceTotalChip.vue')),
+    ProofReceiptOnlineDeliveryCostsChip: defineAsyncComponent(() => import('../components/ProofReceiptOnlineDeliveryCostsChip.vue')),
     PriceCountChip: defineAsyncComponent(() => import('../components/PriceCountChip.vue')),
     LocationChip: defineAsyncComponent(() => import('../components/LocationChip.vue')),
     DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
@@ -83,6 +85,9 @@ export default {
     },
     showReceiptPriceTotal() {
       return this.userIsProofOwner && this.proofIsTypeReceipt && this.proof.receipt_price_total
+    },
+    showReceiptOnlineDeliveryCosts() {
+      return this.userIsProofOwner && this.proofIsTypeReceipt && this.proof.receipt_online_delivery_costs
     },
   },
   methods: {

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -64,6 +64,24 @@
       />
     </v-col>
   </v-row>
+  <v-row v-if="proofIsTypeReceipt" class="mt-0">
+    <v-col cols="6">
+      <div class="text-subtitle-2">
+        <v-icon size="small" :icon="LOCATION_TYPE_ONLINE_ICON" /> {{ $t('Common.ReceiptOnlineDeliveryCosts') }}
+      </div>
+      <v-text-field
+        v-model="proofMetadataForm.receipt_online_delivery_costs"
+        density="compact"
+        variant="outlined"
+        type="text"
+        inputmode="decimal"
+        :rules="priceOnlineDeliveryCostsRules"
+        :suffix="proofMetadataForm.currency"
+        hide-details="auto"
+        @update:modelValue="newValue => proofMetadataForm.receipt_online_delivery_costs = fixComma(newValue)"
+      />
+    </v-col>
+  </v-row>
 </template>
 
 <script>
@@ -80,7 +98,8 @@ export default {
         date: this.currentDate,
         currency: null,
         receipt_price_count: null,
-        receipt_price_total: null
+        receipt_price_total: null,
+        receipt_online_delivery_costs: null,
       })
     },
     proofType: {
@@ -92,6 +111,7 @@ export default {
     return {
       currentDate: utils.currentDate(),
       PROOF_TYPE_RECEIPT_ICON: constants.PROOF_TYPE_RECEIPT_ICON,
+      LOCATION_TYPE_ONLINE_ICON: constants.LOCATION_TYPE_ONLINE_ICON,
     }
   },
   computed: {
@@ -115,6 +135,15 @@ export default {
     },
     priceTotalRules() {
       if (!this.proofMetadataForm.receipt_price_total) return [() => true]  // optional field
+      return [
+        value => !!value && !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
+        value => !isNaN(value) || this.$t('PriceRules.Number'),
+        value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
+        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
+      ]
+    },
+    priceOnlineDeliveryCostsRules() {
+      if (!this.proofMetadataForm.receipt_online_delivery_costs) return [() => true]  // optional field
       return [
         value => !!value && !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),

--- a/src/components/ProofReceiptOnlineDeliveryCostsChip.vue
+++ b/src/components/ProofReceiptOnlineDeliveryCostsChip.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-chip label size="small" :prepend-icon="LOCATION_TYPE_ONLINE_ICON" variant="flat" density="comfortable" :title="$t('Common.ReceiptOnlineDeliveryCosts')">
+    {{ getPriceValueDisplay(price) }}
+  </v-chip>
+</template>
+
+<script>
+import constants from '../constants'
+import utils from '../utils.js'
+
+export default {
+  props: {
+    price: {
+      type: Number,
+      default: null
+    },
+    currency: {
+      type: String,
+      default: null
+    }
+  },
+  data() {
+    return {
+      LOCATION_TYPE_ONLINE_ICON: constants.LOCATION_TYPE_ONLINE_ICON,
+    }
+  },
+  methods: {
+    getPriceValue(priceValue, priceCurrency) {
+      return utils.prettyPrice(priceValue, priceCurrency)
+    },
+    getPriceValueDisplay(price) {
+      price = parseFloat(price)
+      return this.getPriceValue(price, this.currency)
+    },
+  }
+}
+</script>

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -143,6 +143,7 @@ export default {
         currency: null,  // see initProofForm
         receipt_price_count: null,
         receipt_price_total: null,
+        receipt_online_delivery_costs: null,
         ready_for_price_tag_validation: null,  // see initProofForm
         proof_id: null
       },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -354,6 +354,7 @@
 		"Receipts": "Receipts",
 		"ReceiptPriceCount": "Number of prices",
 		"ReceiptPriceTotal": "Total amount",
+		"ReceiptOnlineDeliveryCosts": "Delivery costs",
 		"Recent": "Recent",
 		"Reuses": "Reuses",
 		"ReusesKnown": "Known reuses",

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,7 +4,7 @@ import constants from '../constants'
 
 const PRICE_UPDATE_FIELDS = ['type', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'discount_type', 'price_per', 'currency', 'receipt_quantity', 'date']
 const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['product_code', 'product_name', 'location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
-const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'ready_for_price_tag_validation']
+const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'ready_for_price_tag_validation']
 const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat(['location_id', 'location_osm_id', 'location_osm_type'])  // 'file'
 const LOCATION_ONLINE_CREATE_FIELDS = ['type', 'website_url']
 const LOCATION_SEARCH_LIMIT = 10
@@ -133,6 +133,9 @@ export default {
       }
       if (data.receipt_price_total) {
         formData.append('receipt_price_total', data.receipt_price_total)
+      }
+      if (data.receipt_online_delivery_costs) {
+        formData.append('receipt_online_delivery_costs', data.receipt_online_delivery_costs)
       }
     }
     else if (data.type === constants.PROOF_TYPE_PRICE_TAG) {

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -195,6 +195,7 @@ export default {
         currency: null,
         receipt_price_count: null,
         receipt_price_total: null,
+        receipt_online_delivery_costs: null,
       },
       productPriceForm: {},
       productFormFilled: false,


### PR DESCRIPTION
### What

Following recent changes in the backend: https://github.com/openfoodfacts/open-prices/pull/724

- Display the new `Proof.receipt_online_delivery_costs` field in the proof form. Create & Edit; Only for receipts.
- New `ProofReceiptOnlineDeliveryCostsChip` component to display the delivery costs in the proof footer

### Screenshot

|Page|Before|After|
|-|-|-|
|Proof form|![image](https://github.com/user-attachments/assets/b088c880-f2a2-4290-b1f7-547e5ccfc242)|![image](https://github.com/user-attachments/assets/1349ca02-ce51-4b05-a485-97a22b1ffa42)|
|Proof card|![image](https://github.com/user-attachments/assets/63a59089-444a-4413-9e45-96885b2b0a40)|![image](https://github.com/user-attachments/assets/fcbd485b-f07c-45a2-ad61-87da53347766)|
