### PR TITLE
refactor(Challenge): display Home banner only if ongoing challenge

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -212,6 +212,16 @@ function prettyRelativeDateTime(dateTimeString, size=null) {
   diff < 60 && "just now" || diff < 120 && "1 minute ago" || diff < 3600 && Math.floor(diff / 60) + " minutes ago" || diff < 7200 && "1 hour ago" || diff < 86400 && Math.floor(diff / 3600) + " hours ago") || day_diff == 1 && "Yesterday" || day_diff < 10 && day_diff + " days ago" || Math.ceil(day_diff / 7) + " weeks ago";
 }
 
+/**
+ * input: '2023-12-25', '2023-12-31'
+ * output: true if date (or today) is between start and end dates
+ */
+function isBetweenTwoDates(startDateString, endDateString, date=currentDateTime()) {
+  const startDate = dateStartOfDay(startDateString)
+  const endDate = dateEndOfDay(endDateString)
+  return (startDate <= date) && (date <= endDate)
+}
+
 function dateType(dateString) {
   if (dateString) {
     if (dateString.match(constants.DATE_FULL_REGEX_MATCH)) {
@@ -485,6 +495,7 @@ export default {
   prettyDateTime,
   offDateTime,
   prettyRelativeDateTime,
+  isBetweenTwoDates,
   dateType,
   getOFFUsernameFromAuthToken,
   getCategoryName,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -70,7 +70,7 @@ export default {
       return this.appStore.user.username
     },
     currentChallenge() {
-      return Challenge[0]
+      return Challenge.filter(c => utils.isBetweenTwoDates(c.startDate, c.endDate))[0]
     },
     getApiSize() {
       if (!this.$vuetify.display.smAndUp) return 5


### PR DESCRIPTION
### What

Now that the first challenge is over, hide it from the Home page.
The banner will only be displayed if there is an ongoing challenge.

Note: we could think of more complex rules, for instance display the banner a few days before & after the challenge :bulb: 
