### PR TITLE
feat(Proofs): display the new owner_consumption field

### DIFF
--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -62,6 +62,7 @@ export default {
         currency: null,
         receipt_price_count: null,
         receipt_price_total: null,
+        owner_consumption: null,
         receipt_online_delivery_costs: null,
       },
       loading: false

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -32,6 +32,8 @@
       />
     </v-col>
   </v-row>
+
+  <!--Receipt-only fields: receipt_price_count, receipt_price_total, receipt_online_delivery_costs -->
   <v-row v-if="proofIsTypeReceipt" class="mt-0">
     <v-col cols="6">
       <div class="text-subtitle-2">
@@ -65,6 +67,15 @@
     </v-col>
   </v-row>
   <v-row v-if="proofIsTypeReceipt" class="mt-0">
+    <v-col cols="6" class="pb-0">
+      <v-checkbox
+        v-model="proofMetadataForm.owner_consumption"
+        density="compact"
+        :label="$t('Common.ReceiptOwnerConsumption')"
+        :true-value="true"
+        hide-details="auto"
+      />
+    </v-col>
     <v-col cols="6">
       <div class="text-subtitle-2">
         <v-icon size="small" :icon="LOCATION_TYPE_ONLINE_ICON" /> {{ $t('Common.ReceiptOnlineDeliveryCosts') }}
@@ -99,6 +110,7 @@ export default {
         currency: null,
         receipt_price_count: null,
         receipt_price_total: null,
+        owner_consumption: true,
         receipt_online_delivery_costs: null,
       })
     },

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -143,6 +143,7 @@ export default {
         currency: null,  // see initProofForm
         receipt_price_count: null,
         receipt_price_total: null,
+        owner_consumption: true,  // will be ignored if type is not receipt
         receipt_online_delivery_costs: null,
         ready_for_price_tag_validation: null,  // see initProofForm
         proof_id: null

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -354,6 +354,7 @@
 		"Receipts": "Receipts",
 		"ReceiptPriceCount": "Number of prices",
 		"ReceiptPriceTotal": "Total amount",
+		"ReceiptOwnerConsumption": "Count into my consumption stats",
 		"ReceiptOnlineDeliveryCosts": "Delivery costs",
 		"Recent": "Recent",
 		"Reuses": "Reuses",

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,7 +4,7 @@ import constants from '../constants'
 
 const PRICE_UPDATE_FIELDS = ['type', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'discount_type', 'price_per', 'currency', 'receipt_quantity', 'date']
 const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['product_code', 'product_name', 'location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
-const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'ready_for_price_tag_validation']
+const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'owner_consumption', 'receipt_online_delivery_costs', 'ready_for_price_tag_validation']
 const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat(['location_id', 'location_osm_id', 'location_osm_type'])  // 'file'
 const LOCATION_ONLINE_CREATE_FIELDS = ['type', 'website_url']
 const LOCATION_SEARCH_LIMIT = 10
@@ -133,6 +133,9 @@ export default {
       }
       if (data.receipt_price_total) {
         formData.append('receipt_price_total', data.receipt_price_total)
+      }
+      if (data.owner_consumption === true || data.owner_consumption === false) {
+        formData.append('owner_consumption', data.owner_consumption)
       }
       if (data.receipt_online_delivery_costs) {
         formData.append('receipt_online_delivery_costs', data.receipt_online_delivery_costs)

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -195,6 +195,7 @@ export default {
         currency: null,
         receipt_price_count: null,
         receipt_price_total: null,
+        owner_consumption: null,
         receipt_online_delivery_costs: null,
       },
       productPriceForm: {},


### PR DESCRIPTION
### What

Thanks to the addition of the `Proof.owner_consumption` field in the backend - https://github.com/openfoodfacts/open-prices/issues/583 - we add it in the Proof Upload card/form.


