### PR TITLE
refactor(Forms): replace v-checkbox with v-switch (Proof & Price)

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -50,7 +50,7 @@
       </v-row>
       <v-row class="mt-0">
         <v-col cols="6" class="pb-0">
-          <v-checkbox
+          <v-switch
             v-model="priceForm.price_is_discounted"
             density="compact"
             :label="$t('Common.Discount')"

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -46,7 +46,7 @@
           />
         </v-col>
         <v-col class="pt-0" cols="6">
-          <v-checkbox
+          <v-switch
             v-for="lt in labelTags"
             :key="lt.id"
             v-model="productForm.labels_tags"

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -86,7 +86,7 @@
   </v-row>
   <v-row v-if="proofIsTypeReceipt" class="mt-0">
     <v-col cols="12" class="pb-0">
-      <v-checkbox
+      <v-switch
         v-model="proofMetadataForm.owner_consumption"
         density="compact"
         :label="$t('Common.ReceiptOwnerConsumption')"

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -26,7 +26,7 @@
         <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" />
         <v-row v-if="typePriceTagOnly && multiple" class="mt-0">
           <v-col cols="12" class="pb-0">
-            <v-checkbox
+            <v-switch
               v-model="proofForm.ready_for_price_tag_validation"
               density="compact"
               :label="$t('ProofAdd.PriceValidationAllow')"


### PR DESCRIPTION
### What

In the Proof & Price forms, we had 4 checkbox. Replacing them with switches.
- Proof: ready_for_price_tag_validation, owner_consumption
- Price: labels_tags, price_is_discounted

### Screenshot

|Page|Before|After|
|-|-|-|
|Price form|![image](https://github.com/user-attachments/assets/f5f6caea-9f89-4b31-8d73-47ccaeb5ac68)|![image](https://github.com/user-attachments/assets/819dd518-f2f0-4b06-814f-0678a3ce4df3)|