### PR TITLE
refactor(Forms): add green color to v-switch (Proof, Price & Settings)

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -53,6 +53,7 @@
           <v-switch
             v-model="priceForm.price_is_discounted"
             density="compact"
+            color="success"
             :label="$t('Common.Discount')"
             :true-value="true"
             hide-details="auto"

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -51,6 +51,7 @@
             :key="lt.id"
             v-model="productForm.labels_tags"
             density="compact"
+            color="success"
             :label="lt.name"
             :value="lt.id"
             hide-details="auto"

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -89,6 +89,7 @@
       <v-switch
         v-model="proofMetadataForm.owner_consumption"
         density="compact"
+        color="success"
         :label="$t('Common.ReceiptOwnerConsumption')"
         :true-value="true"
         hide-details="auto"

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -29,6 +29,7 @@
             <v-switch
               v-model="proofForm.ready_for_price_tag_validation"
               density="compact"
+              color="success"
               :label="$t('ProofAdd.PriceValidationAllow')"
               :true-value="true"
               hide-details="auto"

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -131,7 +131,7 @@
           </h3>
           <v-switch
             v-model="appStore.user.drawer_display_experiments"
-            color="primary"
+            color="success"
             :label="$t('UserSettings.SideMenuExperimentsDisplay')"
             density="compact"
             hide-details="auto"
@@ -143,7 +143,7 @@
           <v-switch
             v-model="appStore.user.product_display_barcode"
             class="mb-4"
-            color="primary"
+            color="success"
             :label="$t('UserSettings.ProductDisplayBarcode')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: '1234567890123' })"
             density="compact"
@@ -153,7 +153,7 @@
           <v-switch
             v-model="appStore.user.product_display_category_tag"
             class="mb-4"
-            color="primary"
+            color="success"
             :label="$t('UserSettings.ProductDisplayCategoryTag')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'en:oranges' })"
             density="compact"
@@ -162,7 +162,7 @@
           />
           <v-switch
             v-model="appStore.user.product_display_source"
-            color="primary"
+            color="success"
             :label="$t('UserSettings.ProductDisplaySource')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'OBF' })"
             density="compact"
@@ -175,7 +175,7 @@
           </h3>
           <v-switch
             v-model="appStore.user.location_display_osm_id"
-            color="primary"
+            color="success"
             :label="$t('UserSettings.LocationDisplayOSMID')"
             :hint="$t('Common.ExampleWithColonAndValue', { value: 'N652825274' })"
             density="compact"


### PR DESCRIPTION
### What

Following #1437

Add some color to all the v-switch in the app

### Screenshot

|Page|Before|After|
|-|-|-|
|Price form|![image](https://github.com/user-attachments/assets/64c3c94f-db76-4483-ab8f-a567bcaf161d)|![image](https://github.com/user-attachments/assets/8e38e7ab-72fa-45bb-a4ec-f431abced9b2)|
|Settings|![image](https://github.com/user-attachments/assets/ddd4578e-5724-467b-a6fa-782f695b614b)|![image](https://github.com/user-attachments/assets/cc819142-361a-4fe6-b655-076bd5cf1ea4)|