### PR TITLE
refactor(Forms): add a red asterisk next to the required field labels

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -13,7 +13,7 @@
   </v-row>
   <v-row v-if="mode === 'edit'" class="mt-0">
     <v-col :cols="priceForm.price_is_discounted ? '6' : '12'" class="pb-0">
-      <div class="text-subtitle-2">
+      <div class="text-subtitle-2 required">
         {{ priceForm.price_is_discounted ? $t('PriceForm.LabelDiscounted') : $t('PriceForm.Label') }}
       </div>
       <v-text-field

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -22,7 +22,7 @@
   </v-row>
   <v-row v-else-if="mode === 'edit' && productIsTypeCategory" class="mt-0">
     <v-col cols="6">
-      <div class="text-subtitle-2">
+      <div class="text-subtitle-2 required">
         {{ $t('AddPriceSingle.ProductInfo.CategoryLabel') }}
       </div>
       <v-autocomplete

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="6">
-      <div class="text-subtitle-2">
+      <div class="text-subtitle-2 required">
         {{ $t('Common.Date') }}
       </div>
       <v-text-field
@@ -15,7 +15,7 @@
       />
     </v-col>
     <v-col cols="6">
-      <div class="text-subtitle-2">
+      <div class="text-subtitle-2 required">
         {{ $t('Common.Currency') }}
         <v-icon class="float-right" size="small" icon="mdi-information-outline" />
         <v-tooltip activator="parent" open-on-click location="top">


### PR DESCRIPTION
### What

Add "required" asterisk next Proof/Price input label fields that are indeed required
- Proof date & currency
- Price price & category_tag


### Screenshots

|Proof add|Price add|
|-|-|
|![image](https://github.com/user-attachments/assets/eee9e158-f68f-4d00-9665-bb7b73cafab0)|![image](https://github.com/user-attachments/assets/1cc76edf-ef65-4936-bf0a-0fd0e2cc0ccc)|