### PR TITLE
refactor(Price add): change look & feel of input select fields

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -65,10 +65,13 @@
       />
     </v-col>
     <v-col v-if="priceForm.price_is_discounted" cols="6">
+      <div class="text-subtitle-2">
+        {{ $t('Common.DiscountType') }}
+      </div>
       <v-select
         v-model="priceForm.discount_type"
         density="compact"
-        :label="$t('Common.DiscountType')"
+        variant="outlined"
         :items="priceDiscountTypeSelectorDisplayList"
         :item-title="item => item.value ? $t('Common.' + item.value) : ''"
         :item-value="item => item.key"

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -22,10 +22,14 @@
   </v-row>
   <v-row v-else-if="mode === 'edit' && productIsTypeCategory" class="mt-0">
     <v-col cols="6">
+      <div class="text-subtitle-2">
+        {{ $t('AddPriceSingle.ProductInfo.CategoryLabel') }}
+      </div>
       <v-autocomplete
         v-model="productForm.category_tag"
-        density="comfortable"
-        :label="$t('AddPriceSingle.ProductInfo.CategoryLabel')"
+        :class="productForm.category_tag ? 'outline-border-success' : 'outline-border-error'"
+        density="compact"
+        variant="outlined"
         :items="categoryTags"
         :item-title="item => item.name"
         :item-value="item => item.id"
@@ -33,10 +37,13 @@
       />
     </v-col>
     <v-col cols="6">
+      <div class="text-subtitle-2">
+        {{ $t('AddPriceSingle.ProductInfo.OriginLabel') }}
+      </div>
       <v-autocomplete
         v-model="productForm.origins_tags"
-        density="comfortable"
-        :label="$t('AddPriceSingle.ProductInfo.OriginLabel')"
+        density="compact"
+        variant="outlined"
         :items="originTags"
         :item-title="item => item.name"
         :item-value="item => item.id"


### PR DESCRIPTION
### What

Following #1329 & #1441.

Replace the Price form select fields with their new look & feel (compact + outlined + label on top).

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/83c2e0bd-584c-4e7a-8716-cae78e23dd71)|![image](https://github.com/user-attachments/assets/9c5590d5-0f15-488a-a765-bb53f3f5dcbb)|