### PR TITLE
feat(Proofs): display the new owner_comment field (form, chip, history)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,3 +1,12 @@
+.fake-link {
+    cursor: pointer;
+    color: -webkit-link;
+    text-decoration: underline;
+}
+.fake-link:hover {
+    color: -webkit-link;
+}
+
 .input-lowercase input {
     text-transform: lowercase;
 }

--- a/src/components/HistoryCard.vue
+++ b/src/components/HistoryCard.vue
@@ -1,10 +1,14 @@
 <template>
   <v-card :title="$t('Common.History')" data-name="history-card">
     <v-card-text>
-      {{ getDateTimeFormatted(price.created) }} ({{ getRelativeDateTimeFormatted(price.created) }})
-      <span>- </span>
+      <span>{{ getDateTimeFormatted(price.created) }} ({{ getRelativeDateTimeFormatted(price.created) }})</span>
+      <span> - </span>
       <a :href="getUserDetailUrl">{{ price.owner }}</a>
-      <span>({{ price.source }})</span>
+      <span> ({{ price.source }})</span>
+      <span v-if="price.owner_comment">
+        <span> - </span>
+        <span>{{ price.owner_comment }}</span>
+      </span>
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -64,6 +64,7 @@ export default {
         receipt_price_total: null,
         receipt_online_delivery_costs: null,
         owner_consumption: null,
+        owner_comment: null,
       },
       loading: false
     }

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -12,6 +12,7 @@
       <DateChip class="mr-1" :date="proof.date" :showErrorIfDateMissing="true" :readonly="readonly" />
       <CurrencyChip class="mr-1" :currency="proof.currency" :showErrorIfCurrencyMissing="true" :readonly="readonly" />
       <UserChip v-if="!hideProofOwner" class="mr-1" :username="proof.owner" :readonly="readonly" />
+      <ProofUserCommentChip v-if="proof.owner_comment" class="mr-1" :comment="proof.owner_comment" />
       <RelativeDateTimeChip :dateTime="proof.created" />
     </v-col>
   </v-row>
@@ -38,6 +39,7 @@ export default {
     DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
     CurrencyChip: defineAsyncComponent(() => import('../components/CurrencyChip.vue')),
     UserChip: defineAsyncComponent(() => import('../components/UserChip.vue')),
+    ProofUserCommentChip: defineAsyncComponent(() => import('../components/ProofUserCommentChip.vue')),
     RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
     ProofActionMenuButton: defineAsyncComponent(() => import('../components/ProofActionMenuButton.vue'))
   },

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -85,7 +85,7 @@
     </v-col>
   </v-row>
   <v-row v-if="proofIsTypeReceipt" class="mt-0">
-    <v-col cols="12" class="pb-0">
+    <v-col cols="12" class="pb-1">
       <v-switch
         v-model="proofMetadataForm.owner_consumption"
         density="compact"
@@ -93,6 +93,27 @@
         :label="$t('Common.ReceiptOwnerConsumption')"
         :true-value="true"
         hide-details="auto"
+      />
+    </v-col>
+  </v-row>
+  <v-row class="mt-0">
+    <v-col v-if="!multiple && !displayOwnerCommentField" cols="12">
+      <a href="#" @click="displayOwnerCommentField = true">
+        {{ $t('Common.AddComment') }}
+      </a>
+    </v-col>
+    <v-col v-else-if="!multiple" cols="12">
+      <div class="text-subtitle-2">
+        {{ $t('Common.Comment') }}
+      </div>
+      <v-textarea
+        v-model="proofMetadataForm.owner_comment"
+        rows="2"
+        density="compact"
+        variant="outlined"
+        type="text"
+        hide-details="auto"
+        clearable
       />
     </v-col>
   </v-row>
@@ -115,15 +136,21 @@ export default {
         receipt_price_total: null,
         receipt_online_delivery_costs: null,
         owner_consumption: true,
+        owner_comment: null,
       })
     },
     proofType: {
       type: String,
       default: null
     },
+    multiple: {
+      type: Boolean,
+      default: false
+    }
   },
   data() {
     return {
+      displayOwnerCommentField: false,
       currentDate: utils.currentDate(),
       PROOF_TYPE_RECEIPT_ICON: constants.PROOF_TYPE_RECEIPT_ICON,
       LOCATION_TYPE_ONLINE_ICON: constants.LOCATION_TYPE_ONLINE_ICON,

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -97,12 +97,12 @@
     </v-col>
   </v-row>
   <v-row class="mt-0">
-    <v-col v-if="!multiple && !displayOwnerCommentField" cols="12">
-      <a href="#" @click="displayOwnerCommentField = true">
+    <v-col v-if="!displayOwnerCommentField" cols="12">
+      <a class="fake-link" @click="displayOwnerCommentField = true">
         {{ $t('Common.AddComment') }}
       </a>
     </v-col>
-    <v-col v-else-if="!multiple" cols="12">
+    <v-col v-else cols="12">
       <div class="text-subtitle-2">
         {{ $t('Common.Comment') }}
       </div>
@@ -150,7 +150,7 @@ export default {
   },
   data() {
     return {
-      displayOwnerCommentField: false,
+      displayOwnerCommentField: null,  // see mounted
       currentDate: utils.currentDate(),
       PROOF_TYPE_RECEIPT_ICON: constants.PROOF_TYPE_RECEIPT_ICON,
       LOCATION_TYPE_ONLINE_ICON: constants.LOCATION_TYPE_ONLINE_ICON,
@@ -193,6 +193,9 @@ export default {
         value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
       ]
     },
+  },
+  mounted() {
+    this.displayOwnerCommentField = !this.multiple && !!this.proofMetadataForm.owner_comment
   },
   methods: {
     fixComma(input) {

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -23,9 +23,9 @@
         <ProofTypeInputRow :proofTypeForm="proofForm" :hideProofTypeReceiptChoice="typePriceTagOnly" />
         <LocationInputRow :locationForm="proofForm" />
         <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
-        <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" />
-        <v-row v-if="typePriceTagOnly && multiple" class="mt-0">
-          <v-col cols="12" class="pb-0">
+        <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" />
+        <v-row v-if="typePriceTagOnly && multiple">
+          <v-col cols="12" class="pb-1">
             <v-switch
               v-model="proofForm.ready_for_price_tag_validation"
               density="compact"
@@ -146,6 +146,7 @@ export default {
         receipt_price_total: null,
         receipt_online_delivery_costs: null,
         owner_consumption: true,  // will be ignored if type is not receipt
+        owner_comment: null,
         ready_for_price_tag_validation: null,  // see initProofForm
         proof_id: null
       },

--- a/src/components/ProofUserCommentChip.vue
+++ b/src/components/ProofUserCommentChip.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-chip label size="small" variant="flat" density="comfortable" :title="comment">
+    <v-icon :icon="USER_COMMENT_ICON" />
+  </v-chip>
+</template>
+
+<script>
+import constants from '../constants.js'
+
+export default {
+  props: {
+    comment: {
+      type: String,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      USER_COMMENT_ICON: constants.USER_COMMENT_ICON,
+    }
+  },
+}
+</script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -202,6 +202,7 @@ export default {
     { key: 'edit', value: 'Edit', icon: 'mdi-pencil' },
   ],
   USER_CONSUMPTION_ICON: 'mdi-cart-outline',
+  USER_COMMENT_ICON: 'mdi-comment-text-outline',
   // date regex
   DATE_FULL_REGEX_MATCH: /(\d{4})-(\d{2})-(\d{2})/,
   DATE_YEAR_MONTH_REGEX_MATCH: /(\d{4})-(\d{2})/,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -159,6 +159,7 @@
 	},
 	"Common": {
 		"About": "About",
+		"AddComment": "Add a comment",
 		"AddPrice": "Add a price",
 		"AddPrices": "Add prices",
 		"AddNewPrice": "Add a new price",
@@ -198,6 +199,7 @@
 		"Chart": "Chart",
 		"Clear": "Clear",
 		"Contributors": "Contributors",
+		"Comment": "Comment",
 		"Community": "Community",
 		"Consumption": "Consumption",
 		"Confirm": "Confirm",

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,7 +4,7 @@ import constants from '../constants'
 
 const PRICE_UPDATE_FIELDS = ['type', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'discount_type', 'price_per', 'currency', 'receipt_quantity', 'date']
 const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['product_code', 'product_name', 'location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
-const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'owner_consumption', 'ready_for_price_tag_validation']
+const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'owner_consumption', 'owner_comment', 'ready_for_price_tag_validation']
 const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat(['location_id', 'location_osm_id', 'location_osm_type'])  // 'file'
 const LOCATION_ONLINE_CREATE_FIELDS = ['type', 'website_url']
 const LOCATION_SEARCH_LIMIT = 10
@@ -139,6 +139,9 @@ export default {
       }
       if (data.owner_consumption === true || data.owner_consumption === false) {
         formData.append('owner_consumption', data.owner_consumption)
+      }
+      if (data.owner_comment) {
+        formData.append('owner_comment', data.owner_comment)
       }
     }
     else if (data.type === constants.PROOF_TYPE_PRICE_TAG) {

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -197,6 +197,7 @@ export default {
         receipt_price_total: null,
         receipt_online_delivery_costs: null,
         owner_consumption: null,
+        owner_comment: null,
       },
       productPriceForm: {},
       productFormFilled: false,


### PR DESCRIPTION
### What

Thanks to the addition of the `Proof.owner_comment` field in the backend - https://github.com/openfoodfacts/open-prices/pull/748 - we display it in the frontend
- Proof upload form (link + toggle)
- Proof footer chip (simple chip, similar to #1435)
- Proof history card

### Screenshot

|Page|Image|
|-|-|
|Proof form (create)|![image](https://github.com/user-attachments/assets/d67b2caf-cb80-4756-a071-3ff3fe25f8ce)|
|Proof form (after toggle)|![image](https://github.com/user-attachments/assets/ca39edd2-23bd-4721-8c37-91702cec0fb7)|
|Proof footer|![image](https://github.com/user-attachments/assets/38de4976-e082-4e68-8510-dd0e0d122542)|
|Proof history|![image](https://github.com/user-attachments/assets/0d3eac4a-82c5-4851-8875-9fee358c1588)|