### PR TITLE
fix(Stats): change price_type_group to price_kind (community & consumption)

### DIFF
--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -20,10 +20,10 @@
   </v-row>
   <v-row>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.price_type_group_community_count" :subtitle="$t('Common.Community')" />
+      <StatCard :value="stats.price_kind_community_count" :subtitle="$t('Common.Community')" />
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.price_type_group_consumption_count" :subtitle="$t('Common.Consumption')" />
+      <StatCard :value="stats.price_kind_consumption_count" :subtitle="$t('Common.Consumption')" />
     </v-col>
   </v-row>
 
@@ -202,8 +202,8 @@ export default {
         price_type_product_code_count: 0,
         price_type_category_tag_count: 0,
         price_with_discount_count: 0,
-        price_type_group_community_count: 0,
-        price_type_group_consumption_count: 0,
+        price_kind_community_count: 0,
+        price_kind_consumption_count: 0,
         price_source_web_count: 0,
         price_source_mobile_count: 0,
         price_source_api_count: 0,


### PR DESCRIPTION
### What

Following a renaming in the backend: https://github.com/openfoodfacts/open-prices/pull/775

Update the stats