### PR TITLE
refactor(User Dashboard): fetch price & proof data using the new `kind` filter

### DIFF
--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -156,12 +156,16 @@ export default {
     },
     getPriceParams() {
       let defaultParams = { owner: this.username }
-      defaultParams['proof__type'] = (this.currentTab === 'consumption') ? ['RECEIPT', 'GDPR_REQUEST'] : ['PRICE_TAG', 'SHOP_IMPORT']
+      if (this.currentTab) {
+        defaultParams['kind'] = this.currentTab.toUpperCase()
+      }
       return defaultParams
     },
     getProofParams() {
       let defaultParams = { owner: this.username }
-      defaultParams['type'] = (this.currentTab === 'consumption') ? ['RECEIPT', 'GDPR_REQUEST'] : ['PRICE_TAG', 'SHOP_IMPORT']
+      if (this.currentTab) {
+        defaultParams['kind'] = this.currentTab.toUpperCase()
+      }
       return defaultParams
     },
   },


### PR DESCRIPTION
### What

Following the consumption/community split in the user dashboard (#1402), and changes in the backend (https://github.com/openfoodfacts/open-prices/issues/776 & https://github.com/openfoodfacts/open-prices/issues/777)
- replace the `Proof.type`  filter by `Proof.kind`
- replace the `Price.proof__type` filter by `Price.kind`