### PR TITLE
refactor(User Dashboard): point some CTAs directly to the correct tab. Use 'to' instead of 'click'

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -23,7 +23,9 @@ const LOCATION_TYPE_OSM = 'OSM'
 const LOCATION_TYPE_OSM_ICON = 'mdi-map-marker-outline'
 const LOCATION_TYPE_ONLINE = 'ONLINE'
 const LOCATION_TYPE_ONLINE_ICON = 'mdi-web'
+const USER_CONSUMPTION = 'CONSUMPTION'
 const USER_CONSUMPTION_ICON = 'mdi-cart-outline'
+const USER_COMMUNITY = 'COMMUNITY'
 const OSM_NAME = 'OpenStreetMap'
 
 export default {
@@ -95,8 +97,8 @@ export default {
     {key: 'OTHER', value: 'DiscountTypeOther'},
   ],
   PRICE_PROOF_KIND_LIST: [
-    { key: 'CONSUMPTION', value: 'Consumption', icon: USER_CONSUMPTION_ICON },
-    { key: 'COMMUNITY', value: 'Contributions', icon: 'mdi-account-group' },
+    { key: USER_CONSUMPTION, value: 'Consumption', icon: USER_CONSUMPTION_ICON },
+    { key: USER_COMMUNITY, value: 'Contributions', icon: 'mdi-account-group' },
   ],
   PRICE_TAG_STATUS_WITH_PRICE: 1,
   PRICE_TAG_STATUS_UNREADABLE: 2,
@@ -133,7 +135,9 @@ export default {
     {key: LOCATION_TYPE_OSM, value: LOCATION_TYPE_OSM, icon: LOCATION_TYPE_OSM_ICON},
     {key: LOCATION_TYPE_ONLINE, value: LOCATION_TYPE_ONLINE, icon: LOCATION_TYPE_ONLINE_ICON},
   ],
+  USER_CONSUMPTION: USER_CONSUMPTION,
   USER_CONSUMPTION_ICON: USER_CONSUMPTION_ICON,
+  USER_COMMUNITY: USER_COMMUNITY,
   USER_COMMENT_ICON: 'mdi-comment-text-outline',
   // filter
   PRODUCT_FILTER_LIST: [
@@ -214,8 +218,8 @@ export default {
     { key: 'edit', value: 'Edit', icon: 'mdi-pencil' },
   ],
   USER_DASHBOARD_TAB_LIST: [
-    { key: 'consumption', value: 'MyConsumption', icon: USER_CONSUMPTION_ICON },
-    { key: 'community', value: 'OtherContributions', icon: 'mdi-account-group' },
+    { key: USER_CONSUMPTION.toLowerCase(), value: 'MyConsumption', icon: USER_CONSUMPTION_ICON },
+    { key: USER_COMMUNITY.toLowerCase(), value: 'OtherContributions', icon: 'mdi-account-group' },
   ],
   // date regex
   DATE_FULL_REGEX_MATCH: /(\d{4})-(\d{2})-(\d{2})/,

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -129,7 +129,7 @@
                 color="primary"
                 :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-account-circle"
-                @click="goToUserDashboard"
+                :to="userDashboardUrl"
               >
                 {{ $t('Common.MyDashboard') }}
               </v-btn>
@@ -244,6 +244,10 @@ export default {
         return this.proofPriceUploadedList.findIndex(price => price.category_tag === this.productPriceForm.category_tag) >= 0
       }
       return false
+    },
+    userDashboardUrl() {
+      const dashboardTab = (this.proofObject.type === constants.PROOF_TYPE_RECEIPT && this.proofObject.owner_consumption) ? constants.USER_CONSUMPTION.toLowerCase() : constants.USER_COMMUNITY.toLowerCase()
+      return `/dashboard?multipleSuccess=true&tab=${dashboardTab}`
     }
   },
   methods: {
@@ -315,9 +319,6 @@ export default {
     },
     reloadPage() {
       window.location.reload()
-    },
-    goToUserDashboard() {
-      this.$router.push({ path: '/dashboard', query: { multipleSuccess: 'true' } })
     }
   }
 }

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -55,7 +55,7 @@
                 color="primary"
                 :block="!$vuetify.display.smAndUp"
                 prepend-icon="mdi-account-circle"
-                @click="goToUserDashboard"
+                :to="userDashboardUrl"
               >
                 {{ $t('Common.MyDashboard') }}
               </v-btn>
@@ -69,6 +69,7 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
+import constants from '../constants'
 
 export default {
   components: {
@@ -90,6 +91,12 @@ export default {
       proofUploadCount: 0
     }
   },
+  computed: {
+    userDashboardUrl() {
+      const dashboardTab = constants.USER_COMMUNITY.toLowerCase()  // default on this page
+      return `/dashboard?proofSingleSuccess=true&tab=${dashboardTab}`
+    }
+  },
   methods: {
     proofUploadDone(proofUploadCount) {
       this.proofUploadCount = proofUploadCount
@@ -100,9 +107,6 @@ export default {
     },
     reloadPage() {
       window.location.reload()
-    },
-    goToUserDashboard() {
-      this.$router.push({ path: '/dashboard', query: { proofSingleSuccess: 'true' } })
     }
   }
 }

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -82,7 +82,7 @@
           </v-btn>
         </v-col>
         <v-col>
-          <v-btn color="primary" :block="!$vuetify.display.smAndUp" :aria-label="$t('Common.MyDashboard')" to="/dashboard" :disabled="totalNumberOfPricesToAdd !== numberOfPricesAdded">
+          <v-btn color="primary" :block="!$vuetify.display.smAndUp" :aria-label="$t('Common.MyDashboard')" :to="userDashboardUrl" :disabled="totalNumberOfPricesToAdd !== numberOfPricesAdded">
             {{ $t('ContributionAssistant.GoToDashboard') }}
           </v-btn>
         </v-col>
@@ -96,6 +96,7 @@ import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
+import constants from '../constants'
 
 export default {
   components: {
@@ -148,6 +149,10 @@ export default {
     },
     proofHasReceiptPredictionItems() {
       return this.proofObject?.receiptItems && this.proofObject.receiptItems.length > 0
+    },
+    userDashboardUrl() {
+      const dashboardTab = constants.USER_COMMUNITY.toLowerCase()  // default on this page
+      return `/dashboard?tab=${dashboardTab}`
     }
   },
   mounted() {


### PR DESCRIPTION
### What

Following #1402 (2 tabs consumption & community)
- we change the URL of some of the CTAs that point to the dashboard, to pass the correct `tab` parameter
- we also adapt these buttons to have the URL display (thanks to the `:to`, instead of a `@click`)