### PR TITLE
refactor(Crops): improve perfomances

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -184,6 +184,11 @@ export default {
   mounted() {
     this.resetMode()
   },
+  unmounted() {
+    if (this.productPriceForm.croppedImage) {
+      URL.revokeObjectURL(this.productPriceForm.croppedImage)
+    }
+  },
   methods: {
     resetMode() {
       this.mode = this.forceMode || this.appStore.user.price_form_default_mode

--- a/src/components/ProofImageCropped.vue
+++ b/src/components/ProofImageCropped.vue
@@ -47,10 +47,10 @@ export default {
       this.proofImage.crossOrigin = 'Anonymous'
     },
     cropImage() {
-      const startY = this.boundingBox[0] * this.proofImage.height
-      const startX = this.boundingBox[1] * this.proofImage.width
-      const endY = this.boundingBox[2] * this.proofImage.height
-      const endX = this.boundingBox[3] * this.proofImage.width
+      const startY = Math.round(this.boundingBox[0] * this.proofImage.height)
+      const startX = Math.round(this.boundingBox[1] * this.proofImage.width)
+      const endY = Math.round(this.boundingBox[2] * this.proofImage.height)
+      const endX = Math.round(this.boundingBox[3] * this.proofImage.width)
       const width = Math.abs(endX - startX)
       const height = Math.abs(endY - startY)
       this.canvas.width = width

--- a/src/components/ProofImageCropped.vue
+++ b/src/components/ProofImageCropped.vue
@@ -56,8 +56,10 @@ export default {
       this.canvas.width = width
       this.canvas.height = height
       this.ctx.drawImage(this.proofImage, Math.min(startX, endX), Math.min(startY, endY), width, height, 0, 0, width, height)
-      this.croppedImage = this.canvas.toDataURL()
-      this.$emit('croppedImage', this.croppedImage)
+      this.canvas.toBlob(blob => {
+        this.croppedImage = URL.createObjectURL(blob)
+        this.$emit('croppedImage', this.croppedImage)
+      })
     }
   }
 }

--- a/src/components/ProofImageCropped.vue
+++ b/src/components/ProofImageCropped.vue
@@ -56,6 +56,9 @@ export default {
       this.canvas.width = width
       this.canvas.height = height
       this.ctx.drawImage(this.proofImage, Math.min(startX, endX), Math.min(startY, endY), width, height, 0, 0, width, height)
+      // Note: we started with 'this.croppedImage = URL.canvas.toDataURL()'
+      // but 'createObjectURL' is much more efficient than 'toDataURL'
+      // and it allows us to call 'revokeObjectURL'
       this.canvas.toBlob(blob => {
         this.croppedImage = URL.createObjectURL(blob)
         this.$emit('croppedImage', this.croppedImage)


### PR DESCRIPTION
### What
- Did a deep dive on the price validation performances
- Profiling tools indicate that most of the time is spent on computing `HTMLCanvasElement.toDataURL` and `CanvasRenderingContext2D.drawImage`
--
- This PR replaces `toDataURL` with `toBlob`, which has way better performances
- `toBlob` requires the use of `URL.createObjectURL(blob)` to get a usable image, but that still seems to perform better, and it allows more control on cleanup with `URL.revokeObjectURL` (called when the price form card is unmounted)
--
- This PR also rounds numbers for `drawImage` performances, to avoid antialiasing computations
- However, most time spent is related to rendering the proof images in the canvas, which isn't very efficient if the user device doesn't include a GPU...

### Notes
* The real solution probably relies on serving cropped images from the backend, but that's something else.