### PR TITLE
fix(Price add): Allow 'quantity bought' field to have 3 decimals

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -216,7 +216,7 @@ export default {
         value => !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
-        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
+        value => !value.match(/\.\d{4}/) || this.$t('PriceRules.ThreeDecimals'),
       ]
     },
     receiptQuantitySuffix() {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -582,7 +582,8 @@
 		"NoSpaces": "Please don't use spaces",
 		"Number": "Input a number",
 		"Positive": "Price may not be negative",
-		"TwoDecimals": "Only two decimals allowed"
+		"TwoDecimals": "Only two decimals allowed",
+		"ThreeDecimals": "Only three decimals allowed"
 	},
 	"ProductCard": {
 		"BarcodeLength": "Barcode length: {length}",


### PR DESCRIPTION
### What

Following #1128 (field added) & #1276 (allow 2 decimals)

And support in the backend with https://github.com/openfoodfacts/open-prices/issues/795 (allow 3 decimals)