### PR TITLE
refactor(Receipt Assistant): show a readonly toggle indicating that AI will run on the image

### DIFF
--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -105,6 +105,30 @@
       />
     </v-col>
   </v-row>
+  <v-row v-if="assistedByAI" class="mt-0">
+    <v-col v-if="proofIsTypePriceTag" cols="12" class="pb-1">
+      <v-switch
+        v-model="proofMetadataForm.ready_for_price_tag_validation"
+        density="compact"
+        color="success"
+        :label="$t('ProofAdd.PriceValidationAllow')"
+        :true-value="true"
+        hide-details="auto"
+      />
+    </v-col>
+    <v-col v-else-if="proofIsTypeReceipt" cols="12" class="pb-1">
+      <v-switch
+        v-model="switchReceiptAiAllowValue"
+        density="compact"
+        color="success"
+        :label="$t('ProofAdd.ReceiptAllowAI')"
+        :true-value="true"
+        hide-details="auto"
+        readonly
+        disabled
+      />
+    </v-col>
+  </v-row>
   <v-row v-if="proofIsTypeReceipt" class="mt-0">
     <v-col cols="12" class="pb-1">
       <v-switch
@@ -112,18 +136,6 @@
         density="compact"
         color="success"
         :label="$t('Common.ReceiptOwnerConsumption')"
-        :true-value="true"
-        hide-details="auto"
-      />
-    </v-col>
-  </v-row>
-  <v-row v-if="proofIsTypePriceTag && multiple">
-    <v-col cols="12" class="pb-1">
-      <v-switch
-        v-model="proofMetadataForm.ready_for_price_tag_validation"
-        density="compact"
-        color="success"
-        :label="$t('ProofAdd.PriceValidationAllow')"
         :true-value="true"
         hide-details="auto"
       />
@@ -159,11 +171,16 @@ export default {
     multiple: {
       type: Boolean,
       default: false
+    },
+    assistedByAI: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
       displayOwnerCommentField: null,  // see initProofMetadataForm
+      switchReceiptAiAllowValue: true,  // default until we manage it in the backend
       currentDate: utils.currentDate(),
       PROOF_TYPE_RECEIPT_ICON: constants.PROOF_TYPE_RECEIPT_ICON,
       LOCATION_TYPE_ONLINE_ICON: constants.LOCATION_TYPE_ONLINE_ICON,

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -23,7 +23,7 @@
         <ProofTypeInputRow :proofTypeForm="proofForm" :hideProofTypeReceiptChoice="typePriceTagOnly" :hideProofTypePriceTagChoice="typeReceiptOnly" />
         <LocationInputRow :locationForm="proofForm" />
         <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
-        <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" />
+        <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" :assistedByAI="assistedByAI" />
       </v-sheet>
       <v-sheet v-else-if="step === 2">
         <v-progress-linear
@@ -120,7 +120,11 @@ export default {
     multiple: {
       type: Boolean,
       default: false
-    }
+    },
+    assistedByAI: {
+      type: Boolean,
+      default: false
+    },
   },
   emits: ['proof', 'done'],
   data() {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -621,7 +621,8 @@
 	"ProofAdd": {
 		"HowToMultiple": "All the price tag images you select should share the same shop location, and been taken on the same day.",
 		"HowToMultipleShort": "Pictures should share the same shop location and date.",
-		"PriceValidationAllow": "Allow my pictures' prices to be extracted by AI and validated by the community"
+		"PriceValidationAllow": "Allow my pictures' prices to be extracted by AI and validated by the community",
+		"ReceiptAllowAI": "Allow running AI on your receipt to extract prices"
 	},
 	"ProofCard": {
 		"Proof": "Proof",

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -13,7 +13,7 @@
 
   <v-row v-if="step === 1">
     <v-col cols="12" md="6">
-      <ProofUploadCard :typePriceTagOnly="true" :hideRecentProofChoice="true" :multiple="true" @done="proofUploadDone($event)" />
+      <ProofUploadCard :typePriceTagOnly="true" :hideRecentProofChoice="true" :multiple="true" :assistedByAI="true" @done="proofUploadDone($event)" />
     </v-col>
   </v-row>
 

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -15,7 +15,7 @@
 
   <v-row v-if="step === 1">
     <v-col cols="12" md="6">
-      <ProofUploadCard :typeReceiptOnly="true" @proof="onProofUploaded($event)" />
+      <ProofUploadCard :typeReceiptOnly="true" :assistedByAI="true" @proof="onProofUploaded($event)" />
     </v-col>
   </v-row>
   


### PR DESCRIPTION
### What

Following #1394, we want to be more explicit to users about the use of AI.

We'll need to manage this in the backend.

For now we just show a readonly message.

### Screenshot

![image](https://github.com/user-attachments/assets/d5cf6dfb-d615-4dfa-a674-6a3520b15b9d)
