### PR TITLE
refactor(Proof upload): seperate validation toggle and AI info

### DIFF
--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -106,26 +106,32 @@
     </v-col>
   </v-row>
   <v-row v-if="assistedByAI" class="mt-0">
-    <v-col v-if="proofIsTypePriceTag" cols="12" class="pb-1">
+    <v-col cols="12" class="pb-1">
+      <v-alert
+        v-if="proofIsTypePriceTag"
+        type="info"
+        variant="outlined"
+        density="compact"
+        :text="$t('ProofAdd.PriceTagAIWarning')"
+      />
+      <v-alert
+        v-else-if="proofIsTypeReceipt"
+        type="info"
+        variant="outlined"
+        density="compact"
+        :text="$t('ProofAdd.ReceiptAIWarning')"
+      />
+    </v-col>
+  </v-row>
+  <v-row v-if="assistedByAI && proofIsTypePriceTag" class="mt-0">
+    <v-col cols="12" class="pb-1">
       <v-switch
         v-model="proofMetadataForm.ready_for_price_tag_validation"
         density="compact"
         color="success"
-        :label="$t('ProofAdd.PriceValidationAllow')"
+        :label="$t('ProofAdd.PriceTagAllowCommunityValidation')"
         :true-value="true"
         hide-details="auto"
-      />
-    </v-col>
-    <v-col v-else-if="proofIsTypeReceipt" cols="12" class="pb-1">
-      <v-switch
-        v-model="switchReceiptAiAllowValue"
-        density="compact"
-        color="success"
-        :label="$t('ProofAdd.ReceiptAllowAI')"
-        :true-value="true"
-        hide-details="auto"
-        readonly
-        disabled
       />
     </v-col>
   </v-row>
@@ -180,7 +186,6 @@ export default {
   data() {
     return {
       displayOwnerCommentField: null,  // see initProofMetadataForm
-      switchReceiptAiAllowValue: true,  // default until we manage it in the backend
       currentDate: utils.currentDate(),
       PROOF_TYPE_RECEIPT_ICON: constants.PROOF_TYPE_RECEIPT_ICON,
       LOCATION_TYPE_ONLINE_ICON: constants.LOCATION_TYPE_ONLINE_ICON,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -622,7 +622,10 @@
 		"HowToMultiple": "All the price tag images you select should share the same shop location, and been taken on the same day.",
 		"HowToMultipleShort": "Pictures should share the same shop location and date.",
 		"PriceValidationAllow": "Allow my pictures' prices to be extracted by AI and validated by the community",
-		"ReceiptAllowAI": "Allow running AI on your receipt to extract prices"
+		"PriceTagAllowCommunityValidation": "Allow the community to validate prices extracted by AI",
+		"PriceTagAIWarning": "AI will run on your proofs to extract prices.",
+		"ReceiptAllowAI": "Allow running AI on your receipt to extract prices",
+		"ReceiptAIWarning": "AI will run on your receipt to extract prices."
 	},
 	"ProofCard": {
 		"Proof": "Proof",


### PR DESCRIPTION
### What

Replaces #1501

Changes in this PR
- separate the "AI info" with the "validation" toggle
- clarify wordings

### Screenshots

||Before|After|
|-|-|-|
|Price tag multiple upload|![image](https://github.com/user-attachments/assets/e3af8907-f19d-4df5-8172-58d28dda71a5)|![image](https://github.com/user-attachments/assets/54781fe8-8582-405b-976a-9125519b340b)|
|Receipt assistant|![image](https://github.com/user-attachments/assets/33a558cb-6e83-4cd6-b57a-c251ea686fc9)|![image](https://github.com/user-attachments/assets/432eb657-7b5f-4efc-bb20-e9df7a996bb6)|