### PR TITLE
fix(Proof Upload): only show 'Delivery costs' field if an online location is selected

### DIFF
--- a/src/components/LocationInputRow.vue
+++ b/src/components/LocationInputRow.vue
@@ -45,6 +45,7 @@ export default {
       })
     },
   },
+  emits: ['location'],
   data() {
     return {
       selectedLocation: null,
@@ -93,6 +94,7 @@ export default {
         this.locationForm.location_osm_id = utils.getLocationID(location)
         this.locationForm.location_osm_type = utils.getLocationType(location)
       }
+      this.$emit('location', this.selectedLocation)
     },
   }
 }

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -66,7 +66,7 @@
       />
     </v-col>
   </v-row>
-  <v-row v-if="proofIsTypeReceipt" class="mt-0">
+  <v-row v-if="proofIsTypeReceipt && locationIsTypeOnline" class="mt-0">
     <v-col cols="6">
       <div class="text-subtitle-2">
         <v-icon size="small" :icon="LOCATION_TYPE_ONLINE_ICON" /> {{ $t('Common.ReceiptOnlineDeliveryCosts') }}
@@ -181,7 +181,11 @@ export default {
     assistedByAI: {
       type: Boolean,
       default: false
-    }
+    },
+    locationType: {
+      type: String,
+      default: null
+    },
   },
   data() {
     return {
@@ -205,6 +209,9 @@ export default {
     },
     proofIsTypeReceipt() {
       return this.proofType === constants.PROOF_TYPE_RECEIPT
+    },
+    locationIsTypeOnline() {
+      return this.locationType === constants.LOCATION_TYPE_ONLINE
     },
     priceCountRules() {
       if (!this.proofMetadataForm.receipt_price_count) return [() => true]  // optional field

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -21,9 +21,9 @@
           :text="$t('ProofAdd.HowToMultipleShort')"
         />
         <ProofTypeInputRow :proofTypeForm="proofForm" :hideProofTypeReceiptChoice="typePriceTagOnly" :hideProofTypePriceTagChoice="typeReceiptOnly" />
-        <LocationInputRow :locationForm="proofForm" />
+        <LocationInputRow :locationForm="proofForm" @location="locationObject = $event" />
         <ProofImageInputRow :proofImageForm="proofForm" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
-        <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" :assistedByAI="assistedByAI" />
+        <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" :assistedByAI="assistedByAI" :locationType="locationObject?.type" />
       </v-sheet>
       <v-sheet v-else-if="step === 2">
         <v-progress-linear
@@ -147,6 +147,7 @@ export default {
         proof_id: null
       },
       // data
+      locationObject: null,  // location selected
       proofDateSuccessMessage: false,
       proofSelectedSuccessMessage: false,
       proofSuccessMessage: false,


### PR DESCRIPTION
### What

Following the addition of the 'Delivery costs' input field in the proof upload card - https://github.com/openfoodfacts/open-prices-frontend/pull/1427

We now only display it if the selected location is ONLINE.
