### PR TITLE
feat(Challenge): Add support for multiple product categories

### DIFF
--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -98,35 +98,36 @@ export default {
         }
       })
     },
-    getStats() {
+    async getStats() {
       this.loading = true
-      api.getPriceStats({ ...this.defaultParams, product__categories_tags__contains: this.challenge.categories[0] })
-      .then((data) => {
-        this.challenge.numberOfContributions = data.price__count
-        this.loading = false
-      })
+      let priceCount = 0
+      for (let i = 0; i < this.challenge.categories.length; i++) {
+        const data = await api.getPriceStats({ ...this.defaultParams, product__categories_tags__contains: this.challenge.categories[i] })
+        priceCount += data.price__count
+      }
+      this.challenge.numberOfContributions = priceCount
 
-      api.getProofs({ ...this.defaultParams, size: 1 })
-      .then((data) => {
-        this.challenge.numberOfProofs = data.total
-      })
+      const proofsStats = await api.getProofs({ ...this.defaultParams, size: 1 })
+      this.challenge.numberOfProofs = proofsStats.total
 
       if (this.username) {
-        api.getPriceStats({ ...this.defaultParams, product__categories_tags__contains: this.challenge.categories[0], owner: this.username })
-        .then((data) => {
-          this.challenge.userContributions = data.price__count
-        })
-        api.getProofs({ ...this.defaultParams, owner: this.username, size: 1 })
-        .then((data) => {
-          this.challenge.userProofContributions = data.total
-        })
+        let userPriceCount = 0
+        for (let i = 0; i < this.challenge.categories.length; i++) {
+          const data = await api.getPriceStats({ ...this.defaultParams, product__categories_tags__contains: this.challenge.categories[i], owner: this.username })
+          userPriceCount += data.price__count
+        }
+        this.challenge.userContributions = userPriceCount
+        const userProofsStats = await api.getProofs({ ...this.defaultParams, owner: this.username, size: 1 })
+        this.challenge.userProofContributions = userProofsStats.total
       }
     },
-    getLatestPrices() {
-      api.getPrices({ ...this.defaultParams, product__categories_tags__contains: this.challenge.categories[0], size: 10 })
-      .then((data) => {
-        this.challenge.latestContributions = data.items
-      })
+    async getLatestPrices() {
+      let items = []
+      for (let i = 0; i < this.challenge.categories.length; i++) {
+        const data = await api.getPrices({ ...this.defaultParams, product__categories_tags__contains: this.challenge.categories[i], size: 10 })
+        items = items.concat(data.items)
+      }
+      this.challenge.latestContributions = items.sort((a, b) => b.date.localeCompare(a.date)).slice(0, 10)
     }
   }
 }


### PR DESCRIPTION
### What
- Challenge infos are loaded from the backend
- The `categories` field can contain multiple, comma-separated categories
- Until now, only the first category was used when displaying challenge stats and latest products
- This PR simply loops over the categories and calls the API multiple times

### Note
- Another option would be to query multiple categories at once, see https://github.com/openfoodfacts/open-prices/issues/760
