### PR TITLE
fix(PVA): fix filter refresh and duplication

### DIFF
--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -114,7 +114,7 @@ export default {
       this.priceTagList = []
       this.priceTagTotal = null
       this.priceTagPage = 0
-      this.productPriceForm = []
+      this.productPriceForms = []
       this.getPriceTags()
     },
     updatePriceTagStatus(index, status) {


### PR DESCRIPTION
### What
- I had another case of duplication of Price tags to validate
- I noticed that switching the owner filter not only requires a refresh, but also duplicates existing price tags
- The error came from a typo during the initialization of the `productPriceForms` list

### Notes
- The PVA code uses two lists side by side : `priceTagList` and `productPriceForms`
- When updating or validating price tags, it assumes that indexes are the same in the two lists, which is only true if they are perfectly in sync
- The typo fixed in this PR was also breaking this synchronization. It's then likely that, after a filter change, some status updates were targeting the wrong price tag, thus showing already validated price tag upon refresh (and probably linking pricetags to the wrong prices).
- Overall, using two lists is a bit odd, a refactor might be required to only use `productPriceForms`
- Especially since every pricetag fetched from the API is added to `priceTagList`, but only those with `data.items[i]['predictions'].length > 0` are added `productPriceForms`.
     - If this condition is false, we also have a desync between the lists, leading to similar issues as presented before
     - Since the API call filters on `prediction_count__gte: 1,`, it's likely that the condition is always true .. which makes it useless
