### PR TITLE
feat(Prices): new table view

### DIFF
--- a/src/components/PriceTable.vue
+++ b/src/components/PriceTable.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-data-table :headers="headers" :items="priceList" hide-default-footer>
+    <template #[`item.location`]="{ item }">
+      <LocationChip :location="item.location" :locationId="item.location_id" :readonly="true" />
+    </template>
+    <template #[`item.date`]="{ item }">
+      <DateChip :date="item.date" :readonly="true" />
+    </template>
+    <template #[`item.price`]="{ item }">
+      <PricePriceRow :price="item" :productQuantity="item.product ? item.product.product_quantity : null" :productQuantityUnit="item.product ? item.product.product_quantity_unit : null" />
+    </template>
+    <template #[`item.created`]="{ item }">
+      <RelativeDateTimeChip :dateTime="item.created" />
+    </template>
+  </v-data-table>
+</template>
+
+<script>
+import { defineAsyncComponent } from 'vue'
+
+export default {
+  components: {
+    LocationChip: defineAsyncComponent(() => import('../components/LocationChip.vue')),
+    DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
+    PricePriceRow: defineAsyncComponent(() => import('../components/PricePriceRow.vue')),
+    RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
+  },
+  props: {
+    priceList: {
+      type: Array,
+      default: () => []
+    },
+  },
+  data() {
+    return {
+      headers: [
+        { title: 'Location', key: 'location' },
+        { title: 'Date', key: 'date'},
+        { title: 'Price', key: 'price' },
+        { title: 'Added', key: 'created' },
+        // { title: 'Actions', key: 'actions' },
+      ],
+    }
+  }
+}
+</script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -192,6 +192,7 @@ export default {
   // display
   PRICE_DISPLAY_LIST: [
     { key: 'list', value: 'DisplayList', icon: 'mdi-format-list-bulleted' },
+    { key: 'table', value: 'DisplayTable', icon: 'mdi-table' },
     { key: 'map', value: 'DisplayPriceMap', icon: 'mdi-map-marker' },
     { key: 'chart', value: 'DisplayPriceChart', icon: 'mdi-chart-line' },
   ],

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -231,6 +231,7 @@
 		"Display": "Display",
 		"DisplayList": "List",
 		"DisplayPriceList": "List",
+		"DisplayTable": "Table",
 		"DisplayMap": "Map",
 		"DisplayPriceMap": "Map",
 		"DisplayPriceChart": "Chart",

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -44,6 +44,9 @@
         </v-col>
       </v-row>
     </v-window-item>
+    <v-window-item value="table">
+      <PriceTable class="mt-3" :priceList="productPriceList" />
+    </v-window-item>
     <v-window-item value="map">
       <v-row class="mt-0 mb-1">
         <v-col style="height:400px">
@@ -84,6 +87,7 @@ export default {
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
     DisplayMenu: defineAsyncComponent(() => import('../components/DisplayMenu.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
+    PriceTable: defineAsyncComponent(() => import('../components/PriceTable.vue')),
     LeafletMap: defineAsyncComponent(() => import('../components/LeafletMap.vue')),
     PriceChart: defineAsyncComponent(() => import('../components/PriceChart.vue')),
     OpenFoodFactsAddMenu: defineAsyncComponent(() => import('../components/OpenFoodFactsAddMenu.vue')),


### PR DESCRIPTION
### What

We already have a list (card), map & chart views of prices.
This PR is a v0 of a table view.

Using Vuetify's data-tables: https://vuetifyjs.com/en/components/data-tables/basics/#crud-actions

### Screenshot

||Image|
|-|-|
|List (Card) view|![image](https://github.com/user-attachments/assets/a6c5e100-9a92-4b8e-9e6e-a78bb4511802)|
|New table view|![image](https://github.com/user-attachments/assets/84ad655f-872c-4ef8-96e9-39cccf42fe3d)|
