### PR TITLE
feat(Settings): allow users to set a default price list display

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -875,6 +875,7 @@
 		"LanguageLabel": "Languages",
 		"LocationFinder": "Location finder",
 		"LocationDisplayOSMID": "Display OSM ID",
+		"PriceListDisplay": "Price list diplay",
 		"PriceValidation": "Price validation",
 		"ProductDisplayBarcode": "Display barcode",
 		"ProductDisplayCategoryTag": "Display category tag",

--- a/src/store.js
+++ b/src/store.js
@@ -21,6 +21,7 @@ export const useAppStore = defineStore('app', {
       location_display_osm_id: false,
       drawer_display_experiments: true,
       preferedTheme: null,
+      price_list_display_default_mode: constants.PRICE_DISPLAY_LIST[0].key,
       location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,
       barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key,
       price_form_default_mode: constants.PRICE_FORM_DISPLAY_LIST[0].key

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -155,7 +155,7 @@ export default {
   mounted() {
     this.currentFilter = this.$route.query[constants.FILTER_PARAM] || this.currentFilter
     this.currentOrder = this.$route.query[constants.ORDER_PARAM] || this.currentOrder
-    this.currentDisplay = this.$route.query[constants.DISPLAY_PARAM] || this.currentDisplay
+    this.currentDisplay = this.$route.query[constants.DISPLAY_PARAM] || this.appStore.user.price_list_display_default_mode || this.currentDisplay
     this.getProduct()
     this.initProductPrices()
     // load more

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -59,6 +59,18 @@
               <v-icon size="small" icon="mdi-open-in-new" />
             </a>
           </p>
+          <!-- Price list display -->
+          <h3 class="mt-4 mb-1">
+            {{ $t('UserSettings.PriceListDisplay') }}
+          </h3>
+          <v-select
+            v-model="appStore.user.price_list_display_default_mode"
+            :label="$t('UserSettings.DefaultMode')"
+            :items="priceListDisplayList"
+            :item-title="item => $t('Common.' + item.value)"
+            :item-value="item => item.key"
+            hide-details="auto"
+          />
         </v-card-text>
       </v-card>
     </v-col>
@@ -205,6 +217,7 @@ export default {
       countryList,
       languageList,
       // currencyList,
+      priceListDisplayList: constants.PRICE_DISPLAY_LIST,
       locationSelectorDisplayList: constants.LOCATION_SELECTOR_DISPLAY_LIST,
       productSelectorDisplayList: constants.PRODUCT_SELECTOR_DISPLAY_LIST,
       priceFormDisplayList: constants.PRICE_FORM_DISPLAY_LIST


### PR DESCRIPTION
### What

Following #1522
New settings to allow users to choose between the 4 price displays: list, table, map, chart.

### Screenshot

![image](https://github.com/user-attachments/assets/0a3ab178-7aa9-4818-81bc-ff54027a40ef)

