### PR TITLE
refactor(Challenges): make total proof & price stat counts clickable

### DIFF
--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -18,7 +18,7 @@
     <v-card-text>
       <v-row>
         <v-col cols="6">
-          <StatCard :value="challenge.numberOfProofs" :subtitle="statSubtitleProofCount" />
+          <StatCard :value="challenge.numberOfProofs" :subtitle="statSubtitleProofCount" :to="getChallengeProofListUrl" />
         </v-col>
         <v-col cols="6">
           <StatCard :value="challenge.userProofContributions" :subtitle="statSubtitleProofOwnerCount" />
@@ -40,9 +40,10 @@
     </v-card-actions>
   </v-card>
 </template>
-  
+
 <script>
 import { defineAsyncComponent } from 'vue'
+
 export default {
   components: {
     StatCard: defineAsyncComponent(() => import('../components/StatCard.vue')),
@@ -59,8 +60,10 @@ export default {
     },
     statSubtitleProofOwnerCount() {
       return this.$vuetify.display.smAndUp ? this.$t('Common.PicturesAddedByYou') : this.$t('Common.PicturesByYou')
+    },
+    getChallengeProofListUrl() {
+      return `/challenges/${this.challenge.id}/proofs`
     }
   }
 }
 </script>
-  

--- a/src/components/ChallengeValidateCard.vue
+++ b/src/components/ChallengeValidateCard.vue
@@ -21,7 +21,7 @@
     <v-card-text class="flex-grow-0">
       <v-row>
         <v-col cols="6">
-          <StatCard :value="challenge.numberOfContributions" :subtitle="statSubtitlePriceCount" />
+          <StatCard :value="challenge.numberOfContributions" :subtitle="statSubtitlePriceCount" :to="getChallengePriceListUrl" />
         </v-col>
         <v-col cols="6">
           <StatCard :value="challenge.userContributions" :subtitle="statSubtitlePriceOwnerCount" />
@@ -63,6 +63,9 @@ export default {
     },
     statSubtitlePriceOwnerCount() {
       return this.$vuetify.display.smAndUp ? this.$t('Challenge.PricesAddedByYou', { challenge_title: this.challenge.title }) : this.$t('Challenge.PricesByYou', { challenge_title: this.challenge.title })
+    },
+    getChallengePriceListUrl() {
+      return `/challenges/${this.challenge.id}/prices`
     }
   }
 }


### PR DESCRIPTION
### What

Following #1537 & #1538
Make the new "challenge proof list" & "challenge price list" accessible via the stats cards

### Screenshot

||Image|
|-|-|
|Before|![image](https://github.com/user-attachments/assets/877f78c8-b00e-4669-9b10-ce5f263cf2ac)|
|After|![image](https://github.com/user-attachments/assets/61a42d64-f549-4dac-83e7-4ddb4432e597)|
