### PR TITLE
refactor(Receipt Assistant): show price count & price total below table

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -49,6 +49,10 @@
 
     <v-card-actions>
       <v-row>
+        <v-col cols="6">
+          <ProofReceiptPriceCountChip v-if="proof && items" class="mr-1" :uploadedCount="items.length" :totalCount="proof.receipt_price_count" />
+          <ProofReceiptPriceTotalChip v-if="proof && items" :uploadedCount="proofPriceListSum" :totalCount="proof.receipt_price_total" :currency="proof.currency" />
+        </v-col>
         <v-spacer />
         <v-col>
           <v-btn
@@ -88,16 +92,18 @@
 </template>
   
 <script>
-import api from '../services/api'
 import { defineAsyncComponent } from 'vue'
-import constants from '../constants'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
+import api from '../services/api'
+import constants from '../constants'
 
 export default {
   components: {
     ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
     PriceCategoryChip: defineAsyncComponent(() => import('../components/PriceCategoryChip.vue')),
+    ProofReceiptPriceCountChip: defineAsyncComponent(() => import('../components/ProofReceiptPriceCountChip.vue')),
+    ProofReceiptPriceTotalChip: defineAsyncComponent(() => import('../components/ProofReceiptPriceTotalChip.vue')),
     ContributionAssistantPriceFormCard: defineAsyncComponent(() => import('../components/ContributionAssistantPriceFormCard.vue')),
     BarcodeScannerDialog: defineAsyncComponent(() => import('../components/BarcodeScannerDialog.vue')),
   },
@@ -135,9 +141,13 @@ export default {
       ],
     }
   },
-
   computed: {
     ...mapStores(useAppStore),
+    proofPriceListSum() {
+      return this.items.reduce((acc, price) => {
+        return acc + parseFloat(price.predicted_data.price)
+      }, 0)
+    }
   },
   watch: {
     items: {


### PR DESCRIPTION
### What

In the new Receipt Assistant (following #1501), we add the `ProofReceiptPriceCountChip` & `ProofReceiptPriceTotalChip` components at the footer of the price table.

### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/319da660-28f1-42df-87fb-049a6a31e4b4)|![image](https://github.com/user-attachments/assets/4fba881b-fa92-42a0-9904-11170e480e12)|
