### PR TITLE
feat(Barcode Scanner): use openfoodfacts-webcomponents (and allow user to switch back to html5-qrcode)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   },
   "dependencies": {
     "@intlify/unplugin-vue-i18n": "^4.0.0",
+    "@openfoodfacts/openfoodfacts-webcomponents": "^1.4.2",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
     "@vueuse/core": "^11.1.0",
     "@vueuse/integrations": "^11.1.0",
+    "@webcomponents/webcomponentsjs": "^2.8.0",
     "compressorjs": "^1.2.1",
     "exifreader": "^4.24.0",
     "html5-qrcode": "^2.3.8",

--- a/src/constants.js
+++ b/src/constants.js
@@ -214,6 +214,11 @@ export default {
     { key: 'scan', value: 'BarcodeScan', valueSmallScreen: 'BarcodeScanShort', icon: 'mdi-barcode-scan' },
     { key: 'type', value: 'BarcodeType', valueSmallScreen: 'BarcodeTypeShort', icon: 'mdi-numeric' },
   ],
+  BARCODE_SCANNER_DISPLAY_LIST: [
+    { key: 'auto', value: 'Auto', valueSmallScreen: 'Auto', icon: 'mdi-barcode-scan' },
+    { key: 'off-barcode-scanner', value: 'Off Barcode Scanner', valueSmallScreen: 'Off Scanner', icon: 'mdi-barcode-scan' },
+    { key: 'html5-qrcode', value: 'Html5-Qrcode', valueSmallScreen: 'Html5-Qrcode', icon: 'mdi-barcode-scan' },
+  ],
   PRICE_FORM_DISPLAY_LIST: [
     { key: 'display', value: 'Display', icon: 'mdi-eye-outline' },
     { key: 'edit', value: 'Edit', icon: 'mdi-pencil' },

--- a/src/store.js
+++ b/src/store.js
@@ -24,6 +24,7 @@ export const useAppStore = defineStore('app', {
       price_list_display_default_mode: constants.PRICE_DISPLAY_LIST[0].key,
       location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,
       barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key,
+      barcode_scanner_library: constants.BARCODE_SCANNER_DISPLAY_LIST[0].key,
       price_form_default_mode: constants.PRICE_FORM_DISPLAY_LIST[0].key
     },
   }),

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -117,7 +117,15 @@
             :item-value="item => item.key"
             hide-details="auto"
           />
-          <!-- Barcode scanner -->
+          <v-select
+            v-model="appStore.user.barcode_scanner_library"
+            :label="$t('UserSettings.BarcodeScannerLibrary')"
+            :items="barcodeScannerDisplayList"
+            :item-title="item => item.value"
+            :item-value="item => item.key"
+            hide-details="auto"
+          />
+          <!-- Price Validation -->
           <h3 class="mt-4 mb-1">
             {{ $t('UserSettings.PriceValidation') }}
           </h3>
@@ -220,6 +228,7 @@ export default {
       priceListDisplayList: constants.PRICE_DISPLAY_LIST,
       locationSelectorDisplayList: constants.LOCATION_SELECTOR_DISPLAY_LIST,
       productSelectorDisplayList: constants.PRODUCT_SELECTOR_DISPLAY_LIST,
+      barcodeScannerDisplayList: constants.BARCODE_SCANNER_DISPLAY_LIST,
       priceFormDisplayList: constants.PRICE_FORM_DISPLAY_LIST
     }
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
       template: {
         compilerOptions: {
           // declare barcode-scanner webcomponent as custom element
+          // See https://github.com/openfoodfacts/openfoodfacts-webcomponents for source
           isCustomElement: (tag) => tag === 'barcode-scanner'
         }
       }

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,14 @@ import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 
 export default defineConfig({
   plugins: [
-    vue(),
+    vue({
+      template: {
+        compilerOptions: {
+          // declare barcode-scanner webcomponent as custom element
+          isCustomElement: (tag) => tag === 'barcode-scanner'
+        }
+      }
+    }),
     VueI18nPlugin({
       runtimeOnly: false,
       include: resolve(dirname(fileURLToPath(import.meta.url)), './src/i18n/locales/**'),


### PR DESCRIPTION
### What
- Makes use of the barcode-scanner from https://github.com/openfoodfacts/openfoodfacts-webcomponents
- BarcodeScannerDialog uses the webcomponent by default, if the browser supports it, with a fallback on the previous scanner
- The settings page includes a new parameter to allow users to swap between libraries
- New scanner seems to be performing better on supported formats (ean-8 & ean-13), tests were made on Android Chrome

### Screenshot
| Before | After |
| ---- | ---- |
| ![Screenshot_20250504-180858_Chrome](https://github.com/user-attachments/assets/81ee16b1-d9d5-4700-a18f-38edf874897e) | ![Screenshot_20250504-180817_Chrome](https://github.com/user-attachments/assets/2fa901dc-9b60-4f7e-a120-3f0a6eef818b) |

New settings parameter
![image](https://github.com/user-attachments/assets/156026fa-f473-4131-b593-79d5170c20e2)

### Fixes bug(s)
- Fixes #1512 

