### PR TITLE
fix(Products): better manage non-en category tags

### DIFF
--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -190,7 +190,7 @@ export default {
   },
   mounted() {
     if (this.$route.query.code) {
-      if (this.$route.query.code.startsWith('en')) {
+      if (this.$route.query.code.includes(':')) {
         this.productForm.type = constants.PRICE_TYPE_CATEGORY
         this.productForm.category_tag = this.$route.query.code
       }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -115,7 +115,7 @@ export default {
   computed: {
     ...mapStores(useAppStore),
     productIsCategory() {
-      return this.productId.startsWith('en')
+      return this.productId.includes(':')
     },
     productNotFound() {
       return !this.productIsCategory && this.product && !this.product.source


### PR DESCRIPTION
### What

Fixes #1544 (allowing to display non-en category tags, such as https://prices.openfoodfacts.org/products/fr:batavia)
