### PR TITLE
feat(Receipt Assistant): Add a callout-promo in the ProofUploadCard

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -52,3 +52,7 @@
 .v-stepper-item {
     padding: 1rem !important;
 }
+
+.v-banner__prepend {
+    margin-inline-end: 12px !important;  /* to match with v-alert (16-(32-28)) */
+}

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -21,6 +21,23 @@
           density="compact"
           :text="$t('ProofAdd.HowToMultipleShort')"
         />
+        <v-banner
+          v-if="proofIsTypeReceipt && !assistedByAI"
+          class="mt-4 mb-4"
+          icon="mdi-draw"
+          bg-color="info"
+          rounded
+          lines="2"
+          density="compact"
+          @click="$router.push('/experiments/receipt-assistant')"
+        >
+          <v-banner-text style="padding-inline-end:10px;">
+            {{ $t('ProofAdd.PromoReceiptAssistant') }}
+          </v-banner-text>
+          <v-banner-actions>
+            <v-btn icon="mdi-arrow-right" :aria-label="$t('Common.TryItOut')" to="/experiments/receipt-assistant" />
+          </v-banner-actions>
+        </v-banner>
         <LocationInputRow :locationForm="proofForm" @location="locationObject = $event" />
         <ProofImageInputRow :proofImageForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
         <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" :assistedByAI="assistedByAI" :locationType="locationObject?.type" />
@@ -166,6 +183,9 @@ export default {
     },
     proofTypeFormFilled() {
       return !!this.proofForm.type
+    },
+    proofIsTypeReceipt() {
+      return this.proofTypeFormFilled && this.proofForm.type === constants.PROOF_TYPE_RECEIPT
     },
     proofImageFormFilled() {
       return !!this.proofImageList.length

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -411,6 +411,7 @@
 		"Total": "Total",
 		"Truncate": "Truncate",
 		"Truncated": "Truncated",
+		"TryItOut": "Try it out",
 		"Type": "Type",
 		"UnknownProduct": "Unknown product",
 		"UnknownProductSource": "Unknown product source",
@@ -626,7 +627,8 @@
 		"PriceTagAllowCommunityValidation": "Allow the community to validate prices extracted by AI",
 		"PriceTagAIWarning": "AI will run on your proofs to extract prices.",
 		"ReceiptAllowAI": "Allow running AI on your receipt to extract prices",
-		"ReceiptAIWarning": "AI will run on your receipt to extract prices."
+		"ReceiptAIWarning": "AI will run on your receipt to extract prices.",
+		"PromoReceiptAssistant": "Experiment: try the new receipt assistant to automatically extract prices from your receipts!"
 	},
 	"ProofCard": {
 		"Proof": "Proof",


### PR DESCRIPTION
### What

The recently-added Receipt Assistant is hidden.
Here we show a nudge to users selecting the "receipt" proof type

### Screenshot

![image](https://github.com/user-attachments/assets/2a9297df-f7f9-4b7c-a105-f0edccb7f723)

