### PR TITLE
feat(Proof upload): Add a callout-promo to the multiple price tag proof upload

### DIFF
--- a/src/components/ProofPriceTagAddMultiplePromoBanner.vue
+++ b/src/components/ProofPriceTagAddMultiplePromoBanner.vue
@@ -4,13 +4,13 @@
     bg-color="info"
     rounded
     density="compact"
-    @click="$router.push('/experiments/receipt-assistant')"
+    @click="$router.push('/proofs/add/multiple')"
   >
     <v-banner-text style="padding-inline-end:10px;">
-      {{ $t('ProofAdd.PromoReceiptAssistant') }}
+      {{ $t('ProofAdd.PromoProofPriceTagAddMultiple') }}
     </v-banner-text>
     <v-banner-actions>
-      <v-btn icon="mdi-arrow-right" :aria-label="$t('Common.TryItOut')" to="/experiments/receipt-assistant" />
+      <v-btn icon="mdi-arrow-right" :aria-label="$t('Router.AddProofMultiple')" to="/proofs/add/multiple" />
     </v-banner-actions>
   </v-banner>
 </template>

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -21,6 +21,7 @@
           density="compact"
           :text="$t('ProofAdd.HowToMultipleShort')"
         />
+        <ProofPriceTagAddMultiplePromoBanner v-if="proofIsTypePriceTag && !multiple" class="mt-4 mb-4" />
         <ReceiptAssistantPromoBanner v-if="proofIsTypeReceipt && !assistedByAI" class="mt-4 mb-4" />
         <LocationInputRow :locationForm="proofForm" @location="locationObject = $event" />
         <ProofImageInputRow :proofImageForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
@@ -96,6 +97,7 @@ Compressor.setDefaults({
 export default {
   components: {
     ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
+    ProofPriceTagAddMultiplePromoBanner: defineAsyncComponent(() => import('../components/ProofPriceTagAddMultiplePromoBanner.vue')),
     ReceiptAssistantPromoBanner: defineAsyncComponent(() => import('../components/ReceiptAssistantPromoBanner.vue')),
     LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
     ProofImageInputRow: defineAsyncComponent(() => import('../components/ProofImageInputRow.vue')),
@@ -168,6 +170,9 @@ export default {
     },
     proofTypeFormFilled() {
       return !!this.proofForm.type
+    },
+    proofIsTypePriceTag() {
+      return this.proofTypeFormFilled && this.proofForm.type === constants.PROOF_TYPE_PRICE_TAG
     },
     proofIsTypeReceipt() {
       return this.proofTypeFormFilled && this.proofForm.type === constants.PROOF_TYPE_RECEIPT

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -630,6 +630,7 @@
 		"PriceTagAIWarning": "AI will run on your proofs to extract prices.",
 		"ReceiptAllowAI": "Allow running AI on your receipt to extract prices",
 		"ReceiptAIWarning": "AI will run on your receipt to extract prices.",
+		"PromoProofPriceTagAddMultiple": "To upload multiple price tags (same shop location and date), click here!",
 		"PromoReceiptAssistant": "Experiment: try the new receipt assistant to automatically extract prices from your receipts!"
 	},
 	"ProofCard": {


### PR DESCRIPTION
Similar to #1560

### What

(temporary feature before something better)

Direct users to the multiple upload if users select the "Price tag" proof type

### Screenshot

![image](https://github.com/user-attachments/assets/3f4d012b-1b19-4dde-a40b-a675326f8d22)

