### PR TITLE
fix(PriceAddMultiple): always consider proof_type in Proof upload card

### DIFF
--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -206,6 +206,12 @@ export default {
         this.step = 3
         this.$emit('done', this.proofObjectList.length)
       }
+    },
+    typePriceTagOnly(newTypePriceTagOnly, oldTypePriceTagOnly) {  // eslint-disable-line no-unused-vars
+      this.initProofForm()
+    },
+    typeReceiptOnly(newTypeReceiptOnly, oldTypeReceiptOnly) {  // eslint-disable-line no-unused-vars
+      this.initProofForm()
     }
   },
   mounted() {


### PR DESCRIPTION
Following #1563

### What
- Sometimes the proof_type param wasn't considered, and the proof type choice wasn't selected