### PR TITLE
fix(PriceAddMultiple): made proof delete button work on single proof

### DIFF
--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -171,9 +171,14 @@ export default {
       this.proofImageList = [proof]
     },
     removeImage(index) {
-      this.proofImageList.splice(index, 1)
-      this.proofImagePreviewList.splice(index, 1)
-      this.$emit('proofList', this.proofImageList)
+      if (!Array.isArray(this.proofImageList)) {
+        // Only one proof was selected with v-file-input, so we clear everything
+        this.clearProof()
+      } else {
+        this.proofImageList.splice(index, 1)
+        this.proofImagePreviewList.splice(index, 1)
+        this.$emit('proofList', this.proofImageList)
+      }
     },
     clearProof() {
       this.proofImageList = []

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -225,6 +225,10 @@ export default {
       this.proofForm.currency = this.appStore.getUserLastCurrencyUsed
     },
     handleProofImageList() {
+      if (this.proofImageList.length === 0) {
+        // The list was fully cleared, nothing to do
+        return
+      }
       // can be an existing proof, or a file
       // existing proof: update proofForm + set proofObject
       if (this.proofImageList[0].id) {


### PR DESCRIPTION
### What
- A delete button was added on just-uploaded proofs
- Pressing that button in the prices/add/multiple wasn't doing anything
- This now clears the proof when the button is pressed

### Illustration of the mentioned delete button
![image](https://github.com/user-attachments/assets/65a66791-c32e-45e5-bb2b-bdf1df84932e)

