### PR TITLE
fix(Receipt Assistant): fix init the assistant with a proof_id

### DIFF
--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -191,7 +191,9 @@ export default {
   methods: {
     initWithProofIds(proofIds) {
       if (proofIds.length) {
-        this.onProofUploaded({id: proofIds[0]})
+        api.getProofById(proofIds[0]).then(proof => {
+          this.onProofUploaded(proof)
+        })
       }
     },
     onProofUploaded(proof) {


### PR DESCRIPTION
### What

Same as the Contribution Assistant, allow loading the Receipt Assistant page with a `?proof_ids=` param
