### PR TITLE
refactor(Receipt Assistant): in the proof action menu, change the link to point to the right assistant

### DIFF
--- a/src/components/PriceAddLink.vue
+++ b/src/components/PriceAddLink.vue
@@ -35,7 +35,7 @@ export default {
     },
     target: {
       type: String,
-      default: 'prices-add-multiple'  // 'prices-add-single', 'contribution-assistant'
+      default: 'prices-add-multiple'  // 'prices-add-single', 'contribution-assistant', 'receipt-assistant'
     },
     disabled: {
       type: Boolean,
@@ -46,12 +46,13 @@ export default {
     return {
       ADD_PRICE_SINGLE_BASE_URL: '/prices/add/single',
       ADD_PRICE_MULTIPLE_BASE_URL: '/prices/add/multiple',
-      CONTRIBUTION_ASSISTANT_BASE_URL: '/experiments/contribution-assistant'
+      CONTRIBUTION_ASSISTANT_BASE_URL: '/experiments/contribution-assistant',
+      RECEIPT_ASSISTANT_BASE_URL: '/experiments/receipt-assistant'
     }
   },
   computed: {
     getText() {
-      if (this.target === 'contribution-assistant') {
+      if (['contribution-assistant', 'receipt-assistant'].includes(this.target)) {
         return this.$t('ContributionAssistant.OpenWithTheAssistant')
       }
       else if (this.target === 'prices-add-single') {
@@ -64,12 +65,15 @@ export default {
         if (this.target === 'contribution-assistant') {
           return `${this.CONTRIBUTION_ASSISTANT_BASE_URL}?proof_ids=${this.proofId}`
         }
+        else if (this.target === 'receipt-assistant') {
+          return `${this.RECEIPT_ASSISTANT_BASE_URL}?proof_ids=${this.proofId}`
+        }
         return `${this.ADD_PRICE_MULTIPLE_BASE_URL}?proof_id=${this.proofId}`
       }
       return `${this.ADD_PRICE_SINGLE_BASE_URL}?code=${this.productCode}`
     },
     getIcon() {
-      if (this.target === 'contribution-assistant') {
+      if (['contribution-assistant', 'receipt-assistant'].includes(this.target)) {
         return 'mdi-draw'
       }
       return 'mdi-tag-plus-outline'

--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -7,7 +7,8 @@
           {{ $t('Common.Proof') }}
         </v-list-subheader>
         <v-divider />
-        <PriceAddLink v-if="userIsProofOwner" :proofId="proof.id" display="list-item" target="contribution-assistant" :disabled="!userCanAddPrice" />
+        <PriceAddLink v-if="userIsProofOwner && proofIsTypePriceTag" :proofId="proof.id" display="list-item" target="contribution-assistant" :disabled="!userCanAddPrice" />
+        <PriceAddLink v-else-if="userIsProofOwner && proofIsTypeReceipt" :proofId="proof.id" display="list-item" target="receipt-assistant" :disabled="!userCanAddPrice" />
         <PriceAddLink v-if="userIsProofOwner" :proofId="proof.id" display="list-item" :disabled="!userCanAddPrice" />
         <ShareLink v-if="showProofShare" :overrideUrl="getShareLinkUrl" display="list-item" />
         <v-list-item :slim="true" prepend-icon="mdi-eye-outline" :to="getProofDetailUrl">
@@ -97,6 +98,12 @@ export default {
     ...mapStores(useAppStore),
     username() {
       return this.appStore.user.username
+    },
+    proofIsTypePriceTag() {
+      return this.proof && this.proof.type === constants.PROOF_TYPE_PRICE_TAG
+    },
+    proofIsTypeReceipt() {
+      return this.proof && this.proof.type === constants.PROOF_TYPE_RECEIPT
     },
     userIsProofOwner() {
       return this.username && (this.proof.owner === this.username)


### PR DESCRIPTION
### What

When owner of a receipt proof, there was an option to open it with the assistant.
But it was pointing to the Contribution Assistant. Not the Receipt Assistant.

### Screenshot

![image](https://github.com/user-attachments/assets/dc1b89a7-19d8-4c64-89a0-e26b4bd3d449)
