### PR TITLE
refactor(Proof detail): if the user is the receipt owner, display the quantity column

### DIFF
--- a/src/components/CategoryCard.vue
+++ b/src/components/CategoryCard.vue
@@ -3,8 +3,8 @@
     <v-card-text>
       <v-row>
         <v-col :cols="hideActionMenuButton ? '12' : '11'">
-          <ProductCountChip v-if="sourceCategory" class="mr-1" :count="productCount" :withLabel="true" />
-          <PriceCountChip v-else-if="sourceProduct" class="mr-1" :count="priceCount" />
+          <ProductCountChip v-if="sourceIsCategory" class="mr-1" :count="productCount" :withLabel="true" />
+          <PriceCountChip v-else-if="sourceIsProduct" class="mr-1" :count="priceCount" />
           <CategoryTagChip v-if="showProductCategoryTag" class="mr-1" :category="category" :readonly="true" />
         </v-col>
       </v-row>
@@ -55,14 +55,14 @@ export default {
     categoryFound() {
       return this.category && !this.category.status
     },
-    sourceCategory() {
+    sourceIsCategory() {
       return this.source === 'category'
     },
-    sourceProduct() {
+    sourceIsProduct() {
       return this.source === 'product'
     },
     showProductCategoryTag() {
-      return this.appStore.user.username && this.sourceProduct && this.appStore.user.product_display_category_tag
+      return this.appStore.user.username && this.sourceIsProduct && this.appStore.user.product_display_category_tag
     }
   }
 }

--- a/src/components/PriceAlreadyUploadedListCard.vue
+++ b/src/components/PriceAlreadyUploadedListCard.vue
@@ -58,13 +58,13 @@ export default {
   },
   computed: {
     showCard() {
-      return this.hideCardIfNoProofPriceUploaded && this.proofPriceUploadedList.length > 0
+      return this.hideCardIfNoProofPriceUploaded && (this.proofPriceUploadedList.length > 0)
     },
     proofIsTypeReceipt() {
-      return this.proof && this.proof.type === constants.PROOF_TYPE_RECEIPT
+      return this.proof && (this.proof.type === constants.PROOF_TYPE_RECEIPT)
     },
     showCardFooter() {
-      return this.proofIsTypeReceipt && this.proofPriceUploadedList.length > 0
+      return this.proofIsTypeReceipt && (this.proofPriceUploadedList.length > 0)
     },
     proofPriceUploadedListSum() {
       return this.proofPriceUploadedList.reduce((acc, price) => {

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -196,7 +196,7 @@ export default {
       return !!this.categoryTag
     },
     productIsTypeCategory() {
-      return this.priceForm && this.priceForm.type === constants.PRICE_TYPE_CATEGORY
+      return this.priceForm && (this.priceForm.type === constants.PRICE_TYPE_CATEGORY)
     },
     proofIsTypeReceipt() {
       return this.proofType === constants.PROOF_TYPE_RECEIPT

--- a/src/components/PriceTable.vue
+++ b/src/components/PriceTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-data-table :headers="headers" :items="priceList" hide-default-footer>
+  <v-data-table :headers="headers" :items="priceList" fixed-header hide-default-footer>
     <template #[`item.product_name`]="{ item }">
       {{ getPriceProductTitle(item) }}
     </template>
@@ -16,6 +16,9 @@
     <template #[`item.price`]="{ item }">
       <PricePriceRow :price="item" :productQuantity="item.product ? item.product.product_quantity : null" :productQuantityUnit="item.product ? item.product.product_quantity_unit : null" />
     </template>
+    <template #[`item.receipt_quantity`]="{ item }">
+      {{ item.receipt_quantity }}
+    </template>
     <template #[`item.created`]="{ item }">
       <RelativeDateTimeChip :dateTime="item.created" />
     </template>
@@ -26,6 +29,7 @@
 import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
+import constants from '../constants'
 
 export default {
   components: {
@@ -45,7 +49,11 @@ export default {
       type: String,
       default: 'product',
       examples: ['product', 'proof']
-    }
+    },
+    proof: {
+      type: Object,
+      default: null
+    },
   },
   data() {
     return {
@@ -62,12 +70,35 @@ export default {
         { title: 'Price', key: 'price' },
         { title: 'Added', key: 'created' },
         // { title: 'Actions', key: 'actions' },
-      ]
+      ],
+      proofReceiptPriceOwnerHeaders: [
+        { title: 'Product', key: 'product_name' },
+        { title: 'Details', key: 'product_details' },
+        { title: 'Price', key: 'price' },
+        { title: 'Quantity', key: 'receipt_quantity' },
+        { title: 'Added', key: 'created' },
+        // { title: 'Actions', key: 'actions' },
+      ],
     }
   },
   computed: {
     ...mapStores(useAppStore),
+    username() {
+      return this.appStore.user.username
+    },
+    userIsProofOwner() {
+      return this.username && this.proof && (this.proof.owner === this.username)
+    },
+    sourceIsProof() {
+      return this.source === 'proof'
+    },
+    proofIsTypeReceipt() {
+      return this.proof && (this.proof.type === constants.PROOF_TYPE_RECEIPT)
+    },
     headers() {
+      if (this.sourceIsProof && this.userIsProofOwner && this.proofIsTypeReceipt) {
+        return this.proofReceiptPriceOwnerHeaders
+      }
       return this[`${this.source}PriceHeaders`]
     }
   },

--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -99,14 +99,14 @@ export default {
     username() {
       return this.appStore.user.username
     },
+    userIsProofOwner() {
+      return this.username && this.proof && (this.proof.owner === this.username)
+    },
     proofIsTypePriceTag() {
-      return this.proof && this.proof.type === constants.PROOF_TYPE_PRICE_TAG
+      return this.proof && (this.proof.type === constants.PROOF_TYPE_PRICE_TAG)
     },
     proofIsTypeReceipt() {
-      return this.proof && this.proof.type === constants.PROOF_TYPE_RECEIPT
-    },
-    userIsProofOwner() {
-      return this.username && (this.proof.owner === this.username)
+      return this.proof && (this.proof.type === constants.PROOF_TYPE_RECEIPT)
     },
     getProofFullUrl() {
       // return 'https://prices.openfoodfacts.org/img/0002/qU59gK8PQw.webp'  // PRICE_TAG

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -79,10 +79,10 @@ export default {
       return this.appStore.user.username
     },
     userIsProofOwner() {
-      return this.username && (this.proof.owner === this.username)
+      return this.username && this.proof && (this.proof.owner === this.username)
     },
     proofIsTypeReceipt() {
-      return this.proof && this.proof.type === constants.PROOF_TYPE_RECEIPT
+      return this.proof && (this.proof.type === constants.PROOF_TYPE_RECEIPT)
     },
     showReceiptOwnerConsumption() {
       return this.userIsProofOwner && this.proofIsTypeReceipt && this.proof.owner_consumption

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -172,10 +172,10 @@ export default {
       return !!this.proofForm.type
     },
     proofIsTypePriceTag() {
-      return this.proofTypeFormFilled && this.proofForm.type === constants.PROOF_TYPE_PRICE_TAG
+      return this.proofTypeFormFilled && (this.proofForm.type === constants.PROOF_TYPE_PRICE_TAG)
     },
     proofIsTypeReceipt() {
-      return this.proofTypeFormFilled && this.proofForm.type === constants.PROOF_TYPE_RECEIPT
+      return this.proofTypeFormFilled && (this.proofForm.type === constants.PROOF_TYPE_RECEIPT)
     },
     proofImageFormFilled() {
       return !!this.proofImageList.length

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -27,7 +27,7 @@
       </v-row>
     </v-window-item>
     <v-window-item value="table">
-      <PriceTable class="mt-3 mb-3" :priceList="priceList" source="proof" />
+      <PriceTable class="mt-3 mb-3" :priceList="priceList" source="proof" :proof="proof" />
     </v-window-item>
   </v-window>
 


### PR DESCRIPTION
### What

Following #1522 (new proof detail table view).
For receipts, display the quantity column (but only if the user is the proof owner)

### Screenshot

||Image|
|-|-|
|Before|![image](https://github.com/user-attachments/assets/2b28b8bb-cb0f-4140-8e9f-22c66f786ccf)|
|After|![image](https://github.com/user-attachments/assets/6fd1a119-18be-4b7e-b375-6b1ce884aa42)|
