### PR TITLE
refactor(Receipt Assistant): display the quantity column

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -36,6 +36,9 @@
         <template #[`item.price`]="{ item }">
           <v-text-field v-model="item.predicted_data.price" :suffix="itemPriceSuffix(item)" :hide-details="true" :rules="rules" dense single-line />
         </template>
+        <template #[`item.receipt_quantity`]="{ item }">
+          {{ item.receipt_quantity }}
+        </template>
         <template #[`item.actions`]="{ item }">
           <v-row>
             <v-btn size="x-small" icon="mdi-pencil" @click="showEditProductDialog(item)" />

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -129,6 +129,7 @@ export default {
         { title: 'Product Name', key: 'product_name' },
         { title: 'Product', key: 'product' },
         { title: 'Price', key: 'price' },
+        { title: 'Quantity', key: 'receipt_quantity' },
         { title: 'Actions', key: 'actions' },
       ],
       editProductDialog: false,


### PR DESCRIPTION
### What

In the Receipt Assistant, add the Quantity column between the Price & Actions columns

### Screenshot

![image](https://github.com/user-attachments/assets/8f7c5a55-693e-43ef-9eca-e71dbb3065a6)

