### PR TITLE
refactor(Steppers): last step (Actions): show actions as cards instead of buttons

### DIFF
--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -46,6 +46,7 @@
         class="float-right"
         color="primary"
         variant="flat"
+        type="submit"
         :block="!$vuetify.display.smAndUp"
         :disabled="!proofFormFilled"
         @click="uploadProofList"

--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -149,7 +149,7 @@
   <v-row v-if="step === 4">
     <v-col>
       <v-row>
-        <v-col cols="12" md="6">
+        <v-col cols="12">
           <v-progress-linear
             v-if="!finishedUploading"
             v-model="numberOfPricesAdded"
@@ -163,62 +163,41 @@
           </v-progress-linear>
           <v-alert
             v-if="finishedUploading"
-            class="mb-4"
             type="success"
             variant="outlined"
             density="compact"
             :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
           />
+        </v-col>
+      </v-row>
+      <v-row v-if="finishedUploading">
+        <v-col cols="12" sm="6" lg="4">
           <v-card
-            v-if="finishedUploading"
-            :title="$t('Common.Actions')"
-            prepend-icon="mdi-clipboard-text"
-          >
-            <v-divider />
-            <v-card-text class="text-center">
-              <v-row>
-                <v-col>
-                  <v-btn
-                    color="primary"
-                    :block="!$vuetify.display.smAndUp"
-                    prepend-icon="mdi-image"
-                    :to="'/proofs/' + proofObject.id"
-                  >
-                    {{ $t('ContributionAssistant.GoToProof') }}
-                  </v-btn>
-                </v-col>
-                <v-col>
-                  <v-btn
-                    color="primary"
-                    :block="!$vuetify.display.smAndUp"
-                    prepend-icon="mdi-image-plus"
-                    @click="reloadPage"
-                  >
-                    {{ $t('ContributionAssistant.AddNewProof') }}
-                  </v-btn>
-                </v-col>
-                <v-col v-if="proofIdsFromQueryParam && proofIdsFromQueryParam.length > 1">
-                  <v-btn
-                    :block="!$vuetify.display.smAndUp"
-                    color="primary"
-                    @click="nextProof"
-                  >
-                    {{ $t('ContributionAssistant.NextProof') }}
-                  </v-btn>
-                </v-col>
-                <v-col>
-                  <v-btn
-                    color="primary"
-                    :block="!$vuetify.display.smAndUp"
-                    prepend-icon="mdi-account-circle"
-                    to="/dashboard"
-                  >
-                    {{ $t('Common.MyDashboard') }}
-                  </v-btn>
-                </v-col>
-              </v-row>
-            </v-card-text>
-          </v-card>
+            :title="$t('Common.AddNewProof')"
+            prepend-icon="mdi-image-plus"
+            @click="reloadPage"
+          />
+        </v-col>
+        <v-col v-if="proofIdsFromQueryParam && proofIdsFromQueryParam.length > 1" cols="12" sm="6" lg="4">
+          <v-card
+            :title="$t('ContributionAssistant.NextProof')"
+            prepend-icon="mdi-image"
+            @click="nextProof"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" lg="4">
+          <v-card
+            :title="$t('ContributionAssistant.GoToProof')"
+            prepend-icon="mdi-image"
+            :to="'/proofs/' + proofObject.id"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" lg="4">
+          <v-card
+            :title="$t('Common.MyDashboard')"
+            prepend-icon="mdi-account-circle"
+            :to="getUserDashboardUrl"
+          />
         </v-col>
       </v-row>
       <v-row v-if="finishedUploading && nextProofSuggestions.length">
@@ -354,6 +333,10 @@ export default {
     productPriceFormsMarkedAsError() {
       return this.productPriceForms.filter(productPriceForm => productPriceForm.status > 1)
     },
+    getUserDashboardUrl() {
+      const dashboardTab = constants.USER_COMMUNITY.toLowerCase()  // default on this page
+      return `/dashboard?tab=${dashboardTab}`
+    }
   },
   mounted() {
     if (this.$route.query.proof_ids) {

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -102,44 +102,27 @@
   </v-row>
 
   <v-row v-if="step === 3">
-    <v-col cols="12" md="6">
+    <v-col cols="12">
       <v-alert
-        class="mb-4"
         type="success"
         variant="outlined"
         density="compact"
         :text="$t('Common.PriceAddedCount', { count: proofPriceNewList.length })"
       />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
       <v-card
-        :title="$t('Common.Actions')"
-        prepend-icon="mdi-clipboard-text"
-      >
-        <v-divider />
-        <v-card-text class="text-center">
-          <v-row>
-            <v-col cols="12" sm="6">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-tag-plus-outline"
-                @click="reloadPage"
-              >
-                {{ $t('Common.AddNewPrices') }}
-              </v-btn>
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-account-circle"
-                :to="userDashboardUrl"
-              >
-                {{ $t('Common.MyDashboard') }}
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+        :title="$t('Common.AddNewPrices')"
+        prepend-icon="mdi-tag-plus-outline"
+        @click="reloadPage"
+      />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
+      <v-card
+        :title="$t('Common.MyDashboard')"
+        prepend-icon="mdi-account-circle"
+        :to="getUserDashboardUrl"
+      />
     </v-col>
   </v-row>
 
@@ -250,7 +233,7 @@ export default {
       }
       return false
     },
-    userDashboardUrl() {
+    getUserDashboardUrl() {
       const dashboardTab = (this.proofObject && this.proofObject.type === constants.PROOF_TYPE_RECEIPT && this.proofObject.owner_consumption) ? constants.USER_CONSUMPTION.toLowerCase() : constants.USER_COMMUNITY.toLowerCase()
       return `/dashboard?multipleSuccess=true&tab=${dashboardTab}`
     }

--- a/src/views/ProofAddMultiple.vue
+++ b/src/views/ProofAddMultiple.vue
@@ -18,54 +18,34 @@
   </v-row>
 
   <v-row v-if="step === 2">
-    <v-col cols="12" md="6">
+    <v-col cols="12">
       <v-alert
-        class="mb-4"
         type="success"
         variant="outlined"
         density="compact"
         :text="$t('Common.ProofUploadedCount', { count: proofUploadCount })"
       />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
       <v-card
-        :title="$t('Common.Actions')"
-        prepend-icon="mdi-clipboard-text"
-      >
-        <v-divider />
-        <v-card-text class="text-center">
-          <v-row>
-            <v-col cols="12" sm="4">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-image-plus"
-                @click="reloadPage"
-              >
-                {{ $t('Common.AddNewProofs') }}
-              </v-btn>
-            </v-col>
-            <v-col cols="12" sm="4">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-checkbox-marked-circle-plus-outline"
-                :to="getPriceValidationUrl"
-              >
-                {{ $t('Common.ValidatePrices') }}
-              </v-btn>
-            </v-col>
-            <v-col cols="12" sm="4">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-account-circle"
-                :to="getUserDashboardUrl"
-              >
-                {{ $t('Common.MyDashboard') }}
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+        :title="$t('Common.AddNewProofs')"
+        prepend-icon="mdi-image-plus"
+        @click="reloadPage"
+      />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
+      <v-card
+        :title="$t('Common.ValidatePrices')"
+        prepend-icon="mdi-checkbox-marked-circle-plus-outline"
+        :to="getPriceValidationUrl"
+      />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
+      <v-card
+        :title="$t('Common.MyDashboard')"
+        prepend-icon="mdi-account-circle"
+        :to="getUserDashboardUrl"
+      />
     </v-col>
   </v-row>
 </template>

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -18,44 +18,27 @@
   </v-row>
 
   <v-row v-if="step === 2">
-    <v-col cols="12" md="6">
+    <v-col cols="12">
       <v-alert
-        class="mb-4"
         type="success"
         variant="outlined"
         density="compact"
         :text="$t('Common.ProofUploadedCount', { count: proofUploadCount })"
       />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
       <v-card
-        :title="$t('Common.Actions')"
-        prepend-icon="mdi-clipboard-text"
-      >
-        <v-divider />
-        <v-card-text class="text-center">
-          <v-row>
-            <v-col cols="12" sm="6">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-image-plus"
-                @click="reloadPage"
-              >
-                {{ $t('Common.AddNewProof') }}
-              </v-btn>
-            </v-col>
-            <v-col cols="12" sm="6">
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-account-circle"
-                :to="getUserDashboardUrl"
-              >
-                {{ $t('Common.MyDashboard') }}
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+        :title="$t('Common.AddNewProof')"
+        prepend-icon="mdi-image-plus"
+        @click="reloadPage"
+      />
+    </v-col>
+    <v-col cols="12" sm="6" lg="4">
+      <v-card
+        :title="$t('Common.MyDashboard')"
+        prepend-icon="mdi-account-circle"
+        :to="getUserDashboardUrl"
+      />
     </v-col>
   </v-row>
 </template>

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -50,65 +50,50 @@
   </v-row>
 
   <v-row v-if="step === 3">
-    <v-col cols="12" md="6">
-      <v-progress-linear
-        v-if="!finishedUploading"
-        v-model="numberOfPricesAdded"
-        :max="totalNumberOfPricesToAdd"
-        :color="totalNumberOfPricesToAdd === numberOfPricesAdded ? 'success' : 'primary'"
-        height="25"
-        :striped="totalNumberOfPricesToAdd !== numberOfPricesAdded"
-        rounded
-      />
-      <v-alert
-        v-if="finishedUploading"
-        class="mb-4"
-        type="success"
-        variant="outlined"
-        density="compact"
-        :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
-      />
-      <v-card
-        v-if="finishedUploading"
-        :title="$t('Common.Actions')"
-        prepend-icon="mdi-clipboard-text"
-      >
-        <v-divider />
-        <v-card-text class="text-center">
-          <v-row>
-            <v-col>
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-image"
-                :to="'/proofs/' + proofObject.id"
-              >
-                {{ $t('ContributionAssistant.GoToProof') }}
-              </v-btn>
-            </v-col>
-            <v-col>
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-image-plus"
-                @click="reloadPage"
-              >
-                {{ $t('ContributionAssistant.AddNewProof') }}
-              </v-btn>
-            </v-col>
-            <v-col>
-              <v-btn
-                color="primary"
-                :block="!$vuetify.display.smAndUp"
-                prepend-icon="mdi-account-circle"
-                :to="userDashboardUrl"
-              >
-                {{ $t('Common.MyDashboard') }}
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
+    <v-col>
+      <v-row>
+        <v-col cols="12">
+          <v-progress-linear
+            v-if="!finishedUploading"
+            v-model="numberOfPricesAdded"
+            :max="totalNumberOfPricesToAdd"
+            :color="totalNumberOfPricesToAdd === numberOfPricesAdded ? 'success' : 'primary'"
+            height="25"
+            :striped="totalNumberOfPricesToAdd !== numberOfPricesAdded"
+            rounded
+          />
+          <v-alert
+            v-if="finishedUploading"
+            type="success"
+            variant="outlined"
+            density="compact"
+            :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
+          />
+        </v-col>
+      </v-row>
+      <v-row v-if="finishedUploading">
+        <v-col cols="12" sm="6" lg="4">
+          <v-card
+            :title="$t('Common.AddNewProof')"
+            prepend-icon="mdi-image-plus"
+            @click="reloadPage"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" lg="4">
+          <v-card
+            :title="$t('ContributionAssistant.GoToProof')"
+            prepend-icon="mdi-image"
+            :to="'/proofs/' + proofObject.id"
+          />
+        </v-col>
+        <v-col cols="12" sm="6" lg="4">
+          <v-card
+            :title="$t('Common.MyDashboard')"
+            prepend-icon="mdi-account-circle"
+            :to="getUserDashboardUrl"
+          />
+        </v-col>
+      </v-row>
     </v-col>
   </v-row>
 </template>
@@ -177,7 +162,7 @@ export default {
     finishedUploading() {
       return this.totalNumberOfPricesToAdd === this.numberOfPricesAdded
     },
-    userDashboardUrl() {
+    getUserDashboardUrl() {
       const dashboardTab = (this.proofObject && this.proofObject.type === constants.PROOF_TYPE_RECEIPT && this.proofObject.owner_consumption) ? constants.USER_CONSUMPTION.toLowerCase() : constants.USER_COMMUNITY.toLowerCase()
       return `/dashboard?tab=${dashboardTab}`
     }


### PR DESCRIPTION
### What

v2 of #1568

Done in every page with steppers
- Proof upload card
- Proof add single & Proof add multiple
- Price add multiple
- Receipt Assistant
- Contribution Assistant

### Why

Pave the way for more text/description for each action (card = can add image, description...)

### Screenshot

|Page|Before|After|
|-|-|-|
|Receipt Assistant|<img width="900" height="457" alt="image" src="https://github.com/user-attachments/assets/dc54f835-64aa-4c54-a16d-6a120d97ea23" />|<img width="900" height="353" alt="image" src="https://github.com/user-attachments/assets/d5a155bd-41aa-43f0-ae83-e3db412ab5e1" />|

