### PR TITLE
refactor(Cards): add a right arrow when cards are clickable

### DIFF
--- a/src/views/Experiments.vue
+++ b/src/views/Experiments.vue
@@ -4,6 +4,7 @@
       <v-card
         :title="$t('Router.ContributionAssistant.Title')"
         prepend-icon="mdi-draw"
+        append-icon="mdi-arrow-right"
         to="/experiments/contribution-assistant"
       />
     </v-col>
@@ -11,6 +12,7 @@
       <v-card
         :title="$t('Router.PriceValidationAssistant.Title')"
         prepend-icon="mdi-checkbox-marked-circle-plus-outline"
+        append-icon="mdi-arrow-right"
         to="/experiments/price-validation-assistant"
       />
     </v-col>
@@ -18,6 +20,7 @@
       <v-card
         :title="$t('Router.ReceiptAssistant.Title')"
         prepend-icon="mdi-draw"
+        append-icon="mdi-arrow-right"
         to="/experiments/receipt-assistant"
       />
     </v-col>
@@ -30,6 +33,7 @@
       <v-card
         :title="$t('Router.PriceAddSingle.Title')"
         prepend-icon="mdi-tag-plus-outline"
+        append-icon="mdi-arrow-right"
         to="/prices/add/single"
       />
     </v-col>
@@ -37,6 +41,7 @@
       <v-card
         :title="$t('Router.ProofAddSingle.Title')"
         prepend-icon="mdi-image-plus"
+        append-icon="mdi-arrow-right"
         to="/proofs/add/single"
       />
     </v-col>


### PR DESCRIPTION
### What

We confuse users with different kind of display, some cards act as buttons, some cards act only as display.
For cards that are clickable (like a button), add right arrow in the top right.

This arrow is already displayed on some buttons (not cards)

### Screenshot

|Page|Before|After|
|-|-|-|
|/experiments|<img width="420" height="503" alt="image" src="https://github.com/user-attachments/assets/dcaaa8e5-08e8-4302-a819-da400aed16b0" />|<img width="420" height="503" alt="image" src="https://github.com/user-attachments/assets/088d6914-7f9c-43d7-adcf-1f4a79df6a19" />|
