### PR TITLE
refactor(ContributionAssistant): only fetch pricetags with predictions

### DIFF
--- a/src/views/ContributionAssistant.vue
+++ b/src/views/ContributionAssistant.vue
@@ -408,7 +408,7 @@ export default {
       // Question: callback vs Promise ? Neither are really used in the rest of the code base
       let tries = 0
       const load = () => {
-        api.getPriceTags({proof_id: this.proofObject.id, size: 100}).then(data => {
+        api.getPriceTags({proof_id: this.proofObject.id, size: 100, prediction_count__gte: 1}).then(data => {
           const priceTags = data.items
           const numberOfPriceTagsWithPredictions = priceTags.filter(priceTag => priceTag.predictions.length).length
           if (numberOfPriceTagsWithPredictions >= minNumberOfPriceTagWithPredictions) {


### PR DESCRIPTION
### What
- Following a bug report on slack, the assistant seems to get stuck when gemini prediction are missing (see example here: https://prices.openfoodfacts.org/experiments/contribution-assistant?proof_ids=38224)
- This PR only fetches price tags with at least one prediction, and ignores the other ones
- There might be an underlying issue with gemini, but at least the frontend is more resilient
