### PR TITLE
fix(Receipt Assistant): reduce product form field height. set minimum price form field width

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -26,6 +26,7 @@
             v-else-if="!item.productFound"
             :model-value="item.product_code"
             :hide-details="true"
+            density="compact"
             :rules="rules"
             :append-inner-icon="item.product_code ? 'mdi-magnify' : 'mdi-barcode-scan'"
             @click:append-inner="item.product_code ? findProduct(item) : launchBarcodeScanner(item)"
@@ -141,7 +142,7 @@ export default {
       headers: [
         { title: 'Product Name', key: 'product_name' },
         { title: 'Product', key: 'product' },
-        { title: 'Price', key: 'price' },
+        { title: 'Price', key: 'price', minWidth: '150px' },
         { title: 'Quantity', key: 'receipt_quantity' },
         { title: 'Actions', key: 'actions' },
       ],


### PR DESCRIPTION
### What
- <!-- Describe the Pull Request here -->

### Screenshot

|Page|Before|After|
|-|-|-|
|Desktop|<img width="794" height="689" alt="image" src="https://github.com/user-attachments/assets/fbb4d323-785b-472d-95c5-2b1c3de6cd24" />|<img width="794" height="689" alt="image" src="https://github.com/user-attachments/assets/14ac695b-b658-4371-b3d0-ba100054eff6" />|
|Mobile|<img width="413" height="273" alt="image" src="https://github.com/user-attachments/assets/1c73d3f6-0584-4abc-a741-02b7100c08d0" />|<img width="413" height="273" alt="image" src="https://github.com/user-attachments/assets/af4e918b-56e5-4402-be9b-caad7c49f899" />|

