### PR TITLE
refactor(Utils): move proof stuff to a dedicated file

### DIFF
--- a/src/components/ProofTypeChip.vue
+++ b/src/components/ProofTypeChip.vue
@@ -14,7 +14,7 @@
 
 <script>
 import constants from '../constants'
-import utils from '../utils.js'
+import proof_utils from '../utils/proof.js'
 
 export default {
   props: {
@@ -31,7 +31,7 @@ export default {
   },
   computed: {
     getProofTypeIcon() {
-      return utils.getProofTypeIcon(this.proofType)
+      return proof_utils.getProofTypeIcon(this.proofType)
     },
     getProofTypeName() {
       return this.$t(`Common.${this.proofType}`)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 import CategoryTags from './data/category-tags.json'
-import constants from './constants'
 
 
 function debounce(callback, wait) {
@@ -110,10 +109,6 @@ function getLocaleLabelTagName(locale, labelId) {
   })
 }
 
-function getProofTypeIcon(proofType) {
-  return constants[`PROOF_TYPE_${proofType}_ICON`] || constants.PROOF_ICON
-}
-
 export default {
   debounce,
   getDocumentScrollPercentage,
@@ -130,5 +125,4 @@ export default {
   getLocaleOriginTags,
   getLocaleLabelTags,
   getLocaleLabelTagName,
-  getProofTypeIcon,
 }

--- a/src/utils/proof.js
+++ b/src/utils/proof.js
@@ -1,0 +1,9 @@
+import constants from '../constants'
+
+function getProofTypeIcon(proofType) {
+  return constants[`PROOF_TYPE_${proofType}_ICON`] || constants.PROOF_ICON
+}
+
+export {
+  getProofTypeIcon
+}


### PR DESCRIPTION
### What

Continue splitting the `utils.js` file
