### PR TITLE
refactor(Utils): move price tag handling in the proof utils

### DIFF
--- a/src/utils/proof.js
+++ b/src/utils/proof.js
@@ -1,4 +1,5 @@
 import constants from '../constants'
+import barcode_utils from './barcode.js'
 
 function getImageFullUrl(imagePath) {
   return `${import.meta.env.VITE_OPEN_PRICES_APP_URL}/img/${imagePath}`
@@ -19,8 +20,70 @@ function getProofTypeIcon(proofType) {
   return constants[`PROOF_TYPE_${proofType}_ICON`] || constants.PROOF_ICON
 }
 
+/**
+ * Format the price tag prediction depending on the version
+ * Needed as input for the ContributionAssistantPriceFormCard
+ */
+function handlePriceTag(priceTag) {
+  const priceTagPrediction = priceTag['predictions'][0]
+  const label = priceTagPrediction['data']
+  const barcodeString = label.barcode ? barcode_utils.cleanBarcode(label.barcode.toString()) : ''
+
+  // The first schema was not versioned, so if the field is missing,
+  // we assume it's schema version 1.0
+  const schemaVersion = priceTagPrediction.schema_version || '1.0'
+
+  // fields that are common to all schema versions are initialized here
+  let productPriceForm = {
+    id: priceTag.id,
+    origins_tags: ![null, '', 'unknown', 'other'].includes(label.origin) ? [label.origin] : [],
+    currency: priceTag['proof'].currency, // || this.appStore.getUserLastCurrencyUsed,
+    proof: priceTag['proof'],
+    proofImage: priceTag['proof'].file_path,
+    croppedImage: null,
+    product_code: barcodeString,
+    detected_product_code: barcodeString,
+    product_name: label.product_name,
+    bounding_box: priceTag.bounding_box,
+    status: priceTag.status,  // specific to the ProofPriceTagAssistant (vs the PriceValidationAssistant)
+    price_id: priceTag.price_id,  // specific to the ProofPriceTagAssistant (vs the PriceValidationAssistant)
+    loading: false
+  }
+
+  if (schemaVersion === '1.0') {
+    // For schema version 1.0
+    const priceType = barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY
+    productPriceForm.type = priceType
+    productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.product)) ? label.product : null
+    productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
+    productPriceForm.price = label.price.toString()
+    productPriceForm.price_per = label.unit
+    // price_is_discounted is not supported in schema version 1.0
+    productPriceForm.price_is_discounted = false
+  } else {
+    // version 2.0 and above
+    const priceType = label.type
+    // The selected price is a price constructed by all price information available in the label,
+    // including the discount price if available.
+    const selectedPrice = label.selected_price || {}
+    productPriceForm.type = priceType
+    // we only populate category_tag and labels_tags if the price type is category
+    productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.category)) ? label.category : null
+    productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
+    productPriceForm.price = selectedPrice.price ? selectedPrice.price.toString() : ""
+    productPriceForm.price_per = selectedPrice.price_per || null
+    // in schema 2.0, we detect discount information (price, type)
+    productPriceForm.price_is_discounted = selectedPrice ? selectedPrice.price_is_discounted : false
+    productPriceForm.price_without_discount = selectedPrice.price_without_discount ? selectedPrice.price_without_discount.toString() : ""
+    productPriceForm.discount_type = selectedPrice.discount_type || ""
+  }
+
+  return productPriceForm
+}
+
 export default {
   getImageFullUrl,
   getProofImageFullUrl,
-  getProofTypeIcon
+  getProofTypeIcon,
+  handlePriceTag
 }

--- a/src/views/PriceValidationAssistant.vue
+++ b/src/views/PriceValidationAssistant.vue
@@ -49,8 +49,8 @@ import { defineAsyncComponent } from 'vue'
 import constants from '../constants'
 import api from '../services/api'
 import { useAppStore } from '../store'
-import barcode_utils from '../utils/barcode.js'
 import date_utils from '../utils/date.js'
+import proof_utils from '../utils/proof.js'
 import utils from '../utils.js'
 
 export default {
@@ -172,61 +172,14 @@ export default {
           for (let i = 0; i < data.items.length; i++) {
             // only validate price tags with predictions
             if (data.items[i]['predictions'].length > 0) {
-              const priceTagPrediction = data.items[i]['predictions'][0]
-              const label = priceTagPrediction['data']
-              const barcodeString = label.barcode ? barcode_utils.cleanBarcode(label.barcode.toString()) : ''
-
-              // The first schema was not versioned, so if the field is missing,
-              // we assume it's schema version 1.0
-              const schemaVersion = priceTagPrediction.schema_version || '1.0'
-
-              // fields that are common to all schema versions are initialized here
-              let productPriceForm = {
-                id: data.items[i].id,
-                origins_tags: ![null, '', 'unknown', 'other'].includes(label.origin) ? [label.origin] : [],
-                currency: data.items[i]['proof'].currency || this.appStore.getUserLastCurrencyUsed,
-                proof: data.items[i]['proof'],
-                proofImage: data.items[i]['proof'].file_path,
-                croppedImage: null,
-                product_code: barcodeString,
-                detected_product_code: barcodeString,
-                product_name: label.product_name,
-                bounding_box: data.items[i].bounding_box,
-                loading: false
-              }
-
-              if (schemaVersion === '1.0') {
-                // For schema version 1.0
-                const priceType = barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY
-                productPriceForm.type = priceType
-                productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.product)) ? label.product : null
-                productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
-                productPriceForm.price = label.price.toString()
-                productPriceForm.price_per = label.unit
-                // price_is_discounted is not supported in schema version 1.0
-                productPriceForm.price_is_discounted = false
-              } else {
-                // version 2.0 and above
-                const priceType = label.type
-                // The selected price is a price constructed by all price information available in the label,
-                // including the discount price if available.
-                const selectedPrice = label.selected_price || {}
-                productPriceForm.type = priceType
-                // we only populate category_tag and labels_tags if the price type is category
-                productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.category)) ? label.category : null
-                productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
-                productPriceForm.price = selectedPrice.price ? selectedPrice.price.toString() : ""
-                productPriceForm.price_per = selectedPrice.price_per || null
-                // in schema 2.0, we detect discount information (price, type)
-                productPriceForm.price_is_discounted = selectedPrice ? selectedPrice.price_is_discounted : false
-                productPriceForm.price_without_discount = selectedPrice.price_without_discount ? selectedPrice.price_without_discount.toString() : ""
-                productPriceForm.discount_type = selectedPrice.discount_type || ""
-              }
-
-              this.productPriceForms.push(productPriceForm)
+              this.handlePriceTag(data.items[i])
             }
           }
         })
+    },
+    handlePriceTag(priceTag) {
+      let productPriceForm = proof_utils.handlePriceTag(priceTag)
+      this.productPriceForms.push(productPriceForm)
     },
     updatePriceTag(priceTagId, status, priceId) {
       return api

--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -234,7 +234,6 @@ import { defineAsyncComponent } from 'vue'
 import constants from '../constants.js'
 import api from '../services/api.js'
 import { useAppStore } from '../store.js'
-import barcode_utils from '../utils/barcode.js'
 import geo_utils from '../utils/geo.js'
 import proof_utils from '../utils/proof.js'
 
@@ -458,7 +457,9 @@ export default {
             // Only keep price tags that were selected by the user
             // Note: should we also update ignored price tags to a status of error ?
             this.priceTags = priceTags.filter(priceTag => this.extractedLabels.find(label => label.id === priceTag.id) || newPriceTagIds.includes(priceTag.id))
-            this.handlePriceTags()
+            this.priceTags.forEach(priceTag => {
+              this.handlePriceTag(priceTag)
+            })
           }
         })
       } else {
@@ -467,74 +468,22 @@ export default {
         // Only keep price tags that were selected by the user
         // Note: should we also update ignored price tags to a status of error ?
         this.priceTags = this.priceTags.filter(priceTag => this.extractedLabels.find(label => label.id === priceTag.id))
-        this.handlePriceTags()
+        this.priceTags.forEach(priceTag => {
+          this.handlePriceTag(priceTag)
+        })
       }
-    },
-    handlePriceTags() {
-      this.priceTags.forEach(priceTag => {
-        const priceTagPrediction = priceTag['predictions'][0]
-        const label = priceTagPrediction['data']
-        const barcodeString = label.barcode ? barcode_utils.cleanBarcode(label.barcode.toString()) : ''
-
-        // The first schema was not versioned, so if the field is missing,
-        // we assume it's schema version 1.0
-        const schemaVersion = priceTagPrediction.schema_version || '1.0'
-
-        // fields that are common to all schema versions are initialized here
-        let productPriceForm = {
-          id: priceTag.id,
-          origins_tags: ![null, '', 'unknown', 'other'].includes(label.origin) ? [label.origin] : [],
-          currency: priceTag['proof'].currency || this.appStore.getUserLastCurrencyUsed,
-          proof: priceTag['proof'],
-          proofImage: priceTag['proof'].file_path,
-          croppedImage: null,
-          product_code: barcodeString,
-          detected_product_code: barcodeString,
-          product_name: label.product_name,
-          bounding_box: priceTag.bounding_box,
-          status: priceTag.status,  // specific to the assistant (vs the PVA)
-          price_id: priceTag.price_id,  // specific to the assistant (vs the PVA)
-          loading: false
-        }
-
-        if (schemaVersion === '1.0') {
-          // For schema version 1.0
-          const priceType = barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY
-          productPriceForm.type = priceType
-          productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.product)) ? label.product : null
-          productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
-          productPriceForm.price = label.price.toString()
-          productPriceForm.price_per = label.unit
-          // price_is_discounted is not supported in schema version 1.0
-          productPriceForm.price_is_discounted = false
-        } else {
-          // version 2.0 and above
-          const priceType = label.type
-          // The selected price is a price constructed by all price information available in the label,
-          // including the discount price if available.
-          const selectedPrice = label.selected_price || {}
-          productPriceForm.type = priceType
-          // we only populate category_tag and labels_tags if the price type is category
-          productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.category)) ? label.category : null
-          productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
-          productPriceForm.price = selectedPrice.price ? selectedPrice.price.toString() : ""
-          productPriceForm.price_per = selectedPrice.price_per || null
-          // in schema 2.0, we detect discount information (price, type)
-          productPriceForm.price_is_discounted = selectedPrice ? selectedPrice.price_is_discounted : false
-          productPriceForm.price_without_discount = selectedPrice.price_without_discount ? selectedPrice.price_without_discount.toString() : ""
-          productPriceForm.discount_type = selectedPrice.discount_type || ""
-        }
-
-        if (productPriceForm.price_id) {
-          const proofPriceExisting = this.proofPriceExistingList.find(price => price.id === productPriceForm.price_id)
-          if (proofPriceExisting) {
-            productPriceForm = Object.assign(productPriceForm, proofPriceExisting)
-          }
-        }
-        this.productPriceForms.push(productPriceForm)
-      })
 
       this.step = 3
+    },
+    handlePriceTag(priceTag) {
+      let productPriceForm = proof_utils.handlePriceTag(priceTag)
+      if (productPriceForm.price_id) {
+        const proofPriceExisting = this.proofPriceExistingList.find(price => price.id === productPriceForm.price_id)
+        if (proofPriceExisting) {
+          productPriceForm = Object.assign(productPriceForm, proofPriceExisting)
+        }
+      }
+      this.productPriceForms.push(productPriceForm)
     },
     updatePriceTagStatus(status, productPriceForm) {
       // Called when the user deletes a price during the cleanup step


### PR DESCRIPTION
### What

Following the refactoring in #1616 and the new `utils/proof.js` file.
And following the added complexity in #1606.
We move the identical code in both `ProofPriceTagAssistant` & `PriceValidationAssistant` in the utils file
