### PR TITLE
fix(Price Tag Assistant): PriceTag prediction must have a product or category to be added

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -465,6 +465,7 @@
 			"SendLabelsButton": "Send labels"
 		},
 		"PricesAlreadyAdded": "Prices already added",
+		"PricesWithoutProductOrCategory": "Prices without a product or category",
 		"PricesMarkedAsError": "Prices marked as error",
 		"PriceAddConfirmationMessage": "{numberOfPricesAdded} price(s) will be added to an existing proof on the {date} at {locationName}",
 		"PriceAddProgress": "{numberOfPricesAdded} / {totalNumberOfPrices} prices added",

--- a/src/utils/proof.js
+++ b/src/utils/proof.js
@@ -36,7 +36,15 @@ function handlePriceTag(priceTag) {
   // fields that are common to all schema versions are initialized here
   let productPriceForm = {
     id: priceTag.id,
+    // type  // 'PRODUCT' or 'CATEGORY'
+    // category_tag
+    // labels_tags
     origins_tags: ![null, '', 'unknown', 'other'].includes(label.origin) ? [label.origin] : [],
+    // price
+    // price_per
+    // price_is_discounted
+    // price_without_discount
+    // discount_type
     currency: priceTag['proof'].currency, // || this.appStore.getUserLastCurrencyUsed,
     proof: priceTag['proof'],
     proofImage: priceTag['proof'].file_path,
@@ -54,6 +62,7 @@ function handlePriceTag(priceTag) {
     // For schema version 1.0
     const priceType = barcodeString.length >= 8 ? constants.PRICE_TYPE_PRODUCT : constants.PRICE_TYPE_CATEGORY
     productPriceForm.type = priceType
+    // we only populate category_tag and labels_tags if the price type is category
     productPriceForm.category_tag = (priceType === constants.PRICE_TYPE_CATEGORY && ![null, '', 'unknown', 'other'].includes(label.product)) ? label.product : null
     productPriceForm.labels_tags = (priceType === constants.PRICE_TYPE_CATEGORY && label.organic) ? [constants.PRODUCT_CATEGORY_LABEL_ORGANIC] : []
     productPriceForm.price = label.price.toString()


### PR DESCRIPTION
### What

Add a new section for PriceTag predictions that lack a product or category

### Screenshot

<img width="1137" height="934" alt="image" src="https://github.com/user-attachments/assets/c015f316-d5dd-4996-8e2c-8179910ea985" />
