### PR TITLE
fix(PriceTagAssistant): properly mark drawn price tags as Manual instead of Automatic

### DIFF
--- a/src/components/ContributionAssistantDrawCanvas.vue
+++ b/src/components/ContributionAssistantDrawCanvas.vue
@@ -75,13 +75,13 @@
           this.boundingBoxes = [] // reset boundingBoxes
         }
         if (this.boundingBoxesFromServer) {
-          this.boundingBoxes = this.boundingBoxes.concat(this.boundingBoxesFromServer.map(({boundingBox, id, status}) => {
+          this.boundingBoxes = this.boundingBoxes.concat(this.boundingBoxesFromServer.map(({boundingBox, id, status, created_by	}) => {
             return {
               startY: boundingBox[0] * this.image.height,
               startX: boundingBox[1] * this.image.width,
               endY: boundingBox[2] * this.image.height,
               endX: boundingBox[3] * this.image.width,
-              boundingSource: this.$t('ContributionAssistant.AutomaticBoundingBoxSource'),
+              boundingSource: created_by ? this.$t('ContributionAssistant.ManualBoundingBoxSource') : this.$t('ContributionAssistant.AutomaticBoundingBoxSource'),
               id: id,
               status: status
             }

--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -420,7 +420,7 @@ export default {
         this.loadPriceTagsWithPredictions(1, maxTries, priceTags => {
           this.priceTags = priceTags
           this.boundingBoxesFromServer = this.priceTags.map(priceTag => {
-            return {boundingBox: priceTag.bounding_box, id: priceTag.id, status: priceTag.status}
+            return {boundingBox: priceTag.bounding_box, id: priceTag.id, status: priceTag.status, created_by: priceTag.created_by}
           })
           this.proofWithBoundingBoxesLoading = false
         })


### PR DESCRIPTION
### What
- Before: bounding boxes where always set to "automatic" when created beforehand, an "manual" only when draw right away
- Now: consider who created the bounding box, if an user is mentionned, set it to "manual"
- See issue below for more info

### Fixes bug(s)
- Fixes #1637

