### PR TITLE
fix(ReceiptAssistant): fix editing price and product in place & new item addition

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -264,7 +264,7 @@ export default {
         category_tag: ![null, '', 'unknown', 'other'].includes(item.category_tag) ? item.category_tag : null,
         origins_tags: [],
         labels_tags: [],
-        price: item.price ? item.price.toString() : item.predicted_data.price.toString(),
+        price: item.price ? item.price.toString() : (item.predicted_data.price ? item.predicted_data.price.toString() : null),
         price_per: item.price_per,
         price_is_discounted: item.price_is_discounted,
         price_without_discount: item.price_without_discount ? item.price_without_discount.toString() : null,

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -24,7 +24,7 @@
           <PriceCategoryChip v-if="item.isCategory" :priceCategory="item.category_tag" />
           <v-text-field 
             v-else-if="!item.productFound"
-            :model-value="item.product_code"
+            v-model="item.product_code"
             :hide-details="true"
             density="compact"
             :rules="rules"
@@ -36,7 +36,7 @@
         </template>
         <template #[`item.price`]="{ item }">
           <v-text-field
-            :model-value="item.price"
+            v-model="item.price"
             :suffix="itemPriceSuffix(item)"
             :hide-details="true"
             density="compact"

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -154,7 +154,7 @@ export default {
       // item.productFound means the product was explicitly selected by the user
       if (!this.receiptItems) return []
       const isProductValid = item => item.isCategory ? item.category_tag : item.product_code
-      return this.receiptItems.filter(item => item.predicted_data.price && isProductValid(item))
+      return this.receiptItems.filter(item => item.price && isProductValid(item))
     },
     validNewReceiptItems() {
       return this.validReceiptItems.filter(item => !item.price_id)


### PR DESCRIPTION
### What
- Newly created ReceiptItems were ignored because they weren't considered as valid items
    - Also fixes linked issue: _"Justin told me recently that prices without a product name are not uploaded"_
- Edit button wasn't working on newly created ReceiptItems 
- Rollback two-way binding (see #1639) that was forcing users to open the edit menu, instead of making edits directly on the table (price and product were ignored)

### Screenshot
- See videos in linked issue

### Fixes bug(s)
- Fixes #1639 

