### PR TITLE
feat(ReceiptAssitant): suggest product codes based on product names

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -37,7 +37,7 @@
               <span
                 class="text-primary font-weight-medium"
                 style="cursor: pointer;"
-                @click="item.product_code = item.predicted_product_code"
+                @click="handleClickProductCodeSuggestion(item)"
               >
                 {{ item.predicted_product_code }}
               </span>
@@ -307,6 +307,10 @@ export default {
       this.barcodeScannerDialog = false
       this.barcodeScannerItem.product_code = code
       this.findProduct(this.barcodeScannerItem)
+    },
+    handleClickProductCodeSuggestion(item) {
+      item.product_code = item.predicted_product_code
+      this.findProduct(item)
     }
   }
 }

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -22,16 +22,27 @@
         </template>
         <template #[`item.product`]="{ item }">
           <PriceCategoryChip v-if="item.isCategory" :priceCategory="item.category_tag" />
-          <v-text-field 
-            v-else-if="!item.productFound"
-            :model-value="item.product_code"
-            :hide-details="true"
-            density="compact"
-            :rules="rules"
-            :append-inner-icon="item.product_code ? 'mdi-magnify' : 'mdi-barcode-scan'"
-            @click:append-inner="item.product_code ? findProduct(item) : launchBarcodeScanner(item)"
-            @keydown.enter="findProduct(item)"
-          />
+          <v-container v-else-if="!item.productFound">
+            <v-text-field 
+              v-model="item.product_code"
+              :hide-details="true"
+              density="compact"
+              :rules="rules"
+              :append-inner-icon="item.product_code ? 'mdi-magnify' : 'mdi-barcode-scan'"
+              @click:append-inner="item.product_code ? findProduct(item) : launchBarcodeScanner(item)"
+              @keydown.enter="findProduct(item)"
+            />
+            <div v-if="item.predicted_product_code" class="text-caption">
+              {{ $t('Common.SuggestedBarcode') }}
+              <span
+                class="text-primary font-weight-medium"
+                style="cursor: pointer;"
+                @click="item.product_code = item.predicted_product_code"
+              >
+                {{ item.predicted_product_code }}
+              </span>
+            </div>
+          </v-container>
           <ProductCard v-else :product="item.productFound" :hideCategoriesAndLabels="true" :hideActionMenuButton="true" :readonly="true" elevation="1" />
         </template>
         <template #[`item.price`]="{ item }">
@@ -217,6 +228,7 @@ export default {
           }
           item.price = item.predicted_data.price || null
           item.product_name = item.predicted_data.product_name || ''
+          item.predicted_product_code = item.predicted_data.predicted_product_code || null
         }
         return item
       })
@@ -264,7 +276,7 @@ export default {
         category_tag: ![null, '', 'unknown', 'other'].includes(item.category_tag) ? item.category_tag : null,
         origins_tags: [],
         labels_tags: [],
-        price: item.price ? item.price.toString() : item.predicted_data.price.toString(),
+        price: item.price ? item.price.toString() : (item.predicted_data.price ? item.predicted_data.price.toString() : null),
         price_per: item.price_per,
         price_is_discounted: item.price_is_discounted,
         price_without_discount: item.price_without_discount ? item.price_without_discount.toString() : null,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -403,6 +403,7 @@
 		"SourceCode": "Source code",
 		"Start": "Start",
 		"Stats": "Stats",
+		"SuggestedBarcode": "Suggested barcode :",
 		"Summary": "Summary",
 		"TaglineOriginal": "An open crowdsourced database of food prices",
 		"TaglineAlt1": "The open crowdsourced database of prices",


### PR DESCRIPTION
### What
- Uses predicted generated with backend PR: https://github.com/openfoodfacts/open-prices/pull/952

### Screenshot
<img width="1201" height="510" alt="image" src="https://github.com/user-attachments/assets/83cb3b96-1fdb-445f-8e0b-5dab4de0cd21" />

### Demo gif
![Timeline-12(1)](https://github.com/user-attachments/assets/6cb93c90-b9c6-4e9d-8f89-84b04dcbb730)

### Notes
The current UI requires users to click on the suggested barcode to see associated product.
If the user is unhappy with the suggestion, they would have to edit the product using the edit button on the side, which might not be intuitive.

In the backend PR @teolemon suggested some other interaction, using hover or showing more info, not sure how to make it look nice.