### PR TITLE
Raphodn/challenge detail stats

### DIFF
--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -16,11 +16,8 @@
     </v-card-text>
     <v-card-text>
       <v-row>
-        <v-col cols="6">
-          <StatCard :value="challenge.numberOfProofs" :subtitle="statSubtitleProofCount" :to="getChallengeProofListUrl" />
-        </v-col>
-        <v-col cols="6">
-          <StatCard :value="challenge.userProofContributions" :subtitle="statSubtitleProofOwnerCount" />
+        <v-col>
+          <StatCard :value="challenge.userProofContributions" :subtitle="$t('Common.PicturesAddedByYou')" />
         </v-col>
       </v-row>
     </v-card-text>
@@ -53,16 +50,5 @@ export default {
       default: () => {}
     }
   },
-  computed: {
-    statSubtitleProofCount() {
-      return this.$vuetify.display.smAndUp ? this.$t('Common.PicturesAdded') : this.$t('Common.Pictures')
-    },
-    statSubtitleProofOwnerCount() {
-      return this.$vuetify.display.smAndUp ? this.$t('Common.PicturesAddedByYou') : this.$t('Common.PicturesByYou')
-    },
-    getChallengeProofListUrl() {
-      return `/challenges/${this.challenge.id}/proofs`
-    }
-  }
 }
 </script>

--- a/src/components/ChallengeValidateCard.vue
+++ b/src/components/ChallengeValidateCard.vue
@@ -19,11 +19,8 @@
     </v-card-text>
     <v-card-text class="flex-grow-0">
       <v-row>
-        <v-col cols="6">
-          <StatCard :value="challenge.numberOfContributions" :subtitle="statSubtitlePriceCount" :to="getChallengePriceListUrl" />
-        </v-col>
-        <v-col cols="6">
-          <StatCard :value="challenge.userContributions" :subtitle="statSubtitlePriceOwnerCount" />
+        <v-col>
+          <StatCard :value="challenge.userContributions" :subtitle="$t('Common.PricesAddedByYou')" />
         </v-col>
       </v-row>
     </v-card-text>
@@ -56,16 +53,5 @@ export default {
       default: () => {}
     }
   },
-  computed: {
-    statSubtitlePriceCount() {
-      return this.$vuetify.display.smAndUp ? this.$t('Challenge.PricesAdded', { challenge_title: this.challenge.title }) : this.$t('Challenge.Prices', { challenge_title: this.challenge.title })
-    },
-    statSubtitlePriceOwnerCount() {
-      return this.$vuetify.display.smAndUp ? this.$t('Challenge.PricesAddedByYou', { challenge_title: this.challenge.title }) : this.$t('Challenge.PricesByYou', { challenge_title: this.challenge.title })
-    },
-    getChallengePriceListUrl() {
-      return `/challenges/${this.challenge.id}/prices`
-    }
-  }
 }
 </script>

--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-card>
+    <template #title>
+      <small>{{ title }}</small>
+    </template>
+  
+    <v-card-text>
+      <v-data-table :headers="headers" :items="items" hide-default-header hide-default-footer items-per-page="100">
+        <template #[`item.rank`]="{ index }">
+          {{ index + 1 }}
+        </template>
+        <template #[`item.owner`]="{ item }">
+          {{ item.owner }}
+        </template>
+        <template #[`item.country`]="{ item }">
+          {{ item.country }}
+        </template>
+        <template #[`item.count`]="{ item }">
+          {{ item.count }}
+        </template>
+      </v-data-table>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    items: {
+      type: Array,
+      default: () => []
+    },
+  },
+  computed: {
+    headers() {
+      let allHeaders = [
+        { text: this.$t('Common.Rank'), key: 'rank', width: '10%' },
+        { text: this.$t('Common.User'), key: 'owner' },
+        { text: this.$t('Common.Country'), key: 'country' },
+        { text: this.$t('Common.Count'), key: 'count' },
+      ]
+      return allHeaders.filter((header, index) => index === 0 || this.items.some(item => item[header.key] !== undefined))
+    }
+  }
+}
+</script>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -145,7 +145,7 @@
 		"Prices": "{challenge_title} prices",
 		"PricesAdded": "{challenge_title} prices added",
 		"PricesByYou": "{challenge_title} prices by you",
-		"PricesAddedByYou": "{challenge_title} prices added by you",
+		"PricesAddedByYou": "Prices added by you",
 		"MostRecentContributions": "Most recent contributions",
 		"ChallengeCount": "{count} challenges | {count} challenge | {count} challenges",
 		"ChallengeStatuses": {
@@ -158,7 +158,8 @@
 		"PastOrFutureChallenges": "Past or future challenges",
 		"OngoingChallenges": "Ongoing challenges",
 		"PastChallenges": "Past challenges",
-		"UpcomingChallenges": "Upcoming challenges"
+		"UpcomingChallenges": "Upcoming challenges",
+		"StatsAndRankings": "Stats & rankings"
 	},
 	"Common": {
 		"About": "About",
@@ -359,6 +360,7 @@
 		"PricesAddedToday": "Prices added today",
 		"PricesToday": "Prices today",
 		"PriceNotFound": "Price not found",
+		"PricesAddedByYou": "Prices added by you",
 		"Private": "Private",
 		"Privacy": "Privacy",
 		"ProductCount": "{count} products | {count} product | {count} products",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -159,7 +159,9 @@
 		"OngoingChallenges": "Ongoing challenges",
 		"PastChallenges": "Past challenges",
 		"UpcomingChallenges": "Upcoming challenges",
-		"StatsAndRankings": "Stats & rankings"
+		"StatsAndRankings": "Stats & rankings",
+		"MostPicturesAdded": "Most pictures added",
+		"MostPricesAdded": "Most prices added"
 	},
 	"Common": {
 		"About": "About",
@@ -418,6 +420,8 @@
 		"TopContributors": "Top contributors",
 		"TopLocations": "Top locations",
 		"TopProducts": "Top products",
+		"TopCities": "Top cities",
+		"TopCountries": "Top countries",
 		"Today": "Today",
 		"Top": "Top",
 		"Total": "Total",

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -60,6 +60,17 @@
           <StatCard :value="challenge.stats.price_product_count" :subtitle="$t('Common.Products')" />
         </v-col>
       </v-row>
+      <v-row>
+        <v-col cols="12" sm="6" md="4">
+          <RankingTableCard :title="$t('Challenge.MostPicturesAdded')" :items="challenge.stats.user_proof_count_ranking" />
+        </v-col>
+        <v-col cols="12" sm="6" md="4">
+          <RankingTableCard :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" />
+        </v-col>
+        <v-col cols="12" sm="6" md="4">
+          <RankingTableCard :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" />
+        </v-col>
+      </v-row>
     </v-col>
     <v-col cols="12">
       <i18n-t keypath="Stats.LastUpdated" tag="span" :title="getRelativeDateTimeFormatted(challenge.stats.updated)">
@@ -97,6 +108,7 @@ export default {
     ChallengeTakePicturesCard: defineAsyncComponent(() => import('../components/ChallengeTakePicturesCard.vue')),
     ChallengeValidateCard: defineAsyncComponent(() => import('../components/ChallengeValidateCard.vue')),
     StatCard: defineAsyncComponent(() => import('../components/StatCard.vue')),
+    RankingTableCard: defineAsyncComponent(() => import('../components/RankingTableCard.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
   },
   data() {

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -36,6 +36,40 @@
     </v-col>
   </v-row>
 
+  <v-row v-if="challenge?.stats">
+    <v-col cols="12" class="pb-0">
+      <h2 class="text-h6">
+        {{ $t('Challenge.StatsAndRankings') }}
+      </h2>
+    </v-col>
+    <v-col>
+      <v-row>
+        <v-col cols="6" sm="4" md="3" lg="2">
+          <StatCard :value="challenge.numberOfProofs" :subtitle="$t('Common.Pictures')" :to="getChallengeProofListUrl" />
+        </v-col>
+        <v-col cols="6" sm="4" md="3" lg="2">
+          <StatCard :value="challenge.numberOfContributions" :subtitle="$t('Common.Prices')" :to="getChallengePriceListUrl" />
+        </v-col>
+        <v-col cols="6" sm="4" md="3" lg="2">
+          <StatCard :value="challenge.stats.user_count" :subtitle="$t('Common.Contributors')" />
+        </v-col>
+        <v-col cols="6" sm="4" md="3" lg="2">
+          <StatCard :value="challenge.stats.proof_location_count" :subtitle="$t('Common.Locations')" />
+        </v-col>
+        <v-col cols="6" sm="4" md="3" lg="2">
+          <StatCard :value="challenge.stats.price_product_count" :subtitle="$t('Common.Products')" />
+        </v-col>
+      </v-row>
+    </v-col>
+    <v-col cols="12">
+      <i18n-t keypath="Stats.LastUpdated" tag="span" :title="getRelativeDateTimeFormatted(challenge.stats.updated)">
+        <template #date>
+          {{ getDateTimeFormatted(challenge.stats.updated) }}
+        </template>
+      </i18n-t>
+    </v-col>
+  </v-row>
+
   <v-row v-if="challenge?.latestContributions?.length">
     <v-col cols="12" class="pb-0">
       <h2 class="text-h6">
@@ -53,6 +87,7 @@ import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api.js'
+import date_utils from '../utils/date.js'
 
 export default {
   components: {
@@ -61,6 +96,7 @@ export default {
     ChallengeTimeline: defineAsyncComponent(() => import('../components/ChallengeTimeline.vue')),
     ChallengeTakePicturesCard: defineAsyncComponent(() => import('../components/ChallengeTakePicturesCard.vue')),
     ChallengeValidateCard: defineAsyncComponent(() => import('../components/ChallengeValidateCard.vue')),
+    StatCard: defineAsyncComponent(() => import('../components/StatCard.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
   },
   data() {
@@ -79,6 +115,12 @@ export default {
         tags__contains: `challenge-${this.challenge.id}`
       }
     },
+    getChallengeProofListUrl() {
+      return `/challenges/${this.challenge.id}/proofs`
+    },
+    getChallengePriceListUrl() {
+      return `/challenges/${this.challenge.id}/prices`
+    }
   },
   mounted() {
     this.getChallenge()
@@ -132,7 +174,13 @@ export default {
       .then((data) => {
         this.challenge.latestContributions = data.items
       })
-    }
+    },
+    getDateTimeFormatted(dateTimeString) {
+      return date_utils.offDateTime(dateTimeString)
+    },
+    getRelativeDateTimeFormatted(dateTimeString) {
+      return date_utils.prettyRelativeDateTime(dateTimeString, 'short')
+    },
   }
 }
 </script>


### PR DESCRIPTION
### What

Following new stats in the backend (see https://github.com/openfoodfacts/open-prices/issues/996), we start displaying them in the frontend

### Screenshot

<img width="1190" height="578" alt="image" src="https://github.com/user-attachments/assets/46631d11-ba94-4436-afe6-d187b49762cf" />

<img width="1190" height="733" alt="image" src="https://github.com/user-attachments/assets/13a8a875-dc30-4e1f-bab2-5c3bb3c78349" />
