### PR TITLE
refactor(Challenges): improve display of ranking stats

### DIFF
--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -72,10 +72,10 @@ export default {
   },
   methods: {
     getLocationTitle(location) {
-      return geo_utils.getLocationOSMTitle(location, true, false, true, true) 
+      return geo_utils.getLocationOSMTitle(location, true, false, true, false, true) 
     },
     getCityCountryTitle(location) {
-      return location.osm_address_city ? `${location.osm_address_city}, ${location.osm_address_country}` : location.osm_address_country
+      return geo_utils.getLocationOSMTitle(location, false, false, true, true, true) 
     },
   }
 }

--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -20,7 +20,9 @@
           <ProductCard :product="item" :hidePriceCount="true" :hideCategoriesAndLabels="true" :hideActionMenuButton="true" :readonly="true" elevation="1" />
         </template>
         <template #[`item.count`]="{ item }">
-          {{ item.count }}
+          <div class="float-right">
+            {{ item.count }}
+          </div>
         </template>
       </v-data-table>
     </v-card-text>

--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -12,8 +12,12 @@
         <template #[`item.owner`]="{ item }">
           {{ item.owner }}
         </template>
-        <template #[`item.country`]="{ item }">
-          {{ item.country }}
+        <template #[`item.osm_address_country`]="{ item }">
+          <span v-if="item.id">{{ getLocationTitle(item) }}</span>
+          <span v-else>{{ getCityCountryTitle(item) }}</span>
+        </template>
+        <template #[`item.product_name`]="{ item }">
+          <ProductCard :product="item" :hidePriceCount="true" :hideCategoriesAndLabels="true" :hideActionMenuButton="true" :readonly="true" elevation="1" />
         </template>
         <template #[`item.count`]="{ item }">
           {{ item.count }}
@@ -24,7 +28,13 @@
 </template>
 
 <script>
+import { defineAsyncComponent } from 'vue'
+import geo_utils from '../utils/geo.js'
+
 export default {
+  components: {
+    ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
+  },
   props: {
     title: {
       type: String,
@@ -37,21 +47,34 @@ export default {
     itemsDisplayedCount: {
       type: Number,
       default: 3
+    },
+    hideRank: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
     headers() {
       let allHeaders = [
         { text: this.$t('Common.Rank'), key: 'rank', width: '10%' },
-        { text: this.$t('Common.User'), key: 'owner' },
-        { text: this.$t('Common.Country'), key: 'osm_address_country' },
+        { text: this.$t('Common.User'), key: 'owner' },  // field only in user ranking
+        { text: this.$t('Common.Country'), key: 'osm_address_country' },  // field only in location rankings
+        { text: this.$t('Common.Product'), key: 'product_name' },  // field only in product ranking
         { text: this.$t('Common.Count'), key: 'count' },
       ]
-      return allHeaders.filter((header, index) => index === 0 || this.items.some(item => item[header.key] !== undefined))
+      return allHeaders.filter((header, index) => (!this.hideRank && index === 0) || this.items.some(item => item[header.key] !== undefined))
     },
     itemsDisplayed() {
       return this.items.slice(0, this.itemsDisplayedCount)
     }
+  },
+  methods: {
+    getLocationTitle(location) {
+      return geo_utils.getLocationOSMTitle(location, true, false, true, true) 
+    },
+    getCityCountryTitle(location) {
+      return location.osm_address_city ? `${location.osm_address_city}, ${location.osm_address_country}` : location.osm_address_country
+    },
   }
 }
 </script>

--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -5,7 +5,7 @@
     </template>
   
     <v-card-text>
-      <v-data-table :headers="headers" :items="items" hide-default-header hide-default-footer items-per-page="100">
+      <v-data-table :headers="headers" :items="itemsDisplayed" hide-default-header hide-default-footer items-per-page="100">
         <template #[`item.rank`]="{ index }">
           {{ index + 1 }}
         </template>
@@ -34,6 +34,10 @@ export default {
       type: Array,
       default: () => []
     },
+    itemsDisplayedCount: {
+      type: Number,
+      default: 3
+    }
   },
   computed: {
     headers() {
@@ -44,6 +48,9 @@ export default {
         { text: this.$t('Common.Count'), key: 'count' },
       ]
       return allHeaders.filter((header, index) => index === 0 || this.items.some(item => item[header.key] !== undefined))
+    },
+    itemsDisplayed() {
+      return this.items.slice(0, this.itemsDisplayedCount)
     }
   }
 }

--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -40,7 +40,7 @@ export default {
       let allHeaders = [
         { text: this.$t('Common.Rank'), key: 'rank', width: '10%' },
         { text: this.$t('Common.User'), key: 'owner' },
-        { text: this.$t('Common.Country'), key: 'country' },
+        { text: this.$t('Common.Country'), key: 'osm_address_country' },
         { text: this.$t('Common.Count'), key: 'count' },
       ]
       return allHeaders.filter((header, index) => index === 0 || this.items.some(item => item[header.key] !== undefined))

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -161,7 +161,8 @@
 		"UpcomingChallenges": "Upcoming challenges",
 		"StatsAndRankings": "Stats & rankings",
 		"MostPicturesAdded": "Most pictures added",
-		"MostPricesAdded": "Most prices added"
+		"MostPricesAdded": "Most prices added",
+		"MostPricesFromPicturesAdded": "Most prices from pictures added"
 	},
 	"Common": {
 		"About": "About",

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -63,7 +63,8 @@
       <v-row>
         <v-col cols="12" sm="6" md="4">
           <RankingTableCard class="mb-4" :title="$t('Challenge.MostPicturesAdded')" :items="challenge.stats.user_proof_count_ranking" :hideRank="true" />
-          <RankingTableCard :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" :hideRank="true" />
+          <RankingTableCard class="mb-4" :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" :hideRank="true" />
+          <RankingTableCard :title="$t('Challenge.MostPricesFromPicturesAdded')" :items="challenge.stats.user_price_from_proof_count_ranking" :hideRank="true" />
         </v-col>
         <v-col cols="12" sm="6" md="4">
           <RankingTableCard class="mb-4" :title="$t('Common.TopLocations')" :items="challenge.stats.location_price_count_ranking" :hideRank="true" />

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -68,8 +68,8 @@
         </v-col>
         <v-col cols="12" sm="6" md="4">
           <RankingTableCard class="mb-4" :title="$t('Common.TopLocations')" :items="challenge.stats.location_price_count_ranking" :hideRank="true" />
-          <RankingTableCard class="mb-4" :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" :hideRank="true" />
-          <RankingTableCard :title="$t('Common.TopCities')" :items="challenge.stats.location_city_price_count_ranking" :hideRank="true" />
+          <RankingTableCard class="mb-4" :title="$t('Common.TopCities')" :items="challenge.stats.location_city_price_count_ranking" :hideRank="true" />
+          <RankingTableCard :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" :hideRank="true" />
         </v-col>
         <v-col cols="12" sm="6" md="4">
           <RankingTableCard :title="$t('Common.TopProducts')" :items="challenge.stats.product_price_count_ranking" :hideRank="true" />

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -62,16 +62,16 @@
       </v-row>
       <v-row>
         <v-col cols="12" sm="6" md="4">
-          <RankingTableCard class="mb-4" :title="$t('Challenge.MostPicturesAdded')" :items="challenge.stats.user_proof_count_ranking" />
-          <RankingTableCard :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" />
+          <RankingTableCard class="mb-4" :title="$t('Challenge.MostPicturesAdded')" :items="challenge.stats.user_proof_count_ranking" :hideRank="true" />
+          <RankingTableCard :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" :hideRank="true" />
         </v-col>
         <v-col cols="12" sm="6" md="4">
-          <RankingTableCard class="mb-4" :title="$t('Common.TopLocations')" :items="challenge.stats.location_price_count_ranking" />
-          <RankingTableCard class="mb-4" :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" />
-          <RankingTableCard :title="$t('Common.TopCities')" :items="challenge.stats.location_city_price_count_ranking" />
+          <RankingTableCard class="mb-4" :title="$t('Common.TopLocations')" :items="challenge.stats.location_price_count_ranking" :hideRank="true" />
+          <RankingTableCard class="mb-4" :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" :hideRank="true" />
+          <RankingTableCard :title="$t('Common.TopCities')" :items="challenge.stats.location_city_price_count_ranking" :hideRank="true" />
         </v-col>
         <v-col cols="12" sm="6" md="4">
-          <RankingTableCard :title="$t('Common.TopProducts')" :items="challenge.stats.product_price_count_ranking" />
+          <RankingTableCard :title="$t('Common.TopProducts')" :items="challenge.stats.product_price_count_ranking" :hideRank="true" />
         </v-col>
       </v-row>
     </v-col>

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -66,12 +66,12 @@
           <RankingTableCard :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" />
         </v-col>
         <v-col cols="12" sm="6" md="4">
-          <RankingTableCard :title="$t('Common.TopProducts')" :items="challenge.stats.product_price_count_ranking" />
-        </v-col>
-        <v-col cols="12" sm="6" md="4">
           <RankingTableCard class="mb-4" :title="$t('Common.TopLocations')" :items="challenge.stats.location_price_count_ranking" />
           <RankingTableCard class="mb-4" :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" />
           <RankingTableCard :title="$t('Common.TopCities')" :items="challenge.stats.location_city_price_count_ranking" />
+        </v-col>
+        <v-col cols="12" sm="6" md="4">
+          <RankingTableCard :title="$t('Common.TopProducts')" :items="challenge.stats.product_price_count_ranking" />
         </v-col>
       </v-row>
     </v-col>

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -62,13 +62,16 @@
       </v-row>
       <v-row>
         <v-col cols="12" sm="6" md="4">
-          <RankingTableCard :title="$t('Challenge.MostPicturesAdded')" :items="challenge.stats.user_proof_count_ranking" />
-        </v-col>
-        <v-col cols="12" sm="6" md="4">
+          <RankingTableCard class="mb-4" :title="$t('Challenge.MostPicturesAdded')" :items="challenge.stats.user_proof_count_ranking" />
           <RankingTableCard :title="$t('Challenge.MostPricesAdded')" :items="challenge.stats.user_price_count_ranking" />
         </v-col>
         <v-col cols="12" sm="6" md="4">
-          <RankingTableCard :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" />
+          <RankingTableCard :title="$t('Common.TopProducts')" :items="challenge.stats.product_price_count_ranking" />
+        </v-col>
+        <v-col cols="12" sm="6" md="4">
+          <RankingTableCard class="mb-4" :title="$t('Common.TopLocations')" :items="challenge.stats.location_price_count_ranking" />
+          <RankingTableCard class="mb-4" :title="$t('Common.TopCountries')" :items="challenge.stats.location_country_price_count_ranking" />
+          <RankingTableCard :title="$t('Common.TopCities')" :items="challenge.stats.location_city_price_count_ranking" />
         </v-col>
       </v-row>
     </v-col>


### PR DESCRIPTION
### What

Following #1674
- limit ranking to 3 and hide rank column
- display new location rankings - thanks to https://github.com/openfoodfacts/open-prices/issues/1001
- display new product ranking - thanks to https://github.com/openfoodfacts/open-prices/issues/1003

### Todo

- display the top 10 after clicking on a button ?

### Screenshot

<img width="1195" height="857" alt="image" src="https://github.com/user-attachments/assets/c9139464-c802-41d6-9442-03443857915f" />

