### PR TITLE
refactor(User card): show all stats (even if 0 or 1)

### DIFF
--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -9,17 +9,17 @@
       <v-row>
         <v-col :cols="hideActionMenuButton ? '12' : '11'">
           <PriceCountChip class="mr-1" :count="user.price_count" :withLabel="true" />
-          <v-chip v-if="user.price_currency_count > 1" label size="small" density="comfortable" class="mr-1">
+          <v-chip class="mr-1" label size="small" density="comfortable">
             <v-icon start icon="mdi-cash" />
-            <span id="currency-count">{{ $t('Common.CurrencyCount', { count: user.price_currency_count }) }}</span>
+            <span id="currency-count">{{ $t('Common.CurrencyCount', { count: user.currency_count }) }}</span>
           </v-chip>
           <LocationCountChip class="mr-1" :count="user.location_count" :withLabel="true" />
-          <v-chip v-if="user.location_type_osm_country_count > 1" label size="small" density="comfortable" class="mr-1">
+          <v-chip class="mr-1" label size="small" density="comfortable">
             <v-icon start icon="mdi-map-outline" />
             <span id="country-count">{{ $t('Common.CountryCount', { count: user.location_type_osm_country_count }) }}</span>
           </v-chip>
-          <ProductCountChip v-if="user.product_count" class="mr-1" :count="user.product_count" :withLabel="true" />
-          <ProofCountChip v-if="user.proof_count" class="mr-1" :count="user.proof_count" :withLabel="true" :to="getUserProofListUrl" />
+          <ProductCountChip class="mr-1" :count="user.product_count" :withLabel="true" />
+          <ProofCountChip class="mr-1" :count="user.proof_count" :withLabel="true" :to="getUserProofListUrl" />
         </v-col>
       </v-row>
 


### PR DESCRIPTION
### What

User card
- rename price_currency_count to currency_count (following https://github.com/openfoodfacts/open-prices/pull/1006)
- always show currency_count, location_type_osm_country_count, product_count & price_count (even if = 0)

### Screenshot

|Before|After|
|-|-|
|<img width="447" height="132" alt="image" src="https://github.com/user-attachments/assets/2f36bca7-59e9-4e85-9629-1f0d8e74a8c0" />|<img width="447" height="132" alt="image" src="https://github.com/user-attachments/assets/983f5549-d7fd-44c7-aca8-f6b7ba734aea" />|
