### PR TITLE
fix(ProofPriceTagAssistant): fixed manual boxes addition + increase the time to fetch predicted price tags

### DIFF
--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -388,27 +388,25 @@ export default {
       })
     },
     onProofUploaded(proof) {
+      // move to step 2
+      this.step = 2
+      // store the proof
+      this.proofObject = proof
       // A new proof was selected by the user, or loaded from the query param
       this.extractedLabels = []
       this.productPriceForms = []
       this.boundingBoxesFromServer = []
-
-      // store the proof
-      this.proofObject = proof
-
       // proof image
       const image = new Image()
       image.src = proof_utils.getImageFullUrl(proof.file_path)
       image.crossOrigin = 'Anonymous'
       this.image = image
-
-      this.step = 2
       if (proof.type === constants.PROOF_TYPE_RECEIPT) {
         // No need to check for price tags on receipts
         this.priceTags = []
         this.boundingBoxesFromServer = []
       } else {
-        let maxTries = 5
+        let maxTries = 10
         const oneDayInMs = 24 * 60 * 60 * 1000
         const proofCreatedDate = new Date(proof.created)
         if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
@@ -442,7 +440,7 @@ export default {
               callback([])
               return
             }
-            setTimeout(load, 3000)
+            setTimeout(load, 5000)  //   // maximum wait time: maxTries * 5s (50s)
           }
         })
       }


### PR DESCRIPTION
### What
- Gives more time for ml processing, since new models are slower (~30~ 50 seconds instead of 15)
- Properly waits for ml reply before moving to step 3
- Avoids sending duplicates bounding boxes to server (bug introduced by PR https://github.com/openfoodfacts/open-prices-frontend/pull/1638)
- Avoids affecting products to the wrong pricetag when moving pricetag away from the "Prices without a product or category" list


### Fixes bug(s)
- Fixes https://github.com/openfoodfacts/open-prices-frontend/issues/1690
- Fixes https://github.com/openfoodfacts/open-prices-frontend/issues/1689

