### PR TITLE
refactor(Receipt Assistant): avoid calling the proof API twice

### DIFF
--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -407,12 +407,6 @@ export default {
         this.boundingBoxesFromServer = []
       } else {
         let maxTries = 10
-        const oneDayInMs = 24 * 60 * 60 * 1000
-        const proofCreatedDate = new Date(proof.created)
-        if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
-          // Only try once on old proofs
-          maxTries = 1
-        }
         this.proofWithBoundingBoxesLoading = true
         // Try to load any automatically detected price tags on proof upload
         this.loadPriceTagsWithPredictions(1, maxTries, priceTags => {
@@ -426,10 +420,16 @@ export default {
       this.getExistingProofPrices(this.proofObject.id)
     },
     loadPriceTagsWithPredictions(minNumberOfPriceTagWithPredictions, maxTries, callback) {
-      // Call price tag API every 3 seconds until we have at least minNumberOfPriceTagWithPredictions, max 6 times
+      // Call price tag API until we have at least minNumberOfPriceTagWithPredictions
       // Question: callback vs Promise ? Neither are really used in the rest of the code base
       let tries = 0
       const load = () => {
+        const oneDayInMs = 24 * 60 * 60 * 1000
+        const proofCreatedDate = new Date(this.proofObject.created)
+        if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
+          // Only try once on old proofs
+          maxTries = 1
+        }
         api.getPriceTags({proof_id: this.proofObject.id, size: 100}).then(data => {
           const priceTagsWithPredictions = data.items.filter(priceTag => priceTag.predictions && priceTag.predictions.length)
           if (priceTagsWithPredictions.length >= minNumberOfPriceTagWithPredictions) {

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -190,38 +190,39 @@ export default {
       // store the proof
       this.proofObject = proof
       // load the receipt items
+      let maxTries = 10
       this.loadingPredictions = true
-      this.loadProofWithReceiptItems(proof.id, 10, proof => {
-        api.getPrices({proof_id: proof.id}).then(data => {
+      this.loadProofWithReceiptItems(maxTries, receiptItems => {
+        this.receiptItems = receiptItems
+        api.getPrices({proof_id: this.proofObject.id}).then(data => {
           this.loadingPredictions = false
           this.proofPriceExistingList = data.items
         })
       })
     },
-    loadProofWithReceiptItems(proofId, maxTries, callback) {
+    loadProofWithReceiptItems(maxTries, callback) {
+      // Call receipt items API until we have at least one item
+      // Question: callback vs Promise ? Neither are really used in the rest of the code base
       let tries = 0
       const load = () => {
-        api.getProofById(proofId).then(proof => {
-          const oneDayInMs = 24 * 60 * 60 * 1000
-          const proofCreatedDate = new Date(proof.created)
-          if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
-            // Only try once on old proofs
-            maxTries = 1
-          }
-          api.getReceiptItems({proof_id: proofId}).then(data => {
-            const receiptItems = data.items
-            if (receiptItems.length) {
-              this.receiptItems = receiptItems
-              callback(proof)
-            } else {
-              tries += 1
-              if (tries >= maxTries) {
-                callback(proof)
-                return
-              }
-              setTimeout(load, 5000)  // maximum wait time: maxTries * 5s (50s)
+        const oneDayInMs = 24 * 60 * 60 * 1000
+        const proofCreatedDate = new Date(this.proofObject.created)
+        if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
+          // Only try once on old proofs
+          maxTries = 1
+        }
+        api.getReceiptItems({proof_id: this.proofObject.id}).then(data => {
+          const receiptItems = data.items
+          if (receiptItems.length) {
+            callback(receiptItems)
+          } else {
+            tries += 1
+            if (tries >= maxTries) {
+              callback([])
+              return
             }
-          })
+            setTimeout(load, 5000)  // maximum wait time: maxTries * 5s (50s)
+          }
         })
       }
       load()


### PR DESCRIPTION
### What

mimic the logic we have in the Proof Price Tag Assistant.