### PR TITLE
fix(Proof Price Tag Assistant): restrict to PRICE_TAG proofs

### DIFF
--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -17,7 +17,7 @@
 
   <v-row v-if="step === 1">
     <v-col cols="12" md="6">
-      <ProofUploadCard @proof="onProofUploaded($event)" />
+      <ProofUploadCard :typePriceTagOnly="true" @proof="onProofUploaded($event)" />
     </v-col>
   </v-row>
   


### PR DESCRIPTION
### What

In the first step, only allow uploading PRICE_TAG proofs
