### PR TITLE
fix(Products): fix URL to add a new barcode in OxF

### DIFF
--- a/src/components/OpenFoodFactsAddMenu.vue
+++ b/src/components/OpenFoodFactsAddMenu.vue
@@ -56,7 +56,7 @@ export default {
       return constants[`${source.key.toUpperCase()}_URL`]
     },
     getSourceAddUrlWithLocale(source) {
-      const SOURCE_ADD_URL = `${this.getSourceUrl(source)}/cgi/product.pl?type=search_or_add&action=display&code=${this.productCode}`
+      const SOURCE_ADD_URL = `${this.getSourceUrl(source)}/cgi/product.pl?type=search_or_add&action=process&code=${this.productCode}`
       return SOURCE_ADD_URL.replace('world', this.appStore.user.language)
     },
   }


### PR DESCRIPTION
### What

For unknown products, we already have a button that links to OxF thanks to #522

But the page was not prefilled with the barcode.

<img width="1285" height="214" alt="image" src="https://github.com/user-attachments/assets/4823029d-e929-4245-b90c-f0dc1c2d05e3" />

With this fix, the user is brought to the new product form directly.

Note : "temporary" fix until we have #1336 :)