### PR TITLE
fix(ProofPriceTagAssistant): Properly wait when new boxes are drawn on old proofs

### DIFF
--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -407,6 +407,12 @@ export default {
         this.boundingBoxesFromServer = []
       } else {
         let maxTries = 10
+        const oneDayInMs = 24 * 60 * 60 * 1000
+        const proofCreatedDate = new Date(this.proofObject.created)
+        if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
+          // Only try once on old proofs
+          maxTries = 1
+        }
         this.proofWithBoundingBoxesLoading = true
         // Try to load any automatically detected price tags on proof upload
         this.loadPriceTagsWithPredictions(1, maxTries, priceTags => {
@@ -424,12 +430,6 @@ export default {
       // Question: callback vs Promise ? Neither are really used in the rest of the code base
       let tries = 0
       const load = () => {
-        const oneDayInMs = 24 * 60 * 60 * 1000
-        const proofCreatedDate = new Date(this.proofObject.created)
-        if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
-          // Only try once on old proofs
-          maxTries = 1
-        }
         api.getPriceTags({proof_id: this.proofObject.id, size: 100}).then(data => {
           const priceTagsWithPredictions = data.items.filter(priceTag => priceTag.predictions && priceTag.predictions.length)
           if (priceTagsWithPredictions.length >= minNumberOfPriceTagWithPredictions) {

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -190,9 +190,8 @@ export default {
       // store the proof
       this.proofObject = proof
       // load the receipt items
-      let maxTries = 10
       this.loadingPredictions = true
-      this.loadProofWithReceiptItems(maxTries, receiptItems => {
+      this.loadProofWithReceiptItems(receiptItems => {
         this.receiptItems = receiptItems
         api.getPrices({proof_id: this.proofObject.id}).then(data => {
           this.loadingPredictions = false
@@ -200,15 +199,16 @@ export default {
         })
       })
     },
-    loadProofWithReceiptItems(maxTries, callback) {
+    loadProofWithReceiptItems(callback) {
       // Call receipt items API until we have at least one item
       // Question: callback vs Promise ? Neither are really used in the rest of the code base
+      let maxTries = 10
       let tries = 0
       const load = () => {
+        // Old proof? only try once
         const oneDayInMs = 24 * 60 * 60 * 1000
         const proofCreatedDate = new Date(this.proofObject.created)
         if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
-          // Only try once on old proofs
           maxTries = 1
         }
         api.getReceiptItems({proof_id: this.proofObject.id}).then(data => {


### PR DESCRIPTION
### What
- ProofPriceTagAssistant has a feature skipping wait time when the proof is older than a day.
- This was introduced in PR https://github.com/openfoodfacts/open-prices-frontend/pull/1331 with the idea that it's pointless waiting for an AI process that probably failed
- However, this skip also happened when new boxes were drawn, leading to errors because the frontend did not wait long enough.
- This PR rectifies this, by only skipping the wait time when the proof is first loaded. And fully waiting when new boxes are drawn.
