### PR TITLE
fix(FilterMenu): on Product detail page, hide the type filter

### DIFF
--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -30,7 +30,7 @@
         {{ $t('Common.LatestPrices') }}
       </h2>
       <LoadedCountChip v-if="!loading" :loadedCount="priceList.length" :totalCount="priceTotal" />
-      <FilterMenu kind="price" :currentFilterList="currentFilterList" @update:currentFilterList="updateFilterList($event)" />
+      <FilterMenu kind="price" :hideType="true" :currentFilterList="currentFilterList" @update:currentFilterList="updateFilterList($event)" />
       <OrderMenu kind="price" :currentOrder="currentOrder" @update:currentOrder="selectPriceOrder($event)" />
       <DisplayMenu kind="price" :currentDisplay="currentDisplay" @update:currentDisplay="selectPriceDisplay($event)" />
     </v-col>


### PR DESCRIPTION
### What

Doesn't make sense to have a "price type" filter on the Product detail page (we already know if the product is a "Barcode" or "Category")

Closes #1720 
