### PR TITLE
fix(Tables): display all items available

### DIFF
--- a/src/components/PriceTable.vue
+++ b/src/components/PriceTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-data-table :headers="headers" :items="priceList" fixed-header hide-default-footer>
+  <v-data-table :headers="headers" :items="priceList" :items-per-page="tablePageLimit" fixed-header hide-default-footer>
     <template #[`item.product_name`]="{ item }">
       {{ getPriceProductTitle(item) }}
     </template>
@@ -57,6 +57,7 @@ export default {
   },
   data() {
     return {
+      tablePageLimit: -1,  // all items
       productPriceHeaders: [
         { title: 'Location', key: 'location' },
         { title: 'Date', key: 'date'},

--- a/src/components/RankingTableCard.vue
+++ b/src/components/RankingTableCard.vue
@@ -5,7 +5,7 @@
     </template>
   
     <v-card-text>
-      <v-data-table :headers="headers" :items="itemsDisplayed" hide-default-header hide-default-footer items-per-page="100">
+      <v-data-table :headers="headers" :items="itemsDisplayed" :items-per-page="tablePageLimit" hide-default-header hide-default-footer>
         <template #[`item.rank`]="{ index }">
           {{ index + 1 }}
         </template>
@@ -53,6 +53,11 @@ export default {
     hideRank: {
       type: Boolean,
       default: false
+    }
+  },
+  data() {
+    return {
+      tablePageLimit: -1,  // all items
     }
   },
   computed: {

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -7,7 +7,7 @@
     <v-divider />
 
     <v-card-text>
-      <v-data-table :headers="headers" :items="items" class="elevation-1" fixed-header hide-default-footer mobile-breakpoint="md" :mobile="null" items-per-page="100" :disable-sort="true">
+      <v-data-table :headers="headers" :items="items" :items-per-page="tablePageLimit" class="elevation-1" fixed-header hide-default-footer mobile-breakpoint="md" :mobile="null" :disable-sort="true">
         <template #[`item.product_name`]="{ item }">
           <v-text-field v-if="item.manuallyAdded" v-model="item.product_name" :hide-details="true" :rules="rules" />
           <p v-else>
@@ -147,7 +147,6 @@ export default {
   emits: ['receiptItemsUpdated'],
   data() {
     return {
-      showInfoDetails: true,
       items: [],
       headers: [
         { title: 'Product Name', key: 'product_name' },
@@ -156,6 +155,8 @@ export default {
         { title: 'Quantity', key: 'receipt_quantity' },
         { title: 'Actions', key: 'actions' },
       ],
+      tablePageLimit: -1,  // all items
+      showInfoDetails: true,
       editProductDialog: false,
       editProductItem: null,
       barcodeScannerDialog: false,


### PR DESCRIPTION
### What

We currently have 3 table components:
- Price list display mode: #1522
- Receipt assistant table: #1394
- Ranking table: #1674

Set the number of rows displayed as "infinity", to display all available items (no pagination, footer hidden)

Closes #1550