### PR TITLE
fix(Price table): fix location column sort (v1: by id)

### DIFF
--- a/src/components/PriceTable.vue
+++ b/src/components/PriceTable.vue
@@ -59,7 +59,7 @@ export default {
     return {
       tablePageLimit: -1,  // all items
       productPriceHeaders: [
-        { title: 'Location', key: 'location' },
+        { title: 'Location', key: 'location', sortRaw (a, b) { return a.location_id - b.location_id } },
         { title: 'Date', key: 'date'},
         { title: 'Price', key: 'price' },
         { title: 'Added', key: 'created' },
@@ -67,14 +67,14 @@ export default {
       ],
       proofPriceHeaders: [
         { title: 'Product', key: 'product_name' },
-        { title: 'Details', key: 'product_details' },
+        { title: 'Details', key: 'product_details', sortable: false },
         { title: 'Price', key: 'price' },
         { title: 'Added', key: 'created' },
         // { title: 'Actions', key: 'actions' },
       ],
       proofReceiptPriceOwnerHeaders: [
         { title: 'Product', key: 'product_name' },
-        { title: 'Details', key: 'product_details' },
+        { title: 'Details', key: 'product_details', sortable: false },
         { title: 'Price', key: 'price' },
         { title: 'Quantity', key: 'receipt_quantity' },
         { title: 'Added', key: 'created' },


### PR DESCRIPTION
### What

Price list "table display" component : #1522

The location ordering was broken. Fix it by ordering by location_id.
A v2 would be ordering by name (but there's an issue if mixing with online locations that have a website_url instead).

### Screenshot

<img width="726" height="369" alt="image" src="https://github.com/user-attachments/assets/029412a1-0091-4806-9f0c-5faef8b6db15" />
