### PR TITLE
fix(ProofPriceTagAssistant): no longer truncate wide proofs in canvas

### DIFF
--- a/src/components/ContributionAssistantDrawCanvas.vue
+++ b/src/components/ContributionAssistantDrawCanvas.vue
@@ -72,14 +72,17 @@
         const ctx = canvas.getContext("2d")
         canvas.style.width = "100%"
         this.scale = canvas.offsetWidth / this.image.width
-        const preferedHeight = window.innerHeight - 250
+        const maxHeight = window.innerHeight - 350
 
-        if (preferedHeight < this.image.height) {
+        if (maxHeight < this.image.height) {
           // Image will be too tall
-          // Ajust to fit preferedHeight
+          // Ajust to fit optimal height
+          const aspectRatio = this.image.height / this.image.width
+          const heightFor100PercentWidth = canvas.offsetWidth * aspectRatio
+          const idealHeight = Math.min(maxHeight, heightFor100PercentWidth)
           canvas.style.width = "auto"
-          this.scale = preferedHeight / this.image.height
-          canvas.style.height = preferedHeight + "px"
+          this.scale = idealHeight / this.image.height
+          canvas.style.height = idealHeight + "px"
         }
 
         const newWidth = this.image.width


### PR DESCRIPTION
### What
- The release of the product addition experiment (#1685) broke the display of wider proofs in the Proof Price Tag Assistant
- This PR adds computations for an ideal width and height, no matter the aspect ratio of the proof

### Screenshot

| Before | After |
| ------- | ----- |
| <img width="1903" height="911" alt="Screenshot 2025-10-07 at 21-18-38 Open Prices" src="https://github.com/user-attachments/assets/68acf22b-3b26-4a76-b29b-1e1c071995ae" /> | <img width="1903" height="911" alt="Screenshot 2025-10-07 at 21-18-49 Open Prices" src="https://github.com/user-attachments/assets/458b1172-069a-4568-8f22-79f507516835" /> |