### PR TITLE
feat(CreateOffProduct): better language support

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -529,6 +529,7 @@
 		"NextProof": "Next proof",
 		"PreviousProof": "Previous proof",
 		"ProductAlreadyExists": "Product already exists",
+		"ProductLanguage": "Product language",
 		"ProofNumberOfOutProofs": "Proof ({numberOfOutProofs}/{totalNumberOfProofs})",
 		"StoresWhereSold": "Stores where sold",
 		"UseCropModeToAddImage": "To add a product image, enable crop mode below proof picture and draw a rectangle around the product."


### PR DESCRIPTION
### What
- Requires backend PR: https://github.com/openfoodfacts/open-prices/pull/1081
- Allows users to choose which target language a product should be created in (was English by default, which required edits on openfoodfacts)
- PR also uses two-letter codes as a standardized way to give country and languages information to backend
- PR also changed the "country where sold" field, the field is no longer free-text, and suggests existing countries instead.
