### PR TITLE
refactor(Proof upload): rename multiple price tag upload (url, breadcrumbs)

### DIFF
--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -29,7 +29,7 @@
         variant="flat"
         :block="!$vuetify.display.smAndUp"
         prepend-icon="mdi-image-plus"
-        to="/proofs/add/multiple"
+        to="/proofs/add/multiple-price-tags"
       >
         {{ $t('Challenge.StepTakePictures.AddPictures') }}
       </v-btn>

--- a/src/components/ProofPriceTagAddMultiplePromoBanner.vue
+++ b/src/components/ProofPriceTagAddMultiplePromoBanner.vue
@@ -4,13 +4,13 @@
     bg-color="info"
     rounded
     density="compact"
-    @click="$router.push('/proofs/add/multiple')"
+    @click="$router.push('/proofs/add/multiple/price-tags')"
   >
     <v-banner-text style="padding-inline-end:10px;">
       {{ $t('ProofAdd.PromoProofPriceTagAddMultiple') }}
     </v-banner-text>
     <v-banner-actions>
-      <v-btn icon="mdi-arrow-right" :aria-label="$t('Router.AddProofMultiple.Title')" to="/proofs/add/multiple" />
+      <v-btn icon="mdi-arrow-right" :aria-label="$t('Router.AddProofsPriceTags.Title')" to="/proofs/add/multiple-price-tags" />
     </v-banner-actions>
   </v-banner>
 </template>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -747,6 +747,9 @@
 		"AddProofMultiple": {
 			"Title": "Add multiple proofs"
 		},
+		"AddProofsPriceTags": {
+			"Title": "Add proofs (price tags)"
+		},
 		"Locations": {
 			"Title": "Locations"
 		},
@@ -761,6 +764,9 @@
 		},
 		"Prices": {
 			"Title": "Prices"
+		},
+		"PriceTags": {
+			"Title": "Price tags"
 		},
 		"Proofs": {
 			"Title": "Proofs"

--- a/src/router.js
+++ b/src/router.js
@@ -16,7 +16,7 @@ const routes = [
   { path: '/prices/add/multiple/price-tag', name: 'price-add-multiple-price-tag', redirect: () => { return { path: '/prices/add/multiple' }}},
   { path: '/prices/add/multiple/receipt', name: 'price-add-multiple-receipt', redirect: () => { return { path: '/prices/add/multiple' }}},
   { path: '/proofs/add/single', name: 'proof-add-single', component: () => import('./views/ProofAddSingle.vue'), meta: { title: 'AddProofSingle', icon: 'mdi-image-plus', requiresAuth: true, breadcrumbs: [{title: 'Experiments', disabled: false, to: '/experiments' }, {title: 'AddProofSingle', disabled: true }] }},
-  { path: '/proofs/add/multiple', name: 'proof-add-multiple', component: () => import('./views/ProofPriceTagAddMultiple.vue'), meta: { title: 'AddProofs', icon: 'mdi-image-plus', requiresAuth: true, breadcrumbs: [{title: 'AddProofs', disabled: true }] }},
+  { path: '/proofs/add/multiple/price-tags', name: 'proof-add-multiple-price-tags', component: () => import('./views/ProofPriceTagAddMultiple.vue'), meta: { title: 'AddProofsPriceTags', icon: 'mdi-image-plus', requiresAuth: true, breadcrumbs: [{ title: 'Proofs', disabled: false, to: '/proofs' }, { title: 'AddProofs', disabled: true }, { title: 'PriceTags', disabled: true }] }},
   { path: '/experiments/price-validation-assistant', name: 'price-validation-assistant', component: () => import('./views/PriceValidationAssistant.vue'), meta: { title: 'ValidatePrices', icon: 'mdi-checkbox-marked-circle-plus-outline', requiresAuth: true, breadcrumbs: [{title: 'Experiments', disabled: false, to: '/experiments' }, {title: 'ValidatePrices', disabled: true }] }},
   { path: '/search', name: 'search', component: () => import('./views/Search.vue'), meta: { title: 'Search', icon: 'mdi-magnify', drawerMenu: true, breadcrumbs: [{title: 'Search', disabled: true }] }},
   { path: '/prices/:id', name: 'prices-detail', component: () => import('./views/PriceDetail.vue'), meta: { title: 'Price detail' }},
@@ -55,6 +55,7 @@ const routes = [
   // redirects
   { path: '/experiments/challenge', redirect: '/challenge' },
   { path: '/experiments/contribution-assistant', redirect: '/experiments/proof-price-tag-assistant' },
+  { path: '/proofs/add/multiple', redirect: '/proofs/add/multiple/price-tags' },
   // Why this redirect?
   // The app used to be available at https://prices.openfoodfacts.org/app
   // It is now available at https://prices.openfoodfacts.org


### PR DESCRIPTION
### What

- give more info in the breadcrumbs
  - and allow going back to the all proofs page
  - and one day allow clicking on "Add" as well ? with a page listing the different proof upload options
- be more explicit in the url (as this page is solely dedicated to price tag upload)
  - add a redirect for users using the old url (mobile app ?)
- pave the way to the multiple receipt upload page #1748

### Screenshot

|Before|After|
|-|-|
|<img width="640" height="416" alt="image" src="https://github.com/user-attachments/assets/79132ab7-aa34-456f-9ee4-049550a37499" />|<img width="640" height="416" alt="image" src="https://github.com/user-attachments/assets/5a08ed57-748f-4fe1-8e72-0c862fcb179a" />|