### PR TITLE
refactor(Login): store newly returned user is_moderator info

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,7 @@ export const useAppStore = defineStore('app', {
     user: {
       username: null,
       token: null,
+      is_moderator: false,
       last_product_type_used: constants.PRICE_TYPE_PRODUCT,  // or 'BARCODE'
       last_currency_used: import.meta.env.VITE_DEFAULT_CURRENCY,  // 'EUR'
       recent_locations: [],
@@ -57,9 +58,10 @@ export const useAppStore = defineStore('app', {
     }
   },
   actions: {
-    signIn(token) {
-      this.user.username = utils.getOFFUsernameFromAuthToken(token)
-      this.user.token = token
+    signIn(data) {
+      this.user.username = data['user_id']
+      this.user.token = data['access_token']
+      this.user.is_moderator = data['is_moderator'] || false
     },
     signOut() {
       this.user.username = null

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -92,7 +92,7 @@ export default {
         .signIn(this.signinForm.username.toLowerCase().trim(), this.signinForm.password)
         .then((data) => {
           if (data['access_token']) {
-            this.appStore.signIn(data['access_token'])
+            this.appStore.signIn(data)
             this.done()
           } else {
             alert(this.$t('SignIn.WrongCredentials'))


### PR DESCRIPTION
### What

Following changes in the backend - https://github.com/openfoodfacts/open-prices/pull/1097 - we now know if the user is a moderator or not.

Requires the user to (re) login.
