### PR TITLE
refactor(CreateProduct): Always display list of suggested missing products

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -522,8 +522,8 @@
 		"Select": "Select {currency_code}"
 	},
 	"CreateOffProduct": {
-		"ChooseUnknownProduct": "Choose unknown product",
-		"ChooseUnknownProductGuide": "Or choose an unknown product to add",
+		"SelectUnknownProduct": "Select unknown product",
+		"SelectUnknownProductGuide": "Or select an unknown product to add",
 		"CountriesWhereSold": "Countries where sold",
 		"CreateNewProduct": "Create a new product",
 		"CreateProduct": "Create product",

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -57,7 +57,7 @@
     <v-col cols="12" md="6">
       <v-card
         class="mb-4"
-        :title="$t('CreateOffProduct.ChooseUnknownProductGuide')"
+        :title="$t('CreateOffProduct.SelectUnknownProductGuide')"
         prepend-icon="mdi-tag-plus-outline"
         height="100%"
       >
@@ -368,7 +368,7 @@ export default {
     stepItemList() {
       return [
         {
-          title: this.$t('CreateOffProduct.ChooseUnknownProduct'),
+          title: this.$t('CreateOffProduct.SelectUnknownProduct'),
           value: 1
         },
         {


### PR DESCRIPTION
### What
- Before this PR, the list of suggested missing products didn't show if user landed on experiment with a product_code as query param
- We now load the list every time
- PR also changes the way this first step is displayed, using both columns

### Screenshot
<img width="1903" height="911" alt="image" src="https://github.com/user-attachments/assets/8c39c781-19ec-4480-8ebb-cd8ae360d86b" />

### Related issue
- https://github.com/openfoodfacts/open-prices/issues/1049
