### PR TITLE
fix(Price Validation Assistant): always display the product's barcode

### DIFF
--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -73,7 +73,7 @@
       >
         {{ productForm.product_code }}
       </v-alert>
-      <ProductCard v-if="productForm.product" :product="productForm.product" :hideCategoriesAndLabels="true" :hideProductBarcode="true" :hideActionMenuButton="true" :readonly="true" elevation="1" />
+      <ProductCard v-if="productForm.product" :product="productForm.product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :readonly="true" elevation="1" />
     </v-col>
     <v-col v-else-if="productIsTypeCategory" cols="12">
       <v-alert


### PR DESCRIPTION
### What

When in "display" mode, the predict product's barcode was not displayed (except if set in the user's settings).
Quick change to fix it (independently of the user's settings).

Possible impact on price product card ?

### Screenshot

|Before|After|
|-|-|
|<img width="590" height="635" alt="image" src="https://github.com/user-attachments/assets/292856ed-3a90-4c93-8fb4-779e4e34d9f2" />|<img width="590" height="637" alt="image" src="https://github.com/user-attachments/assets/64bc9d88-39cd-4b71-a580-2461dce90dc3" />|