### PR TITLE
refactor(Proof upload): chain promises instead of compressing/uploading at the same time

### DIFF
--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -274,9 +274,9 @@ export default {
     uploadProofList() {
       this.step = 2
       // loop on images
-      for (let proofImage of this.proofImageList) {
-        this.uploadProof(proofImage)
-      }
+      Promise.all(
+        this.proofImageList.map(proofImage => this.uploadProof(proofImage))
+      )
     },
     uploadProof(proofImage) {
       this.loading = true

--- a/src/views/ProofPriceTagAddMultiple.vue
+++ b/src/views/ProofPriceTagAddMultiple.vue
@@ -102,7 +102,6 @@ export default {
   methods: {
     onProofUploaded(proof) {
       this.firstProofUploaded = proof
-      console.log('Proof uploaded:', proof)
     },
     proofUploadDone(proofUploadCount) {
       this.proofUploadCount = proofUploadCount


### PR DESCRIPTION
### What

When multiple proofs are being uploaded, we weren't managing correctly the compression + upload combo.
Doing things pretty much in parallel, instead of synchronously.

This might also fix images not being uploaded in the selected order ? And image hash calculation to detect duplicates ??

### Ideas to improve

- show a text to explain what is happening
- separate compression & upload steps ?
