### PR TITLE
ci(Tests): Disable them as they are not up to date (and failing)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,4 +1,4 @@
-name: Linting & e2e tests
+name: Linting & e2e tests (disabled)
 
 on: push
 
@@ -16,10 +16,11 @@ jobs:
           runTests: false
       - name: Lint with ESLint
         run: yarn lint
-      - name: Run e2e tests
-        uses: cypress-io/github-action@v6
-        with:
-          # we have already installed all dependencies above
-          install: false
-          # run server in the background
-          start: yarn dev
+      # Disabled? tests are not up to date...
+      # - name: Run e2e tests
+      #   uses: cypress-io/github-action@v6
+      #   with:
+      #     # we have already installed all dependencies above
+      #     install: false
+      #     # run server in the background
+      #     start: yarn dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ There is also a pre-commit configuration set up with [husky](https://typicode.gi
 ### Tests
 
 ```sh
-yarn test
+yarn test:run
 ```
 
 ### Update packages

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:fix": "eslint --fix",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "test": "start-server-and-test dev http://localhost:5173 cy:run",
+    "test:open": "start-server-and-test dev http://localhost:5173 cy:open",
+    "test:run": "start-server-and-test dev http://localhost:5173 cy:run",
     "postinstall": "husky"
   },
   "lint-staged": {

--- a/tests/e2e/spec.cy.js
+++ b/tests/e2e/spec.cy.js
@@ -5,7 +5,7 @@ describe('Basic tests', () => {
     cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/products?app_name=Open+Prices+Web+App&page=1&size=10&brands__like=Snickers&order_by=-price_count', { body: {"items":[],"total":0,"page":1,"size":10,"pages":0} })
     cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/products/code/3011360030498?app_name=Open+Prices+Web+App', { fixture: 'product_3011360030498.json' })
     cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/products/code/0000000000000?app_name=Open+Prices+Web+App', { statusCode: 404, body: { "detail": "Product with code 35647000112700 not found" }})
-    cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/prices?app_name=Open+Prices+Web+App&page=1&size=1&order_by=-created*', { fixture: 'prices.json' })
+    cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/prices?app_name=Open+Prices+Web+App&page=1&size=1&order_by=-created&created__gte=*', { fixture: 'prices.json' })
     cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/prices?app_name=Open+Prices+Web+App&page=1&size=10&order_by=-created', { fixture: 'prices.json' })
     cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/prices?app_name=Open+Prices+Web+App&page=1&size=1&order_by=-date&product_code=3011360030498', { fixture: 'product_3011360030498_prices.json' })
     cy.intercept('GET', 'http://127.0.0.1:8000/api/v1/prices?app_name=Open+Prices+Web+App&page=1&size=10&order_by=-date&product_code=3011360030498', { fixture: 'product_3011360030498_prices.json' })


### PR DESCRIPTION
### What

Last changes in `/tests/src/e2e/specs.cy.js` date back to https://github.com/openfoodfacts/open-prices-frontend/pull/714 (August 2024)

The tests have been failing since.

The backend is tested extensively.

Having tests in the frontend is not a priority (we change and break stuff regularly)