### PR TITLE
fix(Price form): avoid trim() error when called on non-string

### DIFF
--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -205,21 +205,21 @@ export default {
     },
     priceRules() {
       return [
-        value => !!value && !!value.trim() || this.$t('PriceRules.AmountRequired'),
-        value => !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
+        value => !!value && !!value.toString().trim() || this.$t('PriceRules.AmountRequired'),
+        value => !value.toString().trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
-        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
+        value => !value.toString().match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
         value => !!value && !!this.priceForm.currency || this.$t('Common.CurrencyMissing'),
       ]
     },
     receiptQuantityRules() {
       if (!this.priceForm.receipt_quantity) return [() => true]  // optional field
       return [
-        value => !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
+        value => !value.toString().trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
-        value => !value.match(/\.\d{4}/) || this.$t('PriceRules.ThreeDecimals'),
+        value => !value.toString().match(/\.\d{4}/) || this.$t('PriceRules.ThreeDecimals'),
       ]
     },
     receiptQuantitySuffix() {

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -224,19 +224,19 @@ export default {
     priceTotalRules() {
       if (!this.proofMetadataForm.receipt_price_total) return [() => true]  // optional field
       return [
-        value => !!value && !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
+        value => !!value && !value.toString().trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
-        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
+        value => !value.toString().match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
       ]
     },
     priceOnlineDeliveryCostsRules() {
       if (!this.proofMetadataForm.receipt_online_delivery_costs) return [() => true]  // optional field
       return [
-        value => !!value && !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
+        value => !!value && !value.toString().trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
-        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
+        value => !value.toString().match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
       ]
     },
   },

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -177,11 +177,11 @@ export default {
   computed: {
     priceRules() {
       return [
-        value => !!value && !!value.trim() || this.$t('PriceRules.AmountRequired'),
-        value => !value.trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
+        value => !!value && !!value.toString().trim() || this.$t('PriceRules.AmountRequired'),
+        value => !value.toString().trim().match(/ /) || this.$t('PriceRules.NoSpaces'),
         value => !isNaN(value) || this.$t('PriceRules.Number'),
         value => Number(value) >= 0 || this.$t('PriceRules.Positive'),
-        value => !value.match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
+        value => !value.toString().match(/\.\d{3}/) || this.$t('PriceRules.TwoDecimals'),
         value => !!value && !!this.proof.currency || this.$t('Common.CurrencyMissing'),
       ]
     },


### PR DESCRIPTION
### What

Avoid errors when form input rules (with trim) are run on existing data (e.g. sent from the server as decimal instead of strings)

<img width="548" height="71" alt="image" src="https://github.com/user-attachments/assets/bdb98934-11aa-476a-9e80-52475120f257" />
