### PR TITLE
refactor(Receipt Assistant): move error message to new status column

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -7,11 +7,11 @@
     <v-divider />
 
     <v-card-text>
-      <v-data-table :headers="headers" :items="items" :items-per-page="tablePageLimit" fixed-header hide-default-footer mobile-breakpoint="md" :mobile="null" :disable-sort="true" density="comfortable">
+      <v-data-table :headers="headers" :items="items" :row-props="setTableRowClass" :items-per-page="tablePageLimit" fixed-header hide-default-footer mobile-breakpoint="md" :mobile="null" :disable-sort="true" density="comfortable">
         <template #[`item.status`]="{ item }">
           <v-sheet v-if="item.existingPrice">
-            <v-icon icon="mdi-tag-check-outline" color="success" :title="$t('ReceiptAssistant.PriceAlreadyCreated')" />
-            <span v-if="$vuetify.display.smAndDown" class="text-success ml-2">{{ $t('ReceiptAssistant.PriceAlreadyCreated') }}</span>
+            <v-icon icon="mdi-tag-check-outline" :disabled="true" :title="$t('Common.PriceAlreadyUploaded')" />
+            <span v-if="$vuetify.display.smAndDown" class="text-disabled ml-2">{{ $t('Common.PriceAlreadyUploaded') }}</span>
           </v-sheet>
           <v-sheet v-else-if="!item.price">
             <v-icon icon="mdi-alert-circle" color="warning" :title="$t('Common.PriceMissing')" />
@@ -22,8 +22,8 @@
             <span v-if="$vuetify.display.smAndDown" class="text-warning ml-2">{{ $t('Common.ProductMissing') }}</span>
           </v-sheet>
           <v-sheet v-else>
-            <v-icon icon="mdi-tag-plus-outline" :title="$t('ReceiptAssistant.PriceReadyToBeAdded')" />
-            <span v-if="$vuetify.display.smAndDown" class="ml-2">{{ $t('ReceiptAssistant.PriceReadyToBeAdded') }}</span>
+            <v-icon icon="mdi-tag-plus-outline" color="success" :title="$t('Common.PriceReadyToBeUploaded')" />
+            <span v-if="$vuetify.display.smAndDown" class="text-success ml-2">{{ $t('Common.PriceReadyToBeUploaded') }}</span>
           </v-sheet>
         </template>
         <template #[`item.product_name`]="{ item }">
@@ -243,6 +243,13 @@ export default {
         }
         return item
       })
+    },
+    setTableRowClass(item) {
+      // grey out existing prices
+      if (item.item.existingPrice) {
+        return { class: 'text-disabled' }
+      }
+      return { class: '' }
     },
     replaceCommaWithDot(input) {
       return utils.replaceCommaWithDot(input)

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -379,6 +379,8 @@
 		"PriceToValidateCount": "{count} prices to validate | {count} price to validate | {count} prices to validate",
 		"PriceCreated": "Price created!",
 		"PriceMissing": "Price missing",
+		"PriceAlreadyUploaded": "Price already uploaded",
+		"PriceReadyToBeUploaded": "Price ready to be uploaded",
 		"PricesAlreadyUploaded": "Prices already uploaded",
 		"PricesMore": "More prices",
 		"PricesAdded": "Prices added",


### PR DESCRIPTION
### What

- Receipt assistant: thinking of ways to better differentiate "prices already added" vs "prices to add" vs "prices to fill"
- Homogenize: use "uploaded" instead of "created" or "added"

### Todo

better manage prices edition (live instead of using the bottom buttons ?)

### Screenshot

not up to date following changes in #1849 & #1852

||Before|After|
|-|-|-|
|Desktop|<img width="799" height="683" alt="image" src="https://github.com/user-attachments/assets/5be1f8ec-875c-4db3-a5b0-15e96267d3e4" />|<img width="799" height="707" alt="image" src="https://github.com/user-attachments/assets/0d98e722-ec4f-419b-89ad-a4e5d39bde99" />|
|Mobile|<img width="420" height="839" alt="image" src="https://github.com/user-attachments/assets/1dd9498c-4fd3-422c-803c-773c62682b45" />|<img width="420" height="839" alt="image" src="https://github.com/user-attachments/assets/0490fe40-419f-4fbb-b0b3-a3e63d432844" />|