### PR TITLE
fix(OFF Add Link): use user country_code instead of language_code for URL prefix

### DIFF
--- a/src/components/OpenFoodFactsAddMenu.vue
+++ b/src/components/OpenFoodFactsAddMenu.vue
@@ -57,7 +57,7 @@ export default {
     },
     getSourceAddUrlWithLocale(source) {
       const SOURCE_ADD_URL = `${this.getSourceUrl(source)}/cgi/product.pl?type=search_or_add&action=process&code=${this.productCode}`
-      return SOURCE_ADD_URL.replace('world', this.appStore.user.language)
+      return SOURCE_ADD_URL.replace('world', this.appStore.user.country.toLowerCase())
     },
   }
 }


### PR DESCRIPTION
Applies the fix from https://github.com/openfoodfacts/open-prices-frontend/pull/1518 to the “Add to {project}” dropdown menu.

Related-issue: https://github.com/openfoodfacts/open-prices-frontend/issues/458
Follow-up-to: https://github.com/openfoodfacts/open-prices-frontend/pull/1518