### PR TITLE
refactor(Proofs): simple ProofCompactCard component

### DIFF
--- a/src/components/ProofCompactCard.vue
+++ b/src/components/ProofCompactCard.vue
@@ -31,10 +31,6 @@ export default {
       type: String,
       default: 'Display'  // or 'Uploaded'
     },
-    hideProofHeader: {
-      type: Boolean,
-      default: false,
-    },
     showImageThumb: {
       type: Boolean,
       default: false,
@@ -50,10 +46,6 @@ export default {
     readonly: {
       type: Boolean,
       default: false,
-    },
-    imageHeight: {
-      type: String,
-      default: '100%',
     },
   },
   emits: ['proofSelected', 'close'],


### PR DESCRIPTION
### What

new `ProofCompactCard` component (compact version of `ProofCard`)

### Screenshot

|Proof card (currently)|Proof card compact (new)|
|-|-|
|<img width="415" height="411" alt="image" src="https://github.com/user-attachments/assets/f9626e54-8905-4faf-a4e1-6ccd12000381" />|<img width="415" height="110" alt="image" src="https://github.com/user-attachments/assets/3054341d-d32e-4353-bc0f-2f4960ea9b2d" />|
