### PR TITLE
refactor(Cards): move ActionMenuButton components inside v-row above

### DIFF
--- a/src/components/BrandCard.vue
+++ b/src/components/BrandCard.vue
@@ -5,9 +5,10 @@
         <v-col :cols="hideActionMenuButton ? '12' : '11'">
           <ProductCountChip :count="productCount" :withLabel="true" />
         </v-col>
+        <v-col v-if="!hideActionMenuButton" cols="1">
+          <BrandActionMenuButton v-if="!hideActionMenuButton" :brand="brand" />
+        </v-col>
       </v-row>
-
-      <BrandActionMenuButton v-if="!hideActionMenuButton" :brand="brand" />
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/CategoryCard.vue
+++ b/src/components/CategoryCard.vue
@@ -7,9 +7,10 @@
           <PriceCountChip v-else-if="sourceIsProduct" class="mr-1" :count="priceCount" />
           <CategoryTagChip v-if="showProductCategoryTag" class="mr-1" :category="category" :readonly="true" />
         </v-col>
+        <v-col v-if="!hideActionMenuButton" cols="1">
+          <CategoryActionMenuButton v-if="!hideActionMenuButton" :category="category" :source="source" />
+        </v-col>
       </v-row>
-
-      <CategoryActionMenuButton v-if="!hideActionMenuButton" :category="category" :source="source" />
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/CurrencyCard.vue
+++ b/src/components/CurrencyCard.vue
@@ -5,9 +5,10 @@
         <v-col :cols="hideActionMenuButton ? '12' : '11'">
           <PriceCountChip :count="priceCount" :withLabel="true" />
         </v-col>
+        <v-col v-if="!hideActionMenuButton" cols="1">
+          <CurrencyActionMenuButton v-if="!hideActionMenuButton" :currency="currency" />
+        </v-col>
       </v-row>
-
-      <CurrencyActionMenuButton v-if="!hideActionMenuButton" :currency="currency" />
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/DateCard.vue
+++ b/src/components/DateCard.vue
@@ -12,9 +12,10 @@
             {{ dp.name }}
           </v-chip>
         </v-col>
+        <v-col v-if="!hideActionMenuButton" cols="1">
+          <DateActionMenuButton v-if="!hideActionMenuButton" :date="date" />
+        </v-col>
       </v-row>
-
-      <DateActionMenuButton v-if="!hideActionMenuButton" :date="date" />
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/LabelCard.vue
+++ b/src/components/LabelCard.vue
@@ -5,9 +5,10 @@
         <v-col :cols="hideActionMenuButton ? '12' : '11'">
           <ProductCountChip :count="productCount" :withLabel="true" />
         </v-col>
+        <v-col v-if="!hideActionMenuButton" cols="1">
+          <LabelActionMenuButton v-if="!hideActionMenuButton" :label="label" />
+        </v-col>
       </v-row>
-
-      <LabelActionMenuButton v-if="!hideActionMenuButton" :label="label" />
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row class="mt-0">
-    <v-col :cols="hideActionMenuButton ? '12' : '11'">
+    <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
       <ProofChip v-if="price.proof && !hidePriceProof" class="mr-1" :proof="price.proof" />
       <LocationChip v-if="!hidePriceLocation" class="mr-1" :location="price.location" :locationId="price.location_id" :readonly="readonly" />
       <UserChip v-if="!hidePriceOwner" class="mr-1" :username="price.owner" :readonly="readonly" />
@@ -8,9 +8,10 @@
       <UserCommentChip v-if="price.owner_comment" class="mr-1" :comment="price.owner_comment" />
       <RelativeDateTimeChip v-if="!hidePriceCreated" :dateTime="price.created" />
     </v-col>
+    <v-col v-if="!hideActionMenuButton" cols="1">
+      <PriceActionMenuButton v-if="!hideActionMenuButton" :price="price" :hideProductActions="hideProductDetailsRow" />
+    </v-col>
   </v-row>
-
-  <PriceActionMenuButton v-if="!hideActionMenuButton" :price="price" :hideProductActions="hideProductDetailsRow" />
 </template>
 
 <script>

--- a/src/components/ProductDetailsRow.vue
+++ b/src/components/ProductDetailsRow.vue
@@ -16,9 +16,10 @@
       <ProductBarcodeInvalidChip v-if="!hideBarcodeErrors && barcodeInvalid" class="mr-1" />
       <ProductSourceChip v-if="showProductSource" :product="product" />
     </v-col>
+    <v-col v-if="!hideActionMenuButton" cols="1">
+      <ProductActionMenuButton v-if="!hideActionMenuButton" :product="product" />
+    </v-col>
   </v-row>
-
-  <ProductActionMenuButton v-if="!hideActionMenuButton" :product="product" />
 </template>
 
 <script>

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="hideActionMenuButton ? '12' : '11'">
+    <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
       <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" :withLabel="showProofChip" :readonly="true" />
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofUserConsumptionChip v-if="showReceiptOwnerConsumption" class="mr-1" />
@@ -15,9 +15,10 @@
       <UserCommentChip v-if="proof.owner_comment" class="mr-1" :comment="proof.owner_comment" />
       <RelativeDateTimeChip :dateTime="proof.created" />
     </v-col>
+    <v-col v-if="!hideActionMenuButton" cols="1">
+      <ProofActionMenuButton v-if="!hideActionMenuButton" :proof="proof" />
+    </v-col>
   </v-row>
-
-  <ProofActionMenuButton v-if="!hideActionMenuButton" :proof="proof" />
 </template>
 
 <script>

--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -16,9 +16,10 @@
           <ProofCountChip class="mr-1" :count="user.proof_count" :withLabel="true" :to="getUserProofListUrl" />
           <ChallengeCountChip class="mr-1" :count="user.challenge_count" :withLabel="true" />
         </v-col>
+        <v-col v-if="!hideActionMenuButton" cols="1">
+          <UserActionMenuButton v-if="!hideActionMenuButton" :user="user" />
+        </v-col>
       </v-row>
-
-      <UserActionMenuButton v-if="!hideActionMenuButton" :user="user" />
     </v-card-text>
   </v-card>
 </template>


### PR DESCRIPTION
### What

In most of the cards, its ActionMenuButton component was living outside of the main `v-row`.
Cleanup to move all these buttons in a dedicated `v-col`

Exception: `LocationCard`, will be managed separately