### PR TITLE
refactor(Price Validation Assistant): make the 'fix' mode the default + remove the button

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -23,8 +23,8 @@
           />
         </v-col>
       </v-row>
-      <ProductInputRow :productForm="productPriceForm" :mode="mode" :disableInitWhenSwitchingType="true" :hideProductBarcode="false" :hideBarcodeScannerTab="hideProductBarcodeScannerTab" @filled="productFormFilled = $event" />
-      <PriceInputRow :priceForm="productPriceForm" :mode="mode" :hideCurrencyChoice="true" :product="productPriceForm.product" :proofType="productPriceForm.proof ? productPriceForm.proof.type : null" @filled="pricePriceFormFilled = $event" />
+      <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingType="true" :hideProductBarcode="false" :hideBarcodeScannerTab="hideProductBarcodeScannerTab" @filled="productFormFilled = $event" />
+      <PriceInputRow :priceForm="productPriceForm" :hideCurrencyChoice="true" :product="productPriceForm.product" :proofType="productPriceForm.proof ? productPriceForm.proof.type : null" @filled="pricePriceFormFilled = $event" />
       <v-alert
         v-if="!productPriceFormValid"
         class="mt-4 mb-4"
@@ -69,16 +69,6 @@
           <!-- missing PRICE_TAG_STATUS_OTHER -->
         </v-list>
       </v-menu>
-      <v-spacer />
-      <v-btn
-        v-if="mode === 'display'"
-        color="warning"
-        variant="outlined"
-        prepend-icon="mdi-pencil"
-        @click="mode = 'edit'"
-      >
-        {{ $t('Common.Fix') }}
-      </v-btn>
       <v-spacer />
       <v-btn
         v-if="!hideUploadAction"
@@ -163,10 +153,6 @@ export default {
       type: Boolean,
       default: false
     },
-    forceMode: {
-      type: String,
-      default: null
-    },
     hidePriceTagStatusMenu: {
       type: Boolean,
       default: false
@@ -186,7 +172,6 @@ export default {
       PRICE_TAG_STATUS_NO_BARCODE: constants.PRICE_TAG_STATUS_NO_BARCODE,
       PRICE_TAG_STATUS_OTHER: constants.PRICE_TAG_STATUS_OTHER,
       // data
-      mode: null,  // 'display' or 'edit'  // see mounted
       productFormFilled: false,
       pricePriceFormFilled: false,
     }
@@ -233,28 +218,20 @@ export default {
       }
     }
   },
-  mounted() {
-    this.resetMode()
-  },
   unmounted() {
     if (this.productPriceForm.croppedImage) {
       URL.revokeObjectURL(this.productPriceForm.croppedImage)
     }
   },
   methods: {
-    resetMode() {
-      this.mode = this.forceMode || this.appStore.user.price_form_default_mode
-    },
     setCroppedImage(croppedImage) {
       this.productPriceForm.croppedImage = croppedImage
     },
     updatePriceTagStatus(status=null) {
       this.$emit('updatePriceTagStatus', status)
-      this.resetMode()
     },
     validatePriceTag() {
       this.$emit('validatePriceTag', this.productPriceForm)
-      this.resetMode()
     },
     close() {
       this.$emit('close')

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row v-if="mode === 'edit' && productIsTypeCategory">
+  <v-row v-if="productIsTypeCategory">
     <v-col>
       <v-item-group v-model="priceForm.price_per" class="d-inline" mandatory>
         <v-item v-for="cpp in CATEGORY_PRICE_PER_LIST" :key="cpp.key" v-slot="{ isSelected, toggle }" :value="cpp.key">
@@ -11,7 +11,7 @@
       </v-item-group>
     </v-col>
   </v-row>
-  <v-row v-if="mode === 'edit'" class="mt-0">
+  <v-row class="mt-0">
     <v-col :cols="priceForm.price_is_discounted ? '6' : '12'" class="pb-0">
       <div class="text-body-2 required">
         {{ priceForm.price_is_discounted ? $t('PriceForm.LabelDiscounted') : $t('PriceForm.Label') }}
@@ -53,7 +53,7 @@
       />
     </v-col>
   </v-row>
-  <v-row v-if="mode === 'edit'" class="mt-0">
+  <v-row class="mt-0">
     <v-col cols="6" class="pb-1">
       <v-switch
         v-model="priceForm.price_is_discounted"
@@ -95,7 +95,7 @@
       />
     </v-col>
   </v-row>
-  <v-row v-if="mode === 'edit'" class="mt-0">
+  <v-row class="mt-0">
     <v-col v-if="!displayOwnerCommentField" cols="12">
       <a class="fake-link" role="link" tabindex="0" @click="displayOwnerCommentField = true" @keydown.enter="displayOwnerCommentField = true">
         {{ $t('Common.AddComment') }}
@@ -116,16 +116,6 @@
       />
     </v-col>
   </v-row>
-  <v-row v-else-if="mode === 'display'">
-    <v-col cols="12">
-      <v-alert
-        icon="mdi-currency-usd"
-        density="compact"
-      >
-        <PricePriceRow :price="priceForm" />
-      </v-alert>
-    </v-col>
-  </v-row>
 
   <ChangeCurrencyDialog
     v-if="changeCurrencyDialog"
@@ -143,7 +133,6 @@ import utils from '../utils.js'
 
 export default {
   components: {
-    PricePriceRow: defineAsyncComponent(() => import('../components/PricePriceRow.vue')),
     ChangeCurrencyDialog: defineAsyncComponent(() => import('../components/ChangeCurrencyDialog.vue')),
   },
   props: {
@@ -159,10 +148,6 @@ export default {
         currency: null,
         receipt_quantity: null,
       })
-    },
-    mode: {
-      type: String,
-      default: constants.PRICE_FORM_DISPLAY_LIST[1].key,  // 'edit'
     },
     hideCurrencyChoice: {
       type: Boolean,

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row v-if="mode === 'edit'">
+  <v-row>
     <v-col>
       <v-item-group v-model="productForm.type" class="d-inline" mandatory @update:modelValue="setType($event)">
         <v-item v-for="pt in productTypeDisplayList" :key="pt.key" v-slot="{ isSelected, toggle }" :value="pt.key">
@@ -12,7 +12,7 @@
       </v-item-group>
     </v-col>
   </v-row>
-  <v-row v-if="mode === 'edit' && !hideBarcodeMode && productIsTypeProduct" class="mt-0">
+  <v-row v-if="!hideBarcodeMode && productIsTypeProduct" class="mt-0">
     <v-col>
       <ProductCard v-if="productForm.product" :product="productForm.product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :isSelected="true" :readonly="true" elevation="1" @editProduct="showBarcodeScannerDialog" />
       <v-btn v-else class="text-body-2 mb-2" block spaced="end" prepend-icon="mdi-barcode-scan" :class="productForm.product ? 'border-success' : 'border-error'" @click="showBarcodeScannerDialog">
@@ -20,7 +20,7 @@
       </v-btn>
     </v-col>
   </v-row>
-  <v-row v-else-if="mode === 'edit' && productIsTypeCategory" class="mt-0">
+  <v-row v-else-if="productIsTypeCategory" class="mt-0">
     <v-col cols="6">
       <div class="text-body-2 required">
         {{ $t('AddPriceSingle.ProductInfo.CategoryLabel') }}
@@ -63,27 +63,6 @@
       />
     </v-col>
   </v-row>
-  <v-row v-else-if="mode === 'display'">
-    <v-col v-if="productIsTypeProduct" cols="12">
-      <v-alert
-        class="mb-2"
-        icon="mdi-barcode"
-        density="compact"
-      >
-        {{ productForm.product_code }}
-      </v-alert>
-      <ProductCard v-if="productForm.product" :product="productForm.product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :readonly="true" elevation="1" />
-    </v-col>
-    <v-col v-else-if="productIsTypeCategory" cols="12">
-      <v-alert
-        icon="mdi-basket-outline"
-        density="compact"
-      >
-        <PriceCategoryChip :priceCategory="productForm.category_tag" />
-        <PriceCategoryDetailsRow :price="productForm" />
-      </v-alert>
-    </v-col>
-  </v-row>
 
   <BarcodeScannerDialog
     v-if="barcodeScannerDialog"
@@ -107,8 +86,6 @@ import utils from '../utils.js'
 export default {
   components: {
     ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
-    PriceCategoryChip: defineAsyncComponent(() => import('../components/PriceCategoryChip.vue')),
-    PriceCategoryDetailsRow: defineAsyncComponent(() => import('../components/PriceCategoryDetailsRow.vue')),
     BarcodeScannerDialog: defineAsyncComponent(() => import('../components/BarcodeScannerDialog.vue')),
   },
   props: {
@@ -122,10 +99,6 @@ export default {
         origins_tags: '',
         labels_tags: []
       })
-    },
-    mode: {
-      type: String,
-      default: constants.PRICE_FORM_DISPLAY_LIST[1].key,  // 'edit'
     },
     disableInitWhenSwitchingType: {
       type: Boolean,

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -111,7 +111,6 @@
       :hideUploadAction="false"
       :hidePriceTagStatusMenu="true"
       :isInDialog="true"
-      forceMode="edit"
       @validatePriceTag="confirmProduct($event)"
       @close="editProductDialog = false"
     />

--- a/src/constants.js
+++ b/src/constants.js
@@ -227,10 +227,6 @@ export default {
     { key: 'off-barcode-scanner', value: 'Off Barcode Scanner', valueSmallScreen: 'Off Scanner', icon: 'mdi-barcode-scan' },
     { key: 'html5-qrcode', value: 'Html5-Qrcode', valueSmallScreen: 'Html5-Qrcode', icon: 'mdi-barcode-scan' },
   ],
-  PRICE_FORM_DISPLAY_LIST: [
-    { key: 'display', value: 'Display', icon: 'mdi-eye-outline' },
-    { key: 'edit', value: 'Edit', icon: 'mdi-pencil' },
-  ],
   USER_DASHBOARD_TAB_LIST: [
     { key: 'all', value: 'All', icon: 'mdi-home' },
     { key: USER_CONSUMPTION.toLowerCase(), value: 'MyConsumption', icon: USER_CONSUMPTION_ICON },

--- a/src/store.js
+++ b/src/store.js
@@ -25,8 +25,7 @@ export const useAppStore = defineStore('app', {
       price_list_display_default_mode: constants.DISPLAY_LIST[0].key,
       location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,
       barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key,
-      barcode_scanner_library: constants.BARCODE_SCANNER_DISPLAY_LIST[0].key,
-      price_form_default_mode: constants.PRICE_FORM_DISPLAY_LIST[0].key
+      barcode_scanner_library: constants.BARCODE_SCANNER_DISPLAY_LIST[0].key
     },
   }),
   getters: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -125,18 +125,6 @@
             :item-value="item => item.key"
             hide-details="auto"
           />
-          <!-- Price Validation -->
-          <h3 class="mt-4 mb-1">
-            {{ $t('UserSettings.PriceValidation') }}
-          </h3>
-          <v-select
-            v-model="appStore.user.price_form_default_mode"
-            :label="$t('UserSettings.DefaultMode')"
-            :items="priceFormDisplayList"
-            :item-title="item => $t('Common.' + item.value)"
-            :item-value="item => item.key"
-            hide-details="auto"
-          />
         </v-card-text>
       </v-card>
     </v-col>
@@ -229,7 +217,6 @@ export default {
       locationSelectorDisplayList: constants.LOCATION_SELECTOR_DISPLAY_LIST,
       productSelectorDisplayList: constants.PRODUCT_SELECTOR_DISPLAY_LIST,
       barcodeScannerDisplayList: constants.BARCODE_SCANNER_DISPLAY_LIST,
-      priceFormDisplayList: constants.PRICE_FORM_DISPLAY_LIST
     }
   },
   computed: {


### PR DESCRIPTION
### What

Have only 1 display mode in the Price Validation Assistant
- fix by default
- remove the show/edit settings

### Why

- avoid 1 click
- cleaner UI in the edit mode thanks to changes in #1818
- simplify the code

### Screenshot

|Before|After|
|-|-|
|<img width="1208" height="708" alt="image" src="https://github.com/user-attachments/assets/f8f9c212-344a-42a9-a35d-fcf39de26e69" />|<img width="1208" height="785" alt="image" src="https://github.com/user-attachments/assets/781ba5dd-5e0c-4e07-b431-a26fd9326da5" />|
