### PR TITLE
refactor(Dialogs): cleaner UI (remove space & divider) for edit, delete & flag dialogs (price & proof)

### DIFF
--- a/src/components/ModerationFlagCreateDialog.vue
+++ b/src/components/ModerationFlagCreateDialog.vue
@@ -8,17 +8,13 @@
       <v-divider />
 
       <v-card-text>
-        <v-row>
+        <v-row class="mb-4">
           <v-col cols="12">
             <PriceCard v-if="price" :price="price" :product="price.product" :hidePriceFooterRow="false" :hideActionMenuButton="true" :readonly="true" />
             <ProofCard v-else-if="proof" :proof="proof" :hideProofHeader="true" :hideActionMenuButton="true" :readonly="true" />
           </v-col>
         </v-row>
-      </v-card-text>
-
-      <v-divider />
-
-      <v-card-text>
+        <!-- form -->
         <v-row>
           <v-col cols="12">
             <div class="text-body-2 required">
@@ -35,6 +31,8 @@
               hide-details="auto"
             />
           </v-col>
+        </v-row>
+        <v-row class="mt-0">
           <v-col v-if="!displayCommentField" cols="12">
             <a class="fake-link text-body-2" role="link" tabindex="0" @click="displayCommentField = true" @keydown.enter="displayOwnerCommentField = true">
               {{ $t('Common.AddComment') }}

--- a/src/components/PriceDeleteConfirmationDialog.vue
+++ b/src/components/PriceDeleteConfirmationDialog.vue
@@ -8,33 +8,34 @@
       <v-divider />
 
       <v-card-text>
-        <v-row>
+        <v-row class="mb-4">
           <v-col cols="12">
             <PriceCard v-if="price" :price="price" :product="price.product" :hidePriceFooterRow="false" :hideActionMenuButton="true" :readonly="true" />
           </v-col>
         </v-row>
+        <!-- moderator-only alerts -->
         <v-row v-if="!userIsPriceOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-not-price-owner-alert" type="info" icon="mdi-account-off" variant="outlined">
+            <v-alert data-name="user-not-price-owner-alert" type="info" density="compact" variant="outlined" icon="mdi-account-off">
               {{ $t('Common.UserIsNotPriceOwner') }}
             </v-alert>
           </v-col>
         </v-row>
         <v-row v-if="!userIsPriceOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-price-delete-moderator-alert" type="info" icon="mdi-shield-account" variant="outlined">
+            <v-alert data-name="user-price-delete-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
               {{ $t('Common.UserIsModeratorCanDeletePrice') }}
             </v-alert>
           </v-col>
         </v-row>
-      </v-card-text>
-
-      <v-divider />
-
-      <v-card-text>
-        <p class="mb-1">
-          {{ $t('PriceDelete.Confirmation') }}
-        </p>
+        <!-- confirmation message -->
+        <v-row class="mt-0">
+          <v-col cols="12">
+            <p>
+              {{ $t('PriceDelete.Confirmation') }}
+            </p>
+          </v-col>
+        </v-row>
       </v-card-text>
 
       <v-divider />

--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -8,30 +8,27 @@
       <v-divider />
 
       <v-card-text>
-        <v-row>
+        <v-row class="mb-4">
           <v-col cols="12">
             <PriceCard v-if="price" :price="price" :product="price.product" :hidePriceFooterRow="false" :hideActionMenuButton="true" :readonly="true" />
           </v-col>
         </v-row>
+        <!-- moderator-only alerts -->
         <v-row v-if="!userIsPriceOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-not-price-owner-alert" type="info" icon="mdi-account-off" variant="outlined">
+            <v-alert data-name="user-not-price-owner-alert" type="info" density="compact" variant="outlined" icon="mdi-account-off">
               {{ $t('Common.UserIsNotPriceOwner') }}
             </v-alert>
           </v-col>
         </v-row>
         <v-row v-if="!userIsPriceOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-price-edit-moderator-alert" type="info" icon="mdi-shield-account" variant="outlined">
+            <v-alert data-name="user-price-edit-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
               {{ $t('Common.UserIsModeratorCanEditPrice') }}
             </v-alert>
           </v-col>
         </v-row>
-      </v-card-text>
-
-      <v-divider />
-
-      <v-card-text>
+        <!-- form -->
         <ProductInputRow v-if="productIsTypeCategory" :productForm="updatePriceForm" :hideBarcodeMode="true" />
         <PriceInputRow :priceForm="updatePriceForm" :product="price.product" :proofType="price.proof ? price.proof.type : null" :hideCurrencyChoice="true" />
       </v-card-text>

--- a/src/components/ProofDeleteConfirmationDialog.vue
+++ b/src/components/ProofDeleteConfirmationDialog.vue
@@ -8,33 +8,34 @@
       <v-divider />
 
       <v-card-text>
-        <v-row>
+        <v-row class="mb-4">
           <v-col cols="12">
             <ProofCard :proof="proof" :hideProofHeader="true" :hideActionMenuButton="true" :readonly="true" />
           </v-col>
         </v-row>
+        <!-- moderator-only alerts -->
         <v-row v-if="!userIsProofOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-not-proof-owner-alert" type="info" icon="mdi-account-off" variant="outlined">
+            <v-alert data-name="user-not-proof-owner-alert" type="info" density="compact" variant="outlined" icon="mdi-account-off">
               {{ $t('Common.UserIsNotProofOwner') }}
             </v-alert>
           </v-col>
         </v-row>
         <v-row v-if="!userIsProofOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-proof-delete-moderator-alert" type="info" icon="mdi-shield-account" variant="outlined">
+            <v-alert data-name="user-proof-delete-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
               {{ $t('Common.UserIsModeratorCanDeleteProof') }}
             </v-alert>
           </v-col>
         </v-row>
-      </v-card-text>
-
-      <v-divider />
-
-      <v-card-text>
-        <p class="mb-1">
-          {{ $t('ProofDelete.Confirmation') }}
-        </p>
+        <!-- confirmation message -->
+        <v-row class="mt-0">
+          <v-col cols="12">
+            <p>
+              {{ $t('ProofDelete.Confirmation') }}
+            </p>
+          </v-col>
+        </v-row>
       </v-card-text>
 
       <v-divider />

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -8,30 +8,27 @@
       <v-divider />
 
       <v-card-text>
-        <v-row>
+        <v-row class="mb-4">
           <v-col cols="12">
             <ProofCard :proof="proof" :hideProofHeader="true" :hideActionMenuButton="true" :readonly="true" />
           </v-col>
         </v-row>
+        <!-- moderator-only alerts -->
         <v-row v-if="!userIsProofOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-not-proof-owner-alert" type="info" icon="mdi-account-off" variant="outlined">
+            <v-alert data-name="user-not-proof-owner-alert" type="info" density="compact" variant="outlined" icon="mdi-account-off">
               {{ $t('Common.UserIsNotProofOwner') }}
             </v-alert>
           </v-col>
         </v-row>
         <v-row v-if="!userIsProofOwner && userIsModerator" class="mt-0">
           <v-col cols="12">
-            <v-alert data-name="user-proof-edit-moderator-alert" type="info" icon="mdi-shield-account" variant="outlined">
+            <v-alert data-name="user-proof-edit-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
               {{ $t('Common.UserIsModeratorCanEditProof') }}
             </v-alert>
           </v-col>
         </v-row>
-      </v-card-text>
-
-      <v-divider />
-
-      <v-card-text>
+        <!-- form -->
         <ProofTypeInputRow :proofTypeForm="updateProofForm" />
         <ProofMetadataInputRow :proofMetadataForm="updateProofForm" :proofType="updateProofForm.type" />
       </v-card-text>

--- a/src/components/ProofMetadataInputRow.vue
+++ b/src/components/ProofMetadataInputRow.vue
@@ -110,15 +110,15 @@
       <v-alert
         v-if="proofIsTypePriceTag"
         type="info"
-        variant="outlined"
         density="compact"
+        variant="outlined"
         :text="$t('ProofAdd.PriceTagAIWarning')"
       />
       <v-alert
         v-else-if="proofIsTypeReceipt"
         type="info"
-        variant="outlined"
         density="compact"
+        variant="outlined"
         :text="$t('ProofAdd.ReceiptAIWarning')"
       />
     </v-col>


### PR DESCRIPTION
### What

Following a comment here: https://github.com/openfoodfacts/open-prices-frontend/pull/1825#issuecomment-3536732656
- remove blank space & divider
- impact: Price edit/delete dialog ; Proof edit/delete dialog ; price/proof flag dialog

### Screenshot

||Before|After|
|-|-|-|
|Price flag|<img width="414" height="861" alt="image" src="https://github.com/user-attachments/assets/57dfdc32-0ec4-4f46-af87-24e6e9764e43" />|<img width="414" height="861" alt="image" src="https://github.com/user-attachments/assets/8b68d818-bd96-49e3-a9f5-c7f7b2cbe129" />|
