### PR TITLE
refactor(Price input): remove unused/old currency selector

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -24,7 +24,7 @@
         </v-col>
       </v-row>
       <ProductInputRow :productForm="productPriceForm" :disableInitWhenSwitchingType="true" :hideProductBarcode="false" :hideBarcodeScannerTab="hideProductBarcodeScannerTab" @filled="productFormFilled = $event" />
-      <PriceInputRow :priceForm="productPriceForm" :hideCurrencyChoice="true" :product="productPriceForm.product" :proofType="productPriceForm.proof ? productPriceForm.proof.type : null" @filled="pricePriceFormFilled = $event" />
+      <PriceInputRow :priceForm="productPriceForm" :product="productPriceForm.product" :proofType="productPriceForm.proof ? productPriceForm.proof.type : null" @filled="pricePriceFormFilled = $event" />
       <v-alert
         v-if="!productPriceFormValid"
         class="mt-4 mb-4"

--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -30,7 +30,7 @@
         </v-row>
         <!-- form -->
         <ProductInputRow v-if="productIsTypeCategory" :productForm="updatePriceForm" :hideBarcodeMode="true" />
-        <PriceInputRow :priceForm="updatePriceForm" :product="price.product" :proofType="price.proof ? price.proof.type : null" :hideCurrencyChoice="true" />
+        <PriceInputRow :priceForm="updatePriceForm" :product="price.product" :proofType="price.proof ? price.proof.type : null" />
       </v-card-text>
 
       <v-divider />

--- a/src/components/PriceInputRow.vue
+++ b/src/components/PriceInputRow.vue
@@ -28,12 +28,7 @@
         :hint="getPricePerUnit(priceForm.price)"
         persistent-hint
         @update:modelValue="newValue => priceForm.price = replaceCommaWithDot(newValue)"
-      >
-        <template v-if="!hideCurrencyChoice" #prepend-inner>
-          <!-- image from https://www.svgrepo.com/svg/32717/currency-exchange -->
-          <img class="icon-info-currency" role="button" tabindex="0" src="/currency-exchange-svgrepo-com.svg" alt="Currency Exchange icon" @click="changeCurrencyDialog = true" @keydown.enter="changeCurrencyDialog = true" />
-        </template>
-      </v-text-field>
+      />
     </v-col>
     <v-col v-if="priceForm.price_is_discounted" cols="6" class="pb-0">
       <div class="text-body-2">
@@ -119,25 +114,14 @@
       />
     </v-col>
   </v-row>
-
-  <ChangeCurrencyDialog
-    v-if="changeCurrencyDialog"
-    v-model="changeCurrencyDialog"
-    @newCurrencySelected="setCurrencyData($event)"
-    @close="changeCurrencyDialog = false"
-  />
 </template>
 
 <script>
-import { defineAsyncComponent } from 'vue'
 import constants from '../constants'
 import price_utils from '../utils/price.js'
 import utils from '../utils.js'
 
 export default {
-  components: {
-    ChangeCurrencyDialog: defineAsyncComponent(() => import('../components/ChangeCurrencyDialog.vue')),
-  },
   props: {
     priceForm: {
       type: Object,
@@ -152,10 +136,6 @@ export default {
         receipt_quantity: null,
       })
     },
-    hideCurrencyChoice: {
-      type: Boolean,
-      default: false
-    },
     product: {
       type: Object,
       default: null
@@ -169,7 +149,6 @@ export default {
   data() {
     return {
       displayOwnerCommentField: null,  // see mounted
-      changeCurrencyDialog: false,
       CATEGORY_PRICE_PER_LIST: [
         {key: 'KILOGRAM', value: this.$t('AddPriceSingle.CategoryPricePer.PerKg'), icon: 'mdi-weight-kilogram'},
         {key: 'UNIT', value: this.$t('AddPriceSingle.CategoryPricePer.PerUnit'), icon: 'mdi-numeric-1-circle'}

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -58,7 +58,7 @@
                 </v-alert>
               </v-col>
             </v-row>
-            <PriceInputRow :priceForm="productPriceForm" :product="productPriceForm.product" :proofType="proofObject.type" :hideCurrencyChoice="true" @filled="pricePriceFormFilled = $event" />
+            <PriceInputRow :priceForm="productPriceForm" :product="productPriceForm.product" :proofType="proofObject.type" @filled="pricePriceFormFilled = $event" />
           </v-card-text>
           <v-divider />
           <v-card-actions>

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -45,7 +45,7 @@
           </template>
           <v-divider />
           <v-card-text>
-            <PriceInputRow :priceForm="addPriceSingleForm" :product="addPriceSingleForm.product" :hideCurrencyChoice="true" @filled="priceFormFilled = $event" />
+            <PriceInputRow :priceForm="addPriceSingleForm" :product="addPriceSingleForm.product" @filled="priceFormFilled = $event" />
           </v-card-text>
         </v-card>
       </v-col>


### PR DESCRIPTION
### What

Old component that is not used anymore
- had been introduced in #397
- at least in the Price input, as the currency is set on the proof
- could be useful one day on the proof side ?
