### PR TITLE
refactor(Proof Price Tag Assistant): only newly created labels can be deleted

### DIFF
--- a/src/components/ContributionAssistantLabelCard.vue
+++ b/src/components/ContributionAssistantLabelCard.vue
@@ -4,22 +4,18 @@
       <v-img :src="label.imageSrc" height="150px" />
     </v-card-text>
     <v-divider />
-    <v-card-actions>
-      <v-btn v-if="!$vuetify.display.smAndUp && !labelHasPrice" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Delete')" @click="removeLabel()" />
-      <v-btn
-        v-else-if="!labelHasPrice"
-        color="error"
-        variant="outlined"
-        prepend-icon="mdi-delete"
-        size="small"
-        @click="removeLabel()"
-      >
-        {{ $t('Common.Delete') }}
-      </v-btn>
+    <v-card-text>
       <v-chip class="mr-1" label size="small" density="comfortable" prepend-icon="mdi-information-outline">
         {{ label.boundingSource }}
       </v-chip>
-      <PriceCountChip v-if="labelHasPrice" :count="1" :withLabel="true" />
+      <PriceCountChip v-if="hasPrice" :count="1" :withLabel="true" />
+    </v-card-text>
+    <v-divider v-if="canBeDeleted" />
+    <v-card-actions v-if="canBeDeleted">
+      <v-btn v-if="!$vuetify.display.smAndUp" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Delete')" @click="removeLabel()" />
+      <v-btn v-else color="error" variant="outlined" prepend-icon="mdi-delete" size="small" @click="removeLabel()">
+        {{ $t('Common.Delete') }}
+      </v-btn>
     </v-card-actions>
   </v-card>
 </template>
@@ -39,8 +35,17 @@ export default {
   },
   emits: ['removeLabel'],
   computed: {
-    labelHasPrice() {
+    hasPrice() {
       return this.label.status === 1
+    },
+    sourceIsManual() {
+      return this.label.boundingSource === 'manual'
+    },
+    newlyCreated() {
+      return !this.label.id
+    },
+    canBeDeleted() {
+      return this.sourceIsManual && this.newlyCreated
     }
   },
   methods: {


### PR DESCRIPTION
### What

Following #1837 (new ContributionAssistantLabelCard component)

Start improving the label card
- separate label info & delete button
- show the delete button only for newly created (manual) labels

### Screenshot

||Screenshot|
|-|-|
|Before|<img width="1815" height="848" alt="image" src="https://github.com/user-attachments/assets/a7acf3ee-bdcd-4d68-9c4c-61836534243a" />|
|After|<img width="1815" height="848" alt="image" src="https://github.com/user-attachments/assets/8a3496f6-5240-4822-a415-7d0fb5488671" />|