### PR TITLE
refactor(Location selector): when searching my OSM id, remove the osm type filtering

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -539,6 +539,10 @@ export default {
    * OPENSTREETMAP API
   */ 
 
+  /**
+   * Nominatim search by query
+   * @param q: search query
+   */
   openstreetmapNominatimSearch(q) {
     const url = `${constants.OSM_NOMINATIM_SEARCH_URL}?q=${q}&addressdetails=1&format=json&limit=${LOCATION_SEARCH_LIMIT}`
     return fetch(url, {
@@ -548,6 +552,10 @@ export default {
     .then((response) => response.json())
     .then((data) => data.filter(l => !constants.NOMINATIM_RESULT_TYPE_EXCLUDE_LIST.includes(l.type)))
   },
+ /**
+   * Nominatim lookup by OSM ID
+   * @param id: OSM ID (without prefix)
+   */
   openstreetmapNominatimLookup(id) {
     const url = `${constants.OSM_NOMINATIM_LOOKUP_URL}?osm_ids=N${id},W${id},R${id}&addressdetails=1&format=json`
     return fetch(url, {
@@ -555,10 +563,13 @@ export default {
       headers: OP_DEFAULT_HEADERS
     })
     .then((response) => response.json())
-    .then((data) => data.filter(l => !constants.NOMINATIM_RESULT_TYPE_EXCLUDE_LIST.includes(l.type)))
   },
-  // Photon: restrict the search to shop & amenity
-  openstreetmapPhotonSearch(q, restrictToShop=true) {
+  /**
+   * Photon search by query
+   * @param restrictToShop: restrict the search to shop & amenity
+   * @param filterResultsOnProperties: filter out results based on their properties.osm_value
+   */
+  openstreetmapPhotonSearch(q, restrictToShop=true, filterResultsOnProperties=true) {
     let url = `${constants.OSM_PHOTON_SEARCH_URL}?q=${q}&limit=${LOCATION_SEARCH_LIMIT}`
     if (restrictToShop) {
       url += '&osm_tag=shop&osm_tag=amenity'
@@ -569,8 +580,12 @@ export default {
     })
     .then((response) => response.json())
     .then(data => data.features)
-    .then((data) => data.filter(l => !constants.NOMINATIM_RESULT_TYPE_EXCLUDE_LIST.includes(l.properties.osm_value)))
+    .then((data) => data.filter(l => filterResultsOnProperties ? !constants.NOMINATIM_RESULT_TYPE_EXCLUDE_LIST.includes(l.properties.osm_value) : true))
   },
+  /**
+   * OpenStreetMap search by query
+   * @param source: 'nominatim' (default) or 'photon'
+   */
   openstreetmapSearch(q, source='nominatim') {
     if (source === 'photon') {
       return this.openstreetmapPhotonSearch(q)


### PR DESCRIPTION
### What

We now return any location type when search with Nominatim
(But we keep the osm type filtering when doing the normal (Photon) search)

### Why

Allow power-users (searching by id) to find non-shop locations (for instance "fuel")

### Screenshot

|Before|After|
|-|-|
|<img width="1553" height="805" alt="image" src="https://github.com/user-attachments/assets/f7eb096c-9582-4433-ac9c-a0c2bc35da9a" />|<img width="1553" height="805" alt="image" src="https://github.com/user-attachments/assets/4b46ce8c-90de-4637-bc8a-1c4a4c739ca5" />|
