### PR TITLE
refactor(Price): simplify origins_tags & labels_tags Array management

### DIFF
--- a/src/components/ContributionAssistantPriceFormCard.vue
+++ b/src/components/ContributionAssistantPriceFormCard.vue
@@ -103,7 +103,7 @@ export default {
         id: null,
         type: null,
         category_tag: null,
-        origins_tags: '',
+        origins_tags: [],
         labels_tags: [],
         price: null,
         price_per: null,

--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -78,7 +78,7 @@ export default {
         product: null,
         product_code: '',
         category_tag: null,
-        origins_tags: '',
+        origins_tags: [],
         labels_tags: [],
         price: null,
         price_per: null,

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -48,6 +48,7 @@
         :item-title="item => item.name"
         :item-value="item => item.id"
         hide-details="auto"
+        @update:modelValue="newValue => productForm.origins_tags = replaceStringWithList(newValue)"
       />
     </v-col>
     <v-col class="pt-0" cols="6">
@@ -60,6 +61,7 @@
         :label="lt.name"
         :value="lt.id"
         hide-details="auto"
+        @update:modelValue="newValue => productForm.labels_tags = replaceStringWithList(newValue)"
       />
     </v-col>
   </v-row>
@@ -96,7 +98,7 @@ export default {
         product: null,
         product_code: '',
         category_tag: null,
-        origins_tags: '',
+        origins_tags: [],
         labels_tags: []
       })
     },
@@ -197,7 +199,7 @@ export default {
       this.productForm.product = null
       this.productForm.product_code = ''
       this.productForm.category_tag = null
-      this.productForm.origins_tags = ''
+      this.productForm.origins_tags = []
       this.productForm.labels_tags = []
     },
     setType(type) {
@@ -222,6 +224,9 @@ export default {
           console.log(error)
         })
     },
+    replaceStringWithList(value) {
+      return utils.replaceStringWithList(value)
+    }
   }
 }
 </script>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -52,20 +52,12 @@ function extraPriceCreateOrUpdateFiltering(data) {
   else if (filteredData.type == constants.PRICE_TYPE_CATEGORY) {
     delete filteredData.product_code
     delete filteredData.product
-    if (filteredData.origins_tags.length) {
-      if (typeof filteredData.origins_tags === 'string') {
-        filteredData.origins_tags = [filteredData.origins_tags]
-      }
-    } else {
-      filteredData.origins_tags = ['en:unknown']
+    if (filteredData.origins_tags === null || (Array.isArray(filteredData.origins_tags) && filteredData.origins_tags == [''])) {
+      filteredData.origins_tags = []
+      // backend will default to ['en:unknown']
     }
-    if (filteredData.labels_tags) {
-      if (filteredData.labels_tags.length == 0) {
-        filteredData.labels_tags = null
-      }
-      else if (typeof filteredData.labels_tags === 'string') {
-        filteredData.labels_tags = [filteredData.labels_tags]
-      }
+    if (filteredData.labels_tags === null || (Array.isArray(filteredData.labels_tags) && filteredData.labels_tags == [''])) {
+      filteredData.labels_tags = []
     }
   }
   // generic rules

--- a/src/utils.js
+++ b/src/utils.js
@@ -129,6 +129,16 @@ function replaceCommaWithDot(value) {
   return value
 }
 
+function replaceStringWithList(value) {
+  if (value === null) {
+    return []
+  }
+  if (typeof value === 'string') {
+    return value ? [value] : []
+  }
+  return value
+}
+
 export default {
   debounce,
   getDocumentScrollPercentage,
@@ -147,5 +157,6 @@ export default {
   getLocaleLabelTags,
   getLocaleLabelTagName,
   toTitleCase,
-  replaceCommaWithDot
+  replaceCommaWithDot,
+  replaceStringWithList
 }

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -199,7 +199,7 @@ export default {
         product: null,
         product_code: '',
         category_tag: null,
-        origins_tags: '',
+        origins_tags: [],
         labels_tags: [],
         price: null,
         price_per: null,

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -88,7 +88,7 @@ export default {
         product: null,
         product_code: '',
         category_tag: null,
-        origins_tags: '',
+        origins_tags: [],
         labels_tags: [],
         price: null,
         price_per: null,


### PR DESCRIPTION
### What

Manage `origins_tags` (and `labels_tags`) as lists instead of strings.
Delegate to the backend the logic of having `en:unknown` set as a default (for origins_tags only)