### PR TITLE
refactor(PriceCategoryDetailsRow): add option to display the price's category_tag chip before the origins & labels

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -11,8 +11,8 @@
             {{ productTitle }}
           </h3>
 
-          <ProductDetailsRow v-if="!hideProductDetailsRow && hasProduct" :product="product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :readonly="readonly" />
-          <PriceCategoryDetailsRow v-else-if="!hideProductDetailsRow" :price="price" />
+          <ProductDetailsRow v-if="!hideProductDetailsRow && hasProduct" class="mt-0" :product="product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :readonly="readonly" />
+          <PriceCategoryDetailsRow v-else-if="!hideProductDetailsRow" class="mt-0" :price="price" />
 
           <PricePriceRow v-if="price" class="mt-0" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" :hidePriceReceiptQuantity="hidePriceReceiptQuantity" />
         </v-col>

--- a/src/components/PriceCategoryDetailsRow.vue
+++ b/src/components/PriceCategoryDetailsRow.vue
@@ -1,6 +1,7 @@
 <template>
-  <v-row class="mt-0">
+  <v-row>
     <v-col cols="12" class="pt-2 pb-2">
+      <PriceCategoryChip v-if="!hideCategoryChip" :priceCategory="price.category_tag" />
       <PriceOrigins v-if="hasPriceOrigin" class="mr-1" :priceOrigins="price.origins_tags" />
       <PriceLabels v-if="hasPriceLabels" :priceLabels="price.labels_tags" />
     </v-col>
@@ -12,6 +13,7 @@ import { defineAsyncComponent } from 'vue'
 
 export default {
   components: {
+    PriceCategoryChip: defineAsyncComponent(() => import('../components/PriceCategoryChip.vue')),
     PriceOrigins: defineAsyncComponent(() => import('../components/PriceOrigins.vue')),
     PriceLabels: defineAsyncComponent(() => import('../components/PriceLabels.vue')),
   },
@@ -20,6 +22,10 @@ export default {
       type: Object,
       default: null
     },
+    hideCategoryChip: {
+      type: Boolean,
+      default: true
+    }
   },
   computed: {
     hasPriceOrigin() {

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -18,7 +18,7 @@
             </v-col>
           </v-row>
 
-          <ProductDetailsRow :product="product" :hidePriceCount="hidePriceCount" :hideCategoriesAndLabels="hideCategoriesAndLabels" :hideProductBarcode="hideProductBarcode" :hideBarcodeErrors="false" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
+          <ProductDetailsRow class="mt-0" :product="product" :hidePriceCount="hidePriceCount" :hideCategoriesAndLabels="hideCategoriesAndLabels" :hideProductBarcode="hideProductBarcode" :hideBarcodeErrors="false" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
         </v-col>
       </v-row>
     </v-container>

--- a/src/components/ProductDetailsRow.vue
+++ b/src/components/ProductDetailsRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row class="mt-0">
+  <v-row>
     <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
       <PriceCountChip v-if="!hidePriceCount" class="mr-1" :count="product.price_count" @click="goToProduct()" />
       <span v-if="hasProductSource">


### PR DESCRIPTION
### What

PriceCategoryDetailsRow component
- new `hideCategoryChip` prop
- avoid setting class `mt-0` in the components