### PR TITLE
refactor(PriceQuantityPurchasedChip): remove hard-coded margin-left class

### DIFF
--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -9,7 +9,7 @@
           <v-tooltip v-if="price.price_without_discount" activator="parent" open-on-click location="top">{{ $t('PriceCard.FullPrice') }} {{ getPriceValueDisplay(price.price_without_discount) }}</v-tooltip>
         </v-chip>
       </span>
-      <span v-if="!hidePriceReceiptQuantity && price.receipt_quantity" class="mr-1">
+      <span v-if="!hidePriceReceiptQuantity && price.receipt_quantity" class="ml-1">
         <PriceQuantityPurchasedChip :priceQuantityPurchased="price.receipt_quantity" />
       </span>
     </v-col>

--- a/src/components/PriceQuantityPurchasedChip.vue
+++ b/src/components/PriceQuantityPurchasedChip.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-chip class="ml-1" variant="outlined" size="small" density="comfortable">
-    x{{ priceQuantityPurchased }}
+  <v-chip variant="outlined" size="small" density="comfortable">
+    {{ prefix }}{{ priceQuantityPurchased }}
   </v-chip>
 </template>
 
@@ -10,6 +10,11 @@ export default {
     priceQuantityPurchased: {
       type: Number,
       required: true
+    }
+  },
+  computed: {
+    prefix() {
+      return 'x'
     }
   }
 }


### PR DESCRIPTION
### What

Following the creation of the component in #1558
- move the hard-coded class outside of the component
- avoid linting error (store "x" as a variable)
