### PR TITLE
refactor(Location Selector): use LocationSearchResultCard to display the recent list

### DIFF
--- a/src/components/LocationCard.vue
+++ b/src/components/LocationCard.vue
@@ -81,7 +81,7 @@ export default {
     },
     getLocationTitle() {
       if (this.location) {
-        if (this.location.type === constants.LOCATION_TYPE_OSM) {
+        if (this.isTypeOSM) {
           return geo_utils.getLocationOSMTitle(this.location, true, false, true, false, true)
         } else if (this.location.type === constants.LOCATION_TYPE_ONLINE) {
           return geo_utils.getLocationONLINETitle(this.location)

--- a/src/components/LocationSearchResultCard.vue
+++ b/src/components/LocationSearchResultCard.vue
@@ -1,10 +1,12 @@
 <template>
   <v-card>
     <v-card-text>
-      <h4>{{ getLocationTitle(location, true, false, false) }}</h4>
-      {{ getLocationTitle(location, false, true, true) }}<br>
-      <LocationOSMTagChip class="mr-1" :location="location" />
-      <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
+      <h4>{{ getLocationTitle }}</h4>
+      <p>{{ getLocationSubtitle }}</p>
+      <template v-if="!isTypeONLINE">
+        <LocationOSMTagChip class="mr-1" :location="location" />
+        <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
+      </template>
     </v-card-text>
   </v-card>
 </template>
@@ -13,6 +15,7 @@
 import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
+import constants from '../constants'
 import geo_utils from '../utils/geo.js'
 
 export default {
@@ -28,14 +31,24 @@ export default {
   },
   computed: {
     ...mapStores(useAppStore),
+    isTypeONLINE() {
+      return this.location && this.location.type === constants.LOCATION_TYPE_ONLINE
+    },
+    getLocationTitle() {
+      if (this.isTypeONLINE) {
+        return geo_utils.getLocationONLINETitle(this.location)
+      }
+      return geo_utils.getLocationOSMTitle(this.location, true, false, false)
+    },
+    getLocationSubtitle() {
+      if (this.isTypeONLINE) {
+        return ''
+      }
+      return geo_utils.getLocationOSMTitle(this.location, false, true, true)
+    },
     showLocationOSMID() {
       return this.appStore.user.username && this.appStore.user.location_display_osm_id
     },
   },
-  methods: {
-    getLocationTitle(location, withName = true, withRoad = false, withCity = true) {
-      return geo_utils.getLocationOSMTitle(location, withName, withRoad, withCity)
-    },
-  }
 }
 </script>

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -22,12 +22,20 @@
 
         <v-tabs-window v-model="currentDisplay" disabled>
           <v-tabs-window-item value="recent">
-            <p v-for="(location, index) in recentLocations" :key="index">
-              <LocationRecentChip :location="location" :withRemoveAction="true" @click="selectLocation(location)" @click:close="removeRecentLocation(location)" />
-            </p>
-            <v-btn v-if="recentLocations.length" size="small" color="primary" @click="clearRecentLocations">
-              {{ $t('Common.Clear') }}
-            </v-btn>
+            <template v-if="recentLocations.length">
+              <v-row>
+                <v-col v-for="(location, index) in recentLocations" :key="index" cols="12" sm="6" class="pt-2 pb-2">
+                  <LocationSearchResultCard :location="location" height="100%" width="100%" elevation="1" @click="selectLocation(location)" />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col cols="12">
+                  <v-btn size="small" color="primary" @click="clearRecentLocations">
+                    {{ $t('Common.Clear') }}
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </template>
             <p v-else>
               {{ $t('LocationSelector.RecentLocations', recentLocations.length) }}
             </p>
@@ -148,7 +156,6 @@ import utils from '../utils.js'
 
 export default {
   components: {
-    LocationRecentChip: defineAsyncComponent(() => import('../components/LocationRecentChip.vue')),
     LocationSearchResultCard: defineAsyncComponent(() => import('../components/LocationSearchResultCard.vue')),
     LeafletMap: defineAsyncComponent(() => import('../components/LeafletMap.vue')),
   },


### PR DESCRIPTION
### What

Use the new `LocationSearchResultCard` component built in #1867
- slowly homogenize location info display
- we lose the per-location delete action, we'll have to find a way to re-add at some point (bottom right menu, or even swipe ?)

### Screenshot

|Before|After|
|-|-|
|<img width="407" height="478" alt="image" src="https://github.com/user-attachments/assets/bd38a527-4f53-43cc-bb20-6084f2e1d9eb" />|<img width="407" height="478" alt="image" src="https://github.com/user-attachments/assets/ae2d9805-0e5b-40ff-974b-c503bcf2ee3d" />|