### PR TITLE
feat(Proofs): allow editing a proof's location

### DIFF
--- a/src/components/LocationInputRow.vue
+++ b/src/components/LocationInputRow.vue
@@ -37,6 +37,10 @@ export default {
         location_osm_type: null
       })
     },
+    existingLocation: {
+      type: Object,
+      default: null
+    },
   },
   emits: ['location'],
   data() {
@@ -63,12 +67,12 @@ export default {
     },
   },
   mounted() {
-    // this.initLocationForm()
+    this.initLocationForm()
   },
   methods: {
     initLocationForm() {
-      if (this.recentLocations.length) {
-        this.setLocationData(this.recentLocations[0])
+      if (this.existingLocation) {
+        this.selectedLocation = this.existingLocation
       }
     },
     showLocationSelectorDialog() {

--- a/src/components/ProofEditDialog.vue
+++ b/src/components/ProofEditDialog.vue
@@ -30,6 +30,7 @@
         </v-row>
         <!-- form -->
         <ProofTypeInputRow :proofTypeForm="updateProofForm" />
+        <LocationInputRow :locationForm="updateProofForm" :existingLocation="proof.location" />
         <ProofMetadataInputRow :proofMetadataForm="updateProofForm" :proofType="updateProofForm.type" />
       </v-card-text>
 
@@ -41,7 +42,7 @@
           color="primary"
           variant="flat"
           :block="!$vuetify.display.smAndUp"
-          :disabled="!formFilled"
+          :disabled="!proofFormFilled"
           :loading="loading"
           @click="updateProof"
         >
@@ -62,6 +63,7 @@ export default {
   components: {
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
     ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
+    LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
     ProofMetadataInputRow: defineAsyncComponent(() => import('../components/ProofMetadataInputRow.vue')),
   },
   props: {
@@ -75,6 +77,9 @@ export default {
     return {
       updateProofForm: {
         type: null,
+        location_id: null,
+        location_osm_id: null,
+        location_osm_type: '',
         date: null,
         currency: null,
         receipt_price_count: null,
@@ -103,9 +108,20 @@ export default {
     dialogWidth() {
       return this.$vuetify.display.smAndUp ? '80%' : '100%'
     },
-    formFilled() {
-      let keys = ['type', 'date', 'currency']
-      return Object.values(this.updateProofForm).filter(k => keys.includes(k)).every(k => !!this.updateProofForm[k])
+    proofTypeFormFilled() {
+      return !!this.updateProofForm.type
+    },
+    proofLocationFormFilled() {
+      let keysOSM = ['location_osm_id', 'location_osm_type']
+      let keysONLINE = ['location_id']
+      return Object.keys(this.updateProofForm).filter(k => keysOSM.includes(k)).every(k => !!this.updateProofForm[k]) || Object.keys(this.updateProofForm).filter(k => keysONLINE.includes(k)).every(k => !!this.updateProofForm[k])
+    },
+    proofMetadataFormFilled() {
+      let keys = ['date', 'currency']
+      return Object.keys(this.updateProofForm).filter(k => keys.includes(k)).every(k => !!this.updateProofForm[k])
+    },
+    proofFormFilled() {
+      return this.proofTypeFormFilled && this.proofLocationFormFilled && this.proofMetadataFormFilled
     },
   },
   mounted() {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,8 +4,8 @@ import constants from '../constants'
 
 const PRICE_UPDATE_FIELDS = ['type', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'discount_type', 'price_per', 'currency', 'receipt_quantity', 'owner_comment', 'date']
 const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['product_code', 'product_name', 'location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
-const PROOF_UPDATE_FIELDS = ['type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'owner_consumption', 'owner_comment', 'ready_for_price_tag_validation']
-const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat(['location_id', 'location_osm_id', 'location_osm_type'])  // 'file'
+const PROOF_UPDATE_FIELDS = ['type', 'location_id', 'location_osm_id', 'location_osm_type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'owner_consumption', 'owner_comment', 'ready_for_price_tag_validation']
+const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat([])  // 'file'
 const LOCATION_ONLINE_CREATE_FIELDS = ['type', 'website_url']
 const LOCATION_SEARCH_LIMIT = 10
 


### PR DESCRIPTION
### What

Allow proof owners (and moderators) to edit the proof's location
- LocationInputRow: new prop to init with an existing location
- display the location selector in the proof edit dialog

### Todo

- the API doesn't yet allow changing a proof by location_id
  - so restrict the ability to change location type (hard, and unlilkely to happen often)
  - and restrict the edition to only OSM locations ?

### Screenshot

|Before|After|
|-|-|
|<img width="397" height="856" alt="image" src="https://github.com/user-attachments/assets/5e58fb43-3153-4c11-8d62-627c3d659ece" />|<img width="397" height="856" alt="image" src="https://github.com/user-attachments/assets/d71d488a-93ec-4253-b824-5541357e1500" />|