### PR TITLE
fix(Cards): avoid line jump for cards with top-right edit action

### DIFF
--- a/src/components/LocationSearchResultCard.vue
+++ b/src/components/LocationSearchResultCard.vue
@@ -7,7 +7,7 @@
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>
-            <v-col :cols="!isSelected ? '12' : '10'" :class="isSelected ? 'pr-0' : ''" @click="clickLocation()">
+            <v-col :cols="!isSelected ? '12' : '10'" @click="clickLocation()">
               <h4>{{ getLocationTitle }}</h4>
               <p>{{ getLocationSubtitle }}</p>
               <template v-if="!isTypeONLINE">
@@ -15,7 +15,7 @@
                 <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
               </template>
             </v-col>
-            <v-col v-if="isSelected" cols="2">
+            <v-col v-if="isSelected" cols="2" class="pl-0">
               <v-btn class="float-right" icon="mdi-pencil" size="x-small" density="comfortable" variant="text" :title="$t('Common.Edit')" @click="clickLocation()" />
             </v-col>
           </v-row>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -8,12 +8,12 @@
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>
-            <v-col :cols="!isSelected ? '12' : '10'" :class="isSelected ? 'pr-0' : ''">
+            <v-col :cols="!isSelected ? '12' : '10'">
               <h3 id="product-title" role="link" tabindex="0" @click="clickProduct()" @keydown.enter="clickProduct()">
                 {{ getProductTitle() }}
               </h3>
             </v-col>
-            <v-col v-if="isSelected" cols="2">
+            <v-col v-if="isSelected" cols="2" class="pl-0">
               <v-btn class="float-right" icon="mdi-pencil" size="x-small" density="comfortable" variant="text" :title="$t('Common.Edit')" @click="clickProduct()" />
             </v-col>
           </v-row>


### PR DESCRIPTION
### What

Following recent changes in the Product & Location card/input functionalities
- product card : #1818 (& #1821)
- location card : #1871

Quick fix to avoid the "edit action" icon to move to the next line

### Screenshot

||Before|After|
|-|-|-|
|Product card|<img width="516" height="270" alt="image" src="https://github.com/user-attachments/assets/3a8c0a89-0677-499c-8b3c-d39e132ad503" />|<img width="516" height="270" alt="image" src="https://github.com/user-attachments/assets/e7130deb-d503-41fd-813f-cdee90907c38" />|