### PR TITLE
refactor(Location Card): use the LocationSearchResultCard everywhere

### DIFF
--- a/src/components/LocationSearchResultCard.vue
+++ b/src/components/LocationSearchResultCard.vue
@@ -19,7 +19,7 @@
         </v-col>
       </v-row>
 
-      <LocationFooterRow v-if="location && !hideLocationFooterRow" :location="location" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
+      <LocationFooterRow v-if="location && !hideLocationFooterRow" class="mt-0" :location="location" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
     </v-card-text>
   </v-card>
 </template>
@@ -87,14 +87,19 @@ export default {
       if (this.isTypeONLINE) {
         return ''
       }
-      return geo_utils.getLocationOSMTitle(this.location, false, true, true)
+      return geo_utils.getLocationOSMTitle(this.location, false, true, false, false, false)
     },
   },
   methods: {
     clickLocation() {
       if (this.isSelected) {
         this.$emit('editLocation', this.location)
+        return
       }
+      if (this.readonly) {
+        return
+      }
+      this.$router.push({ path: `/locations/${this.location.id}` })
     }
   }
 }

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -18,7 +18,7 @@
         </v-col>
       </v-row>
 
-      <PriceFooterRow v-if="price && !hidePriceFooterRow" :price="price" :hidePriceProof="hidePriceProof" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceCreated="hidePriceCreated" :hideProductDetailsRow="hideProductDetailsRow" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
+      <PriceFooterRow v-if="price && !hidePriceFooterRow" class="mt-0" :price="price" :hidePriceProof="hidePriceProof" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceCreated="hidePriceCreated" :hideProductDetailsRow="hideProductDetailsRow" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
     </v-container>
   </v-card>
 </template>

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row class="mt-0">
+  <v-row>
     <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
       <ProofChip v-if="price.proof && !hidePriceProof" class="mr-1" :proof="price.proof" />
       <LocationChip v-if="!hidePriceLocation" class="mr-1" :location="price.location" :locationId="price.location_id" :readonly="readonly" />

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -27,7 +27,7 @@
     <v-container v-if="latestPrice" class="pa-2">
       <h4>{{ $t('ProductCard.LatestPrice') }}</h4>
       <PricePriceRow class="mt-0" :price="latestPrice" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit" />
-      <PriceFooterRow :price="latestPrice" />
+      <PriceFooterRow class="mt-0" :price="latestPrice" />
     </v-container>
   </v-card>
 </template>

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -35,6 +35,23 @@ function getLocationRoad(locationObject) {
     return locationRoad
   }
   // OP
+  // return everything from osm_display_name between locationName & locationCity
+  else if (locationObject.osm_display_name) {
+    const locationName = getLocationName(locationObject)
+    const locationCity = getLocationCity(locationObject)
+    let startIndex = locationObject.osm_display_name.indexOf(locationName)
+    if (startIndex !== -1) {
+      startIndex += locationName.length
+      let endIndex = locationObject.osm_display_name.indexOf(locationCity, startIndex)
+      if (endIndex === -1) {
+        endIndex = locationObject.osm_display_name.length
+      }
+      let locationRoad = locationObject.osm_display_name.substring(startIndex, endIndex).trim()
+      // remove leading and trailing commas
+      locationRoad = locationRoad.replace(/^,|,$/g, '').trim()
+      return locationRoad
+    }
+  }
   return ''
 }
 
@@ -73,7 +90,7 @@ function getLocationOSMTitle(locationObject, withName=true, withRoad=false, with
   if (withName) {
     locationTitle += `${getLocationName(locationObject)}`
   }
-  if (withRoad && (locationObject.address || locationObject.properties)) {
+  if (withRoad && (locationObject.address || locationObject.properties || locationObject.osm_display_name)) {
     locationTitle += locationTitle ? ', ' : ''
     locationTitle += getLocationRoad(locationObject)
   }

--- a/src/views/CountryCityDetail.vue
+++ b/src/views/CountryCityDetail.vue
@@ -19,7 +19,7 @@
     <v-window-item value="list">
       <v-row class="mt-0 mb-1">
         <v-col v-for="location in countryCityLocationList" :key="location" cols="12" sm="6" md="4" xl="3">
-          <LocationCard :location="location" :hideLocationOSMID="true" :hideCountryCity="true" height="100%" />
+          <LocationSearchResultCard :location="location" :hideCountryCity="true" height="100%" />
         </v-col>
       </v-row>
     </v-window-item>
@@ -50,7 +50,7 @@ export default {
     CountryCard: defineAsyncComponent(() => import('../components/CountryCard.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     DisplayMenu: defineAsyncComponent(() => import('../components/DisplayMenu.vue')),
-    LocationCard: defineAsyncComponent(() => import('../components/LocationCard.vue')),
+    LocationSearchResultCard: defineAsyncComponent(() => import('../components/LocationSearchResultCard.vue')),
     LeafletMap: defineAsyncComponent(() => import('../components/LeafletMap.vue')),
   },
   data() {

--- a/src/views/CountryDetail.vue
+++ b/src/views/CountryDetail.vue
@@ -19,7 +19,7 @@
     <v-window-item value="list">
       <v-row class="mt-0 mb-1">
         <v-col v-for="location in countryLocationList" :key="location" cols="12" sm="6" md="4" xl="3">
-          <LocationCard :location="location" :hideLocationOSMID="true" :hideCountryCity="true" height="100%" />
+          <LocationSearchResultCard :location="location" :hideCountryCity="true" height="100%" />
         </v-col>
       </v-row>
     </v-window-item>
@@ -50,7 +50,7 @@ export default {
     CountryCard: defineAsyncComponent(() => import('../components/CountryCard.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     DisplayMenu: defineAsyncComponent(() => import('../components/DisplayMenu.vue')),
-    LocationCard: defineAsyncComponent(() => import('../components/LocationCard.vue')),
+    LocationSearchResultCard: defineAsyncComponent(() => import('../components/LocationSearchResultCard.vue')),
     LeafletMap: defineAsyncComponent(() => import('../components/LeafletMap.vue')),
   },
   data() {

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <LocationCard :location="location" readonly />
+      <LocationSearchResultCard v-if="location" :location="location" readonly />
       <p v-if="!loading && !location" class="text-red">
         {{ $t('Common.LocationNotFound') }}
       </p>
@@ -59,7 +59,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
-    LocationCard: defineAsyncComponent(() => import('../components/LocationCard.vue')),
+    LocationSearchResultCard: defineAsyncComponent(() => import('../components/LocationSearchResultCard.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -11,7 +11,7 @@
 
   <v-row class="mt-0">
     <v-col v-for="location in locationList" :key="location" cols="12" sm="6" md="4" xl="3">
-      <LocationCard :location="location" :hideLocationOSMID="true" height="100%" />
+      <LocationSearchResultCard :location="location" height="100%" />
     </v-col>
   </v-row>
 
@@ -30,9 +30,9 @@ import utils from '../utils.js'
 
 export default {
   components: {
-    LocationCard: defineAsyncComponent(() => import('../components/LocationCard.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
+    LocationSearchResultCard: defineAsyncComponent(() => import('../components/LocationSearchResultCard.vue')),
   },
   data() {
     return {


### PR DESCRIPTION
### What

Use the `LocationSearchResultCard` in the following pages (replacing the existing `LocationCard`)
- location list & location detail
- city & cityCountry detail

### Screenshot

||Image|
|-|-|
|LocationList (before)|<img width="1185" height="192" alt="image" src="https://github.com/user-attachments/assets/84545abe-fe96-4aa2-a3df-9dd5ef09b181" />|
|LocationList (after)|<img width="1185" height="192" alt="image" src="https://github.com/user-attachments/assets/6bed097f-151f-42db-9d46-d159999714d9" />|
