### PR TITLE
refactor(Cards): homogenize padding & layout between Product, Price & Location cards. Avoid using v-container

### DIFF
--- a/src/components/LocationCard.vue
+++ b/src/components/LocationCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card :class="isSelected ? 'border-success' : ''" data-name="location-search-result-card">
+  <v-card v-if="location" :id="'location_' + location.id" :class="isSelected ? 'border-success' : ''" data-name="location-card">
     <v-card-text class="pa-2">
       <v-row>
         <v-col class="pr-0" style="max-width:20%;">
@@ -19,7 +19,7 @@
         </v-col>
       </v-row>
 
-      <LocationFooterRow v-if="location && !hideLocationFooterRow" class="mt-0" :location="location" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
+      <LocationFooterRow v-if="!hideLocationFooterRow" class="mt-0" :location="location" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
     </v-card-text>
   </v-card>
 </template>

--- a/src/components/LocationDetailsRow.vue
+++ b/src/components/LocationDetailsRow.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-row class="mt-0">
-    <v-col cols="12">
+  <v-row>
+    <v-col cols="12" class="pt-2 pb-2">
       <LocationOSMTagChip class="mr-1" :location="location" />
       <LocationOSMIDChip v-if="showLocationOSMID" :location="location" />
       <template v-if="!hideCountryCity">

--- a/src/components/LocationFooterRow.vue
+++ b/src/components/LocationFooterRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
+    <v-col :cols="hideActionMenuButton ? '12' : '11'">
       <PriceCountChip class="mr-1" :count="location.price_count" :withLabel="true" source="location" @click="goToLocation()" />
       <UserCountChip class="mr-1" :count="location.user_count" :withLabel="true" />
       <ProductCountChip class="mr-1" :count="location.product_count" :withLabel="true" />

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -24,8 +24,8 @@
           <v-tabs-window-item value="recent">
             <template v-if="recentLocations.length">
               <v-row>
-                <v-col v-for="(location, index) in recentLocations" :key="index" cols="12" sm="6" class="pt-2 pb-2">
-                  <LocationCard :location="location" :hideLocationFooterRow="true" height="100%" width="100%" elevation="1" @click="selectLocation(location)" />
+                <v-col v-for="(location, index) in recentLocations" :key="index" cols="12" sm="6">
+                  <LocationCard :location="location" :hideLocationFooterRow="true" class="mb-2" height="100%" width="100%" elevation="1" @click="selectLocation(location)" />
                 </v-col>
               </v-row>
               <v-row>

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card v-if="price" :id="'price_' + price.id" data-name="price-card">
-    <v-container class="pa-2">
+    <v-card-text class="pa-2">
       <v-row>
         <v-col v-if="!hideProductImage" class="pr-0" style="max-width:20%;">
           <v-img v-if="product && product.image_url" :src="product.image_url" max-height="100px" @click="goToProduct()" />
-          <v-img v-else :src="productImageDefault" height="50px" width="50px" style="filter:invert(.9);" />
+          <v-img v-else :src="productImageDefault" width="100px" style="filter:invert(.9);" />
         </v-col>
         <v-col :style="hideProductImage ? '' : 'max-width:80%'">
           <h3 v-if="!hideProductTitle" id="product-title" role="link" tabindex="0" @click="goToProduct()" @keydown.enter="goToProduct()">
@@ -14,12 +14,12 @@
           <ProductDetailsRow v-if="!hideProductDetailsRow && hasProduct" class="mt-0" :product="product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :readonly="readonly" />
           <PriceCategoryDetailsRow v-else-if="!hideProductDetailsRow" class="mt-0" :price="price" />
 
-          <PricePriceRow v-if="price" class="mt-0" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" :hidePriceReceiptQuantity="hidePriceReceiptQuantity" />
+          <PricePriceRow class="mt-0" :price="price" :productQuantity="product ? product.product_quantity : null" :productQuantityUnit="product ? product.product_quantity_unit : null" :hidePriceReceiptQuantity="hidePriceReceiptQuantity" />
         </v-col>
       </v-row>
 
-      <PriceFooterRow v-if="price && !hidePriceFooterRow" class="mt-0" :price="price" :hidePriceProof="hidePriceProof" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceCreated="hidePriceCreated" :hideProductDetailsRow="hideProductDetailsRow" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
-    </v-container>
+      <PriceFooterRow v-if="!hidePriceFooterRow" class="mt-0" :price="price" :hidePriceProof="hidePriceProof" :hidePriceLocation="hidePriceLocation" :hidePriceOwner="hidePriceOwner" :hidePriceDate="hidePriceDate" :hidePriceCreated="hidePriceCreated" :hideProductDetailsRow="hideProductDetailsRow" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
+    </v-card-text>
   </v-card>
 </template>
 

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
+    <v-col :cols="hideActionMenuButton ? '12' : '11'">
       <ProofChip v-if="price.proof && !hidePriceProof" class="mr-1" :proof="price.proof" />
       <LocationChip v-if="!hidePriceLocation" class="mr-1" :location="price.location" :locationId="price.location_id" :readonly="readonly" />
       <UserChip v-if="!hidePriceOwner" class="mr-1" :username="price.owner" :readonly="readonly" />

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card v-if="product" :id="'product_' + product.code" :class="isSelected ? 'border-success' : ''" data-name="product-card">
-    <v-container class="pa-2" :style="latestPrice ? 'position:relative;' : ''">
-      <v-row v-if="product">
+    <v-card-text class="pa-2" :style="latestPrice ? 'position:relative;' : ''">
+      <v-row>
         <v-col class="pr-0" style="max-width:20%;">
           <v-img v-if="product.image_url" :src="product.image_url" max-height="100px" @click="clickProduct()" />
-          <v-img v-if="!product.image_url" :src="productImageDefault" height="100px" width="100px" style="filter:invert(.9);" />
+          <v-img v-else :src="productImageDefault" width="100px" style="filter:invert(.9);" />
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>
@@ -21,14 +21,14 @@
           <ProductDetailsRow class="mt-0" :product="product" :hidePriceCount="hidePriceCount" :hideCategoriesAndLabels="hideCategoriesAndLabels" :hideProductBarcode="hideProductBarcode" :hideBarcodeErrors="false" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
         </v-col>
       </v-row>
-    </v-container>
+    </v-card-text>
 
     <v-divider v-if="latestPrice" />
-    <v-container v-if="latestPrice" class="pa-2">
+    <v-card-text v-if="latestPrice" class="pa-2">
       <h4>{{ $t('ProductCard.LatestPrice') }}</h4>
       <PricePriceRow class="mt-0" :price="latestPrice" :productQuantity="product.product_quantity" :productQuantityUnit="product.product_quantity_unit" />
       <PriceFooterRow class="mt-0" :price="latestPrice" />
-    </v-container>
+    </v-card-text>
   </v-card>
 </template>
 

--- a/src/components/ProofCompactCard.vue
+++ b/src/components/ProofCompactCard.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card v-if="proof" :id="'proof_' + proof.id" :class="mode == 'Uploaded' ? 'border-success' : 'border-transparent'" data-name="proof-card" @click="selectProof">
-    <v-container class="pa-2">
+    <v-card-text class="pa-2">
       <v-row>
         <v-col class="pr-0" style="max-width:20%;">
           <v-img v-if="proof.file_path" :src="getProofImageFullUrl" max-height="100px" />
@@ -10,7 +10,7 @@
           <ProofFooterRow :proof="proof" :hideActionMenuButton="hideActionMenuButton" :readonly="readonly" />
         </v-col>
       </v-row>
-    </v-container>
+    </v-card-text>
   </v-card>
 </template>
 

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col :cols="hideActionMenuButton ? '12' : '11'" class="pt-2 pb-2">
+    <v-col :cols="hideActionMenuButton ? '12' : '11'">
       <ProofChip v-if="showProofChip" class="mr-1" :proof="proof" :withLabel="showProofChip" :readonly="true" />
       <ProofTypeChip v-if="!hideProofType" class="mr-1" :proofType="proof.type" />
       <ProofUserConsumptionChip v-if="showReceiptOwnerConsumption" class="mr-1" />

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" sm="6">
-      <LocationCard v-if="location" :location="location" readonly />
+      <LocationCard :location="location" readonly />
       <p v-if="!loading && !location" class="text-red">
         {{ $t('Common.LocationNotFound') }}
       </p>


### PR DESCRIPTION
### What

Following #1888 & #1892 (linked with #1085)
- homogenize padding of Product/Price/Location cards, especially the *FooterRow
- use `v-card-text` instead of `v-container` (smaller text)
- same image (or default icon) size
