### PR TITLE
refactor(Proof upload): move the existing alert (or banner) above the form

### DIFF
--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -2,8 +2,9 @@
   <v-row>
     <v-col cols="12">
       <!-- RECEIPT: warning message -->
-      <ProofReceiptWarningAlert v-if="proofImageForm.type === PROOF_TYPE_RECEIPT" class="mb-4" />
+      <ProofReceiptWarningAlert v-if="proofIsTypeReceipt" class="mb-4" />
 
+      <!-- Selection menu -->
       <v-menu scroll-strategy="close" :disabled="loading">
         <template #activator="{ props }">
           <v-btn v-bind="props" class="text-body-2" block spaced="end" prepend-icon="mdi-image" append-icon="mdi-menu-down" :class="hasProofImageSelected ? 'border-success' : 'border-error'">
@@ -127,6 +128,15 @@ export default {
     }
   },
   computed: {
+    proofTypeFormFilled() {
+      return !!this.proofImageForm.type
+    },
+    proofIsTypePriceTag() {
+      return this.proofTypeFormFilled && (this.proofImageForm.type === constants.PROOF_TYPE_PRICE_TAG)
+    },
+    proofIsTypeReceipt() {
+      return this.proofTypeFormFilled && (this.proofImageForm.type === constants.PROOF_TYPE_RECEIPT)
+    },
     hasProofImageSelected() {
       return Array.isArray(this.proofImageList) ? this.proofImageList.length : !!this.proofImageList
     },

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -12,10 +12,14 @@
     <v-divider v-if="!hideHeader" />
     <v-card-text>
       <v-sheet v-if="step === 1">
+        <v-row v-if="typePriceTagOnly && multiple || proofIsTypePriceTag && !multiple || proofIsTypeReceipt && !assistedByAI">
+          <v-col>
+            <ProofPriceTagMultipleAlert v-if="proofIsTypePriceTag && multiple" />
+            <ProofPriceTagAddMultiplePromoBanner v-if="proofIsTypePriceTag && !multiple" />
+            <ReceiptAssistantPromoBanner v-if="proofIsTypeReceipt && !assistedByAI" />
+          </v-col>
+        </v-row>
         <ProofTypeInputRow :proofTypeForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" />
-        <ProofPriceTagMultipleAlert v-if="proofIsTypePriceTag && multiple" class="mt-4 mb-4" />
-        <ProofPriceTagAddMultiplePromoBanner v-if="proofIsTypePriceTag && !multiple" class="mt-4 mb-4" />
-        <ReceiptAssistantPromoBanner v-if="proofIsTypeReceipt && !assistedByAI" class="mt-4 mb-4" />
         <LocationInputRow :locationForm="proofForm" @location="locationObject = $event" />
         <ProofImageInputRow :proofImageForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
         <ProofMetadataInputRow :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" :assistedByAI="assistedByAI" :locationType="locationObject?.type" />
@@ -92,10 +96,10 @@ Compressor.setDefaults({
 
 export default {
   components: {
-    ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
     ProofPriceTagMultipleAlert: defineAsyncComponent(() => import('../components/ProofPriceTagMultipleAlert.vue')),
     ProofPriceTagAddMultiplePromoBanner: defineAsyncComponent(() => import('../components/ProofPriceTagAddMultiplePromoBanner.vue')),
     ReceiptAssistantPromoBanner: defineAsyncComponent(() => import('../components/ReceiptAssistantPromoBanner.vue')),
+    ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
     LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
     ProofImageInputRow: defineAsyncComponent(() => import('../components/ProofImageInputRow.vue')),
     ProofMetadataInputRow: defineAsyncComponent(() => import('../components/ProofMetadataInputRow.vue')),


### PR DESCRIPTION
### What

- move the alert or banner above the "proof type" input
- put them in a `v-row`

### Why

- clarifies the start of the form
- simplifies spacing rules
  - see next PR: #1918

### Screenshot

||Before|After|
|-|-|-|
|Proof upload: multiple price tags|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/4f736a7d-43cf-4b1f-919d-0498cfef2d4d" />|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/0c7e8467-91c4-49f7-8023-7c188cb21d12" />|
|Proof upload: receipt|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/b1758f60-6018-4f30-a86d-c9f86174e795" />|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/aa55a1c4-a12b-4baa-a07f-8750fc053798" />|
