### PR TITLE
refactor(UI): make alert & banner look similar and more compact

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -57,10 +57,11 @@
 .v-banner--density-compact {
     padding: 8px !important;
 }
-
+.v-alert__prepend,
 .v-banner__prepend {
     margin-inline-end: 12px !important;  /* to match with v-alert (16-(32-28)) */
 }
+
 .chip-group {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Following #1927 

### What

||Before|After|
|-|-|-|
|v-alert (density: compact)|padding-left: 16px<br>padding-right: 16px<br>padding-top: 8px<br>padding-bottom: 8px|padding: 8px|
|v-banner (density: compact)|padding-left: 16px<br>padding-right: 8px<br>padding-top: 16px<br>padding-bottom: 16px|padding: 8px|

### Screenshots

||Before|After padding|After padding & inline|
|-|-|-|-|
|Proof upload: receipt|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/8c66610e-afbd-47b4-be6b-5c85522e17db" />|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/936b1532-f5d8-408a-9f31-da9e54fc1872" />|<img width="412" height="776" alt="image" src="https://github.com/user-attachments/assets/42fcbba2-14a8-4505-82e0-30c36d633ae3" />|
