### PR TITLE
refactor(Product Card): only display ProductSourceChip if the product has a source (avoids duplicate message)

### DIFF
--- a/src/components/ProductDetailsRow.vue
+++ b/src/components/ProductDetailsRow.vue
@@ -95,7 +95,7 @@ export default {
       return this.product.code && !barcode_utils.isBarcodeValid(this.product.code)
     },
     showProductSource() {
-      return this.appStore.user.username && this.appStore.user.product_display_source
+      return this.hasProductSource && this.appStore.user.username && this.appStore.user.product_display_source
     },
   },
   methods: {


### PR DESCRIPTION
### What

Following #1363 & #1365.
Hide the chip if the source is unknown.
(only applies for users who have set the "show product source" setting to True)

### Screenshot

|Before|After|
|-|-|
|<img width="412" height="390" alt="image" src="https://github.com/user-attachments/assets/4946bc23-f68b-438a-ad8d-19ab25be881d" />|<img width="412" height="366" alt="image" src="https://github.com/user-attachments/assets/6a17472b-f29b-420c-ae5c-dea21aac0e14" />|
