### PR TITLE
refactor(Proof Upload): move receipt privacy warning at the top

### DIFF
--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -3,9 +3,6 @@
     <v-col>
       <v-row>
         <v-col cols="12">
-          <!-- RECEIPT: warning message -->
-          <ProofReceiptWarningAlert v-if="proofIsTypeReceipt" class="mb-3" />
-
           <div class="text-body-2 required">
             <span v-if="multiple">{{ $t('Common.Pictures') }}</span>
             <span v-else>{{ $t('Common.Picture') }}</span>
@@ -93,7 +90,6 @@ import proof_utils from '../utils/proof.js'
 
 export default {
   components: {
-    ProofReceiptWarningAlert: defineAsyncComponent(() => import('../components/ProofReceiptWarningAlert.vue')),
     UserRecentProofsDialog: defineAsyncComponent(() => import('../components/UserRecentProofsDialog.vue')),
   },
   props: {

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -14,9 +14,14 @@
       <v-sheet v-if="step === 1">
         <v-row v-if="showTopAlertOrBanner">
           <v-col>
-            <ProofPriceTagMultipleAlert v-if="proofIsTypePriceTag && multiple" />
-            <ProofPriceTagAddMultiplePromoBanner v-if="proofIsTypePriceTag && !multiple" />
-            <ReceiptAssistantPromoBanner v-if="proofIsTypeReceipt && !assistedByAI" />
+            <template v-if="proofIsTypePriceTag">
+              <ProofPriceTagAddMultiplePromoBanner v-if="!multiple" />
+              <ProofPriceTagMultipleAlert v-else />
+            </template>
+            <template v-else-if="proofIsTypeReceipt">
+              <ReceiptAssistantPromoBanner v-if="!assistedByAI" class="mb-3" />
+              <ProofReceiptWarningAlert />
+            </template>
           </v-col>
         </v-row>
         <ProofTypeInputRow :class="showTopAlertOrBanner ? 'mt-0' : ''" :proofTypeForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" />
@@ -96,9 +101,10 @@ Compressor.setDefaults({
 
 export default {
   components: {
-    ProofPriceTagMultipleAlert: defineAsyncComponent(() => import('../components/ProofPriceTagMultipleAlert.vue')),
     ProofPriceTagAddMultiplePromoBanner: defineAsyncComponent(() => import('../components/ProofPriceTagAddMultiplePromoBanner.vue')),
+    ProofPriceTagMultipleAlert: defineAsyncComponent(() => import('../components/ProofPriceTagMultipleAlert.vue')),
     ReceiptAssistantPromoBanner: defineAsyncComponent(() => import('../components/ReceiptAssistantPromoBanner.vue')),
+    ProofReceiptWarningAlert: defineAsyncComponent(() => import('../components/ProofReceiptWarningAlert.vue')),
     ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
     LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
     ProofImageInputRow: defineAsyncComponent(() => import('../components/ProofImageInputRow.vue')),
@@ -179,7 +185,7 @@ export default {
       return this.proofTypeFormFilled && (this.proofForm.type === constants.PROOF_TYPE_RECEIPT)
     },
     showTopAlertOrBanner() {
-      return this.typePriceTagOnly && this.multiple || this.proofIsTypePriceTag && !this.multiple || this.proofIsTypeReceipt && !this.assistedByAI
+      return this.proofIsTypePriceTag || this.proofIsTypeReceipt
     },
     proofImageFormFilled() {
       return !!this.proofImageList.length


### PR DESCRIPTION
### What

Following a comment in #1919
- looks much nicer in my opinion
- similar to the "price tag" proof upload workflow, where the warning alert is at the top as well

### Screenshot

||Before|After|
|-|-|-|
|Proof upload: receipt|<img width="411" height="646" alt="image" src="https://github.com/user-attachments/assets/95d8f361-ede3-4cd4-9cea-c9ee8143ab23" />|<img width="411" height="646" alt="image" src="https://github.com/user-attachments/assets/cb7b104f-ddbd-4491-8fb1-727b5f1c0dec" />|
|Proof upload: receipt assistant|<img width="411" height="646" alt="image" src="https://github.com/user-attachments/assets/270e4c5d-62ba-49bd-8a0b-b0a91c12eaef" />|<img width="411" height="646" alt="image" src="https://github.com/user-attachments/assets/b825ad99-3578-450f-8c77-638804fb00fc" />|
