### PR TITLE
refactor(UI): replace alert info (blue) color with primary (brown)

### DIFF
--- a/src/components/AIUsageAlert.vue
+++ b/src/components/AIUsageAlert.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-alert v-if="source === 'proof_price_tag'" type="info" density="compact" variant="outlined">
+  <v-alert v-if="source === 'proof_price_tag'" data-name="ai-usage-proof-price-tag-alert" type="primary" density="compact" variant="outlined" icon="mdi-information">
     {{ $t('ProofAdd.PriceTagAIWarning') }}
   </v-alert>
-  <v-alert v-else-if="source === 'proof_receipt'" type="info" density="compact" variant="outlined">
+  <v-alert v-else-if="source === 'proof_receipt'" data-name="ai-usage-proof-receipt-alert" type="primary" density="compact" variant="outlined" icon="mdi-information">
     {{ $t('ProofAdd.ReceiptAIWarning') }}
   </v-alert>
 </template>

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -85,10 +85,10 @@
               </v-row>
 
               <p v-else>
-                <v-alert class="mb-2" type="info" variant="outlined" density="compact">
+                <v-alert class="mb-2" type="primary" variant="outlined" density="compact" icon="mdi-information">
                   {{ $t('LocationSelector.NoResultHelpKeywords') }}
                 </v-alert>
-                <v-alert class="mb-2" type="info" variant="outlined" density="compact">
+                <v-alert class="mb-2" type="primary" variant="outlined" density="compact" icon="mdi-information">
                   <i18n-t keypath="LocationSelector.NoResultHelpOSM" tag="span">
                     <template #osm_name>
                       {{ OSM_NAME }}

--- a/src/components/ModerationAlert.vue
+++ b/src/components/ModerationAlert.vue
@@ -1,28 +1,28 @@
 <template>
   <template v-if="source === 'dashboard'">
-    <v-alert data-name="user-moderator-alert" type="info" variant="outlined" density="compact" icon="mdi-shield-account">
+    <v-alert data-name="user-moderator-alert" type="primary" variant="outlined" density="compact" icon="mdi-shield-account">
       {{ $t('Common.UserIsModerator') }}
     </v-alert>
   </template>
   <template v-else-if="source === 'price'">
-    <v-alert v-if="action === 'edit'" data-name="user-price-edit-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-if="action === 'edit'" data-name="user-price-edit-moderator-alert" type="primary" density="compact" variant="outlined" icon="mdi-shield-account">
       {{ $t('Common.UserIsModeratorCanEditPrice') }}
     </v-alert>
-    <v-alert v-else-if="action === 'delete'" data-name="user-price-delete-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-else-if="action === 'delete'" data-name="user-price-delete-moderator-alert" type="primary" density="compact" variant="outlined" icon="mdi-shield-account">
       {{ $t('Common.UserIsModeratorCanDeletePrice') }}
     </v-alert>
-    <v-alert v-else data-name="user-not-price-owner-alert" type="info" variant="outlined" density="compact" icon="mdi-account-off">
+    <v-alert v-else data-name="user-not-price-owner-alert" type="primary" variant="outlined" density="compact" icon="mdi-account-off">
       {{ $t('Common.UserIsNotPriceOwner') }}
     </v-alert>
   </template>
   <template v-else-if="source === 'proof'">
-    <v-alert v-if="action === 'edit'" data-name="user-proof-edit-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-if="action === 'edit'" data-name="user-proof-edit-moderator-alert" type="primary" density="compact" variant="outlined" icon="mdi-shield-account">
       {{ $t('Common.UserIsModeratorCanEditProof') }}
     </v-alert>
-    <v-alert v-else-if="action === 'delete'" data-name="user-proof-delete-moderator-alert" type="info" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-else-if="action === 'delete'" data-name="user-proof-delete-moderator-alert" type="primary" density="compact" variant="outlined" icon="mdi-shield-account">
       {{ $t('Common.UserIsModeratorCanDeleteProof') }}
     </v-alert>
-    <v-alert v-else data-name="user-not-proof-owner-alert" type="info" variant="outlined" density="compact" icon="mdi-account-off">
+    <v-alert v-else data-name="user-not-proof-owner-alert" type="primary" variant="outlined" density="compact" icon="mdi-account-off">
       {{ $t('Common.UserIsNotProofOwner') }}
     </v-alert>
   </template>

--- a/src/components/ProofPriceTagAddMultiplePromoBanner.vue
+++ b/src/components/ProofPriceTagAddMultiplePromoBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <v-banner
     icon="mdi-image-multiple"
-    bg-color="info"
+    bg-color="primary"
     rounded
     density="compact"
     @click="$router.push('/proofs/add/price-tags')"

--- a/src/components/ReceiptAssistantPromoBanner.vue
+++ b/src/components/ReceiptAssistantPromoBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <v-banner
     icon="mdi-draw"
-    bg-color="info"
+    bg-color="primary"
     rounded
     density="compact"
     @click="$router.push('/experiments/receipt-assistant')"

--- a/src/views/ChallengeList.vue
+++ b/src/views/ChallengeList.vue
@@ -62,9 +62,10 @@
     <v-col>
       <v-alert
         class="mb-2"
-        type="info"
+        type="primary"
         variant="outlined"
         density="compact"
+        icon="mdi-information"
       >
         <i18n-t keypath="Challenge.AlertNew" tag="span">
           <template #url>

--- a/src/views/Community.vue
+++ b/src/views/Community.vue
@@ -44,9 +44,10 @@
     <v-col>
       <v-alert
         class="mb-2"
-        type="info"
+        type="primary"
         variant="outlined"
         density="compact"
+        icon="mdi-information"
       >
         <i18n-t keypath="Reuses.AlertNew" tag="span">
           <template #url>

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -85,7 +85,7 @@
         >
           <v-divider />
           <v-card-text>
-            <v-alert v-if="productExists" type="info" variant="outlined" density="compact">
+            <v-alert v-if="productExists" type="warning" variant="outlined" density="compact">
               {{ $t('CreateOffProduct.ProductAlreadyExists') }}
             </v-alert>
             <div class="text-body-2">
@@ -221,7 +221,7 @@
                 {{ $t('Common.Image') }}
               </div>
               <v-img v-if="drawnImageSrc" :src="drawnImageSrc" max-height="200px" />
-              <v-alert v-else class="mb-2" type="info" variant="outlined" density="compact">
+              <v-alert v-else class="mb-2" type="primary" variant="outlined" density="compact" icon="mdi-information">
                 {{ $t('CreateOffProduct.UseCropModeToAddImage') }}
               </v-alert>
             </div>

--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -26,7 +26,7 @@
       <v-alert v-if="drawCanvasLoaded && !boundingBoxesFromServer.length && !proofWithBoundingBoxesLoading" class="mb-2" type="warning" variant="outlined" density="compact">
         {{ $t('ContributionAssistant.BoundingBoxesFromServerWarning') }}
       </v-alert>
-      <v-alert v-if="drawCanvasLoaded && proofWithBoundingBoxesLoading" class="mb-2" type="info" variant="outlined" density="compact" icon="mdi-magnify">
+      <v-alert v-if="drawCanvasLoaded && proofWithBoundingBoxesLoading" class="mb-2" type="primary" variant="outlined" density="compact" icon="mdi-information">
         {{ $t('ContributionAssistant.FindBoundingBoxesRunning') }}
         <v-progress-circular indeterminate />
       </v-alert>
@@ -157,9 +157,10 @@
         <v-col>
           <v-alert
             class="mb-2"
-            type="info"
+            type="primary"
             variant="outlined"
             density="compact"
+            icon="mdi-information"
           >
             <p>
               {{ $t('ContributionAssistant.PriceAddConfirmationMessage', { numberOfPricesAdded: productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length, date: proofObject.date, locationName: locationName }) }}

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -21,7 +21,7 @@
   
   <v-row v-if="step === 2">
     <v-col v-if="loadingPredictions" cols="12">
-      <v-alert class="mb-2" type="info" variant="outlined" density="compact">
+      <v-alert class="mb-2" type="primary" variant="outlined" density="compact" icon="mdi-information">
         {{ $t('ReceiptAssistant.WaitForExtraction') }}
         <v-progress-circular indeterminate />
       </v-alert>

--- a/src/views/Reuses.vue
+++ b/src/views/Reuses.vue
@@ -9,9 +9,10 @@
     <v-col>
       <v-alert
         class="mb-2"
-        type="info"
+        type="primary"
         variant="outlined"
         density="compact"
+        icon="mdi-information"
       >
         <i18n-t keypath="Reuses.AlertNew" tag="span">
           <template #url>

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -5,9 +5,10 @@
         <v-row>
           <v-col>
             <v-alert
-              type="info"
+              type="primary"
               variant="outlined"
               density="compact"
+              icon="mdi-information"
             >
               <i18n-t keypath="Common.SignInOFFAccount" tag="span">
                 <template #url>


### PR DESCRIPTION
### What

In #1268 & #1269 we had already replaced the default "primary" color to the OFF color system.
But there was still places where we used "info" instead of "primary".
This PR makes these last changes.

### Screenshot

||Before|After|
|-|-|-|
|Proof upload (price tags)|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/46d06c6b-9885-4383-9c3e-f738fec58fa6" />|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/c36cfa43-fa52-4215-98db-eba7fe48a95d" />|
|Proof upload (receipt)|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/d3ad68e5-a9cf-4d47-a397-e1e8dc48cf61" />|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/a0f0835c-0b6f-4357-af9d-e602eca39abd" />|
|Price edit modal|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/fa1cebaf-8b79-4857-aa88-d20725408ac1" />|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/dfa385ad-884f-42df-bd47-dd7c63e83286" />|
|Location search with 0 results|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/f2a54b30-3af7-4f9b-9920-ed4b7a28413c" />|<img width="415" height="701" alt="image" src="https://github.com/user-attachments/assets/183cc1b9-8022-4e86-9d74-48e2035d99f9" />|