### PR TITLE
feat(Prices): allow editing a price's product

### DIFF
--- a/src/components/PriceEditDialog.vue
+++ b/src/components/PriceEditDialog.vue
@@ -25,7 +25,7 @@
           </v-col>
         </v-row>
         <!-- form -->
-        <ProductInputRow v-if="productIsTypeCategory" :productForm="updatePriceForm" :hideBarcodeMode="true" />
+        <ProductInputRow :productForm="updatePriceForm" :hideProductTypeInput="true" />
         <PriceInputRow :priceForm="updatePriceForm" :product="price.product" :proofType="price.proof ? price.proof.type : null" />
       </v-card-text>
 
@@ -52,7 +52,6 @@ import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import api from '../services/api'
-import constants from '../constants'
 
 export default {
   components: {
@@ -102,9 +101,6 @@ export default {
     userIsModerator() {
       return this.username && this.appStore.user.is_moderator
     },
-    productIsTypeCategory() {
-      return this.updatePriceForm && this.updatePriceForm.type === constants.PRICE_TYPE_CATEGORY
-    },
     dialogHeight() {
       return this.$vuetify.display.smAndUp ? '80%' : '100%'
     },
@@ -123,7 +119,6 @@ export default {
       })
     },
     updatePrice() {
-      // update price
       api
         .updatePrice(this.price.id, this.updatePriceForm)
         .then((response) => {

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -12,7 +12,7 @@
       </v-item-group>
     </v-col>
   </v-row>
-  <v-row v-if="productIsTypeProduct && !hideBarcodeMode" class="mt-0">
+  <v-row v-if="productIsTypeProduct" class="mt-0">
     <v-col>
       <ProductCard v-if="productForm.product" :product="productForm.product" :hideCategoriesAndLabels="true" :hideProductBarcode="hideProductBarcode" :hideActionMenuButton="true" :isSelected="true" :readonly="true" elevation="1" @editProduct="showBarcodeScannerDialog" />
       <v-btn v-else class="text-body-2 mb-2" block spaced="end" prepend-icon="mdi-barcode-scan" :class="productForm.product ? 'border-success' : 'border-error'" @click="showBarcodeScannerDialog">
@@ -111,10 +111,6 @@ export default {
       type: Boolean,
       default: false
     },
-    hideBarcodeMode: {
-      type: Boolean,
-      default: false
-    },
     hideProductBarcode: {
       type: Boolean,
       default: true
@@ -142,9 +138,6 @@ export default {
       return this.productForm && this.productForm.type === constants.PRICE_TYPE_CATEGORY
     },
     productTypeDisplayList() {
-      if (this.hideBarcodeMode) {
-        return constants.PRICE_TYPE_LIST.filter(pt => pt.key !== constants.PRICE_TYPE_PRODUCT)
-      }
       return constants.PRICE_TYPE_LIST
     },
     productProductFormFilled() {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -2,8 +2,8 @@ import { useAppStore } from '../store'
 import constants from '../constants'
 
 
-const PRICE_UPDATE_FIELDS = ['type', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'discount_type', 'price_per', 'currency', 'receipt_quantity', 'owner_comment', 'date']
-const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['product_code', 'product_name', 'location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
+const PRICE_UPDATE_FIELDS = ['type', 'product_code', 'product_name', 'category_tag', 'labels_tags', 'origins_tags', 'price', 'price_is_discounted', 'price_without_discount', 'discount_type', 'price_per', 'currency', 'receipt_quantity', 'owner_comment', 'date']
+const PRICE_CREATE_FIELDS = PRICE_UPDATE_FIELDS.concat(['location_id', 'location_osm_id', 'location_osm_type', 'proof_id'])
 const PROOF_UPDATE_FIELDS = ['type', 'location_id', 'location_osm_id', 'location_osm_type', 'date', 'currency', 'receipt_price_count', 'receipt_price_total', 'receipt_online_delivery_costs', 'owner_consumption', 'owner_comment', 'ready_for_price_tag_validation']
 const PROOF_CREATE_FIELDS = PROOF_UPDATE_FIELDS.concat([])  // 'file'
 const LOCATION_ONLINE_CREATE_FIELDS = ['type', 'website_url']


### PR DESCRIPTION
### What

Similar to #1879 (Proof location).
And thanks to https://github.com/openfoodfacts/open-prices/issues/586 (backend change).

Allow price owners (and moderators) to edit the price's product.

We don't allow to change the product type though (from barcode to category, and vice-versa).

### Screenshot

|Before|After|
|-|-|
|<img width="408" height="851" alt="image" src="https://github.com/user-attachments/assets/1b0310c1-22f4-4897-abcc-e4c7b769eb87" />|<img width="408" height="851" alt="image" src="https://github.com/user-attachments/assets/e00836a8-bc62-44ad-b81f-ce466cf949b3" />|