### PR TITLE
refactor(Product Detail): if product missing, new promo banner to talk about the CreateOffProduct experiment

### DIFF
--- a/src/components/CreateOffProductPromoBanner.vue
+++ b/src/components/CreateOffProductPromoBanner.vue
@@ -7,7 +7,7 @@
     @click="$router.push(url)"
   >
     <v-banner-text style="padding-inline-end:10px;">
-      {{ $t('ProofAdd.PromoReceiptAssistant') }}
+      {{ $t('ProofAdd.ProductMissingPromoBanner') }}
     </v-banner-text>
     <v-spacer /><!-- needed to push v-banner-actions to the right on big screens -->
     <v-banner-actions>
@@ -20,7 +20,7 @@
 export default {
   data() {
     return {
-      url: '/experiments/receipt-assistant',
+      url: '/experiments/create-off-product',
     }
   },
 }

--- a/src/components/CreateOpenFoodFactsProductPromoBanner.vue
+++ b/src/components/CreateOpenFoodFactsProductPromoBanner.vue
@@ -6,7 +6,7 @@
     density="compact"
     @click="$router.push(url)"
   >
-    <v-banner-text style="padding-inline-end:10px;">
+    <v-banner-text>
       {{ $t('CreateOffProduct.ProductMissingPromoBanner') }}
     </v-banner-text>
     <v-spacer /><!-- needed to push v-banner-actions to the right on big screens -->

--- a/src/components/CreateOpenFoodFactsProductPromoBanner.vue
+++ b/src/components/CreateOpenFoodFactsProductPromoBanner.vue
@@ -7,7 +7,7 @@
     @click="$router.push(url)"
   >
     <v-banner-text style="padding-inline-end:10px;">
-      {{ $t('ProofAdd.ProductMissingPromoBanner') }}
+      {{ $t('CreateOffProduct.ProductMissingPromoBanner') }}
     </v-banner-text>
     <v-spacer /><!-- needed to push v-banner-actions to the right on big screens -->
     <v-banner-actions>
@@ -18,9 +18,15 @@
 
 <script>
 export default {
+  props: {
+    productCode: {
+      type: String,
+      default: '',
+    },
+  },
   data() {
     return {
-      url: '/experiments/create-off-product',
+      url: `/experiments/create-off-product?product_code=${this.productCode}`,
     }
   },
 }

--- a/src/components/ProofPriceTagAddMultiplePromoBanner.vue
+++ b/src/components/ProofPriceTagAddMultiplePromoBanner.vue
@@ -4,14 +4,24 @@
     bg-color="primary"
     rounded
     density="compact"
-    @click="$router.push('/proofs/add/price-tags')"
+    @click="$router.push(url)"
   >
     <v-banner-text style="padding-inline-end:10px;">
       {{ $t('ProofAdd.PromoProofPriceTagAddMultiple') }}
     </v-banner-text>
     <v-spacer /><!-- needed to push v-banner-actions to the right on big screens -->
     <v-banner-actions>
-      <v-btn icon="mdi-arrow-right" :aria-label="$t('Router.AddProofsPriceTags.Title')" to="/proofs/add/multiple-price-tags" />
+      <v-btn icon="mdi-arrow-right" :aria-label="$t('Router.AddProofsPriceTags.Title')" :to="url" />
     </v-banner-actions>
   </v-banner>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      url: '/proofs/add/price-tags',
+    }
+  },
+}
+</script>

--- a/src/components/ProofPriceTagAddMultiplePromoBanner.vue
+++ b/src/components/ProofPriceTagAddMultiplePromoBanner.vue
@@ -6,7 +6,7 @@
     density="compact"
     @click="$router.push(url)"
   >
-    <v-banner-text style="padding-inline-end:10px;">
+    <v-banner-text>
       {{ $t('ProofAdd.PromoProofPriceTagAddMultiple') }}
     </v-banner-text>
     <v-spacer /><!-- needed to push v-banner-actions to the right on big screens -->

--- a/src/components/ReceiptAssistantPromoBanner.vue
+++ b/src/components/ReceiptAssistantPromoBanner.vue
@@ -6,7 +6,7 @@
     density="compact"
     @click="$router.push(url)"
   >
-    <v-banner-text style="padding-inline-end:10px;">
+    <v-banner-text>
       {{ $t('ProofAdd.PromoReceiptAssistant') }}
     </v-banner-text>
     <v-spacer /><!-- needed to push v-banner-actions to the right on big screens -->

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -581,7 +581,8 @@
 		"ProductLanguage": "Product language",
 		"ProofNumberOfOutProofs": "Proof ({numberOfOutProofs}/{totalNumberOfProofs})",
 		"StoresWhereSold": "Stores where sold",
-		"UseCropModeToAddImage": "To add a product image, enable crop mode below proof picture and draw a rectangle around the product."
+		"UseCropModeToAddImage": "To add a product image, enable crop mode below proof picture and draw a rectangle around the product.",
+		"ProductMissingPromoBanner": "Experiment: create this product using data from Open Prices"
 	},
 	"UserRecentProofsDialog": {
 		"SelectRecentProof": "Select one of your recent proofs"

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -9,6 +9,7 @@
   <v-row v-if="productOrCategoryNotFound" class="mt-0">
     <v-col cols="12" sm="6">
       <ProductNotFoundAlert v-if="productNotFound" :productCode="productId" />
+      <CreateOpenFoodFactsProductPromoBanner v-if="productNotFound && priceTotal" class="mt-3" :productCode="productId" />
       <CategoryNotFoundAlert v-else-if="categoryNotFound" :categoryTag="productId" />
     </v-col>
   </v-row>
@@ -76,6 +77,7 @@ export default {
     CategoryCard: defineAsyncComponent(() => import('../components/CategoryCard.vue')),
     ProductNotFoundAlert: defineAsyncComponent(() => import('../components/ProductNotFoundAlert.vue')),
     CategoryNotFoundAlert: defineAsyncComponent(() => import('../components/CategoryNotFoundAlert.vue')),
+    CreateOpenFoodFactsProductPromoBanner: defineAsyncComponent(() => import('../components/CreateOpenFoodFactsProductPromoBanner.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),


### PR DESCRIPTION
### What

In #1685 we created a new experiment allowing users to create new products directly to Open Food Facts using Open Prices data.

Here we add a promo banner to this page `CreateOpenFoodFactsProductPromoBanner`
- on the product details page
- only if the product is not found
- and it has at least 1 price

### Screenshot

|Before|After|
|-|-|
|<img width="962" height="541" alt="image" src="https://github.com/user-attachments/assets/46ffca16-e960-46ac-8681-c5fa82d6d5b3" />|<img width="962" height="541" alt="Screenshot from 2026-01-03 22-37-06" src="https://github.com/user-attachments/assets/9d6d61a2-dcce-487d-a686-66f774108f81" />|
