### PR TITLE
refactor(Steppers): move each step in a template tag. Don't show 'action' step as complete

### DIFF
--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -7,126 +7,133 @@
           <v-divider />
           <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step > 2" />
           <v-divider />
-          <v-stepper-item :title="stepItemList[2].title" :value="stepItemList[2].value" :complete="step === 3" />
+          <v-stepper-item :title="stepItemList[2].title" :value="stepItemList[2].value" :complete="step > 3" />
         </v-stepper-header>
       </v-stepper>
     </v-col>
   </v-row>
 
-  <v-row v-if="step === 1">
-    <!-- Step 1: proof (image, location, date & currency) -->
-    <v-col cols="12" md="6">
-      <ProofUploadCard :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" @proof="onProofUploaded($event)" />
-    </v-col>
-  </v-row>
+  <!-- Step 1: proof upload -->
+  <template v-if="step === 1">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofUploadCard :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" @proof="onProofUploaded($event)" />
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 2">
-    <v-col cols="12" md="6">
-      <ProofCard mode="Uploaded" :proof="proofObject" :hideActionMenuButton="true" :readonly="true" />
-    </v-col>
-    <v-col cols="12" md="6">
-      <!-- Step 2a: product prices already uploaded -->
-      <PriceAlreadyUploadedListCard :proof="proofObject" :proofPriceUploadedList="proofPriceUploadedList" />
+  <template v-if="step === 2">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofCard mode="Uploaded" :proof="proofObject" :hideActionMenuButton="true" :readonly="true" />
+      </v-col>
+      <v-col cols="12" md="6">
+        <!-- Step 2a: product prices already uploaded -->
+        <PriceAlreadyUploadedListCard :proof="proofObject" :proofPriceUploadedList="proofPriceUploadedList" />
 
-      <!-- Step 2b: new product price form -->
-      <v-btn
-        v-if="!Object.keys(productPriceForm).length"
-        class="mr-2"
-        color="primary"
-        :loading="loading"
-        @click="initNewProductPriceForm"
-      >
-        {{ $t('AddPriceMultiple.ProductPriceDetails.Add') }}
-      </v-btn>
-      <v-form v-else @submit.prevent="createPrice">
-        <v-card
-          id="product-price-form"
-          class="border-transparent mb-4"
-          :title="$t('AddPriceMultiple.ProductPriceDetails.NewPrice')"
-          prepend-icon="mdi-tag-plus-outline"
-          height="100%"
+        <!-- Step 2b: new product price form -->
+        <v-btn
+          v-if="!Object.keys(productPriceForm).length"
+          class="mr-2"
+          color="primary"
+          :loading="loading"
+          @click="initNewProductPriceForm"
         >
-          <v-divider />
-          <v-card-text>
-            <ProductInputRow :productForm="productPriceForm" @filled="productFormFilled = $event" />
-            <v-row v-if="productFormFilled && existingProductFound" class="mt-0">
-              <v-col>
-                <v-alert data-name="existing-product-alert" type="warning" variant="outlined" density="compact">
-                  <p>
-                    <i>{{ $t('AddPriceMultiple.ProductPriceDetails.ExistingProductFound') }}</i>
-                  </p>
-                </v-alert>
-              </v-col>
-            </v-row>
-            <PriceInputRow :priceForm="productPriceForm" :product="productPriceForm.product" :proofType="proofObject.type" @filled="pricePriceFormFilled = $event" />
-          </v-card-text>
-          <v-divider />
-          <v-card-actions>
-            <v-row>
-              <v-col>
-                <v-btn
-                  density="comfortable"
-                  color="error"
-                  icon="mdi-delete"
-                  @click="clearProductPriceForm"
-                />
-              </v-col>
-              <v-spacer />
-              <v-col>
-                <v-btn
-                  class="float-right"
-                  color="primary"
-                  variant="flat"
-                  type="submit"
-                  :loading="loading"
-                  :disabled="!productPriceFormFilled"
-                >
-                  {{ $t('Common.Upload') }}
-                </v-btn>
-              </v-col>
-            </v-row>
-          </v-card-actions>
-        </v-card>
-      </v-form>
+          {{ $t('AddPriceMultiple.ProductPriceDetails.Add') }}
+        </v-btn>
+        <v-form v-else @submit.prevent="createPrice">
+          <v-card
+            id="product-price-form"
+            class="border-transparent mb-4"
+            :title="$t('AddPriceMultiple.ProductPriceDetails.NewPrice')"
+            prepend-icon="mdi-tag-plus-outline"
+            height="100%"
+          >
+            <v-divider />
+            <v-card-text>
+              <ProductInputRow :productForm="productPriceForm" @filled="productFormFilled = $event" />
+              <v-row v-if="productFormFilled && existingProductFound" class="mt-0">
+                <v-col>
+                  <v-alert data-name="existing-product-alert" type="warning" variant="outlined" density="compact">
+                    <p>
+                      <i>{{ $t('AddPriceMultiple.ProductPriceDetails.ExistingProductFound') }}</i>
+                    </p>
+                  </v-alert>
+                </v-col>
+              </v-row>
+              <PriceInputRow :priceForm="productPriceForm" :product="productPriceForm.product" :proofType="proofObject.type" @filled="pricePriceFormFilled = $event" />
+            </v-card-text>
+            <v-divider />
+            <v-card-actions>
+              <v-row>
+                <v-col>
+                  <v-btn
+                    density="comfortable"
+                    color="error"
+                    icon="mdi-delete"
+                    @click="clearProductPriceForm"
+                  />
+                </v-col>
+                <v-spacer />
+                <v-col>
+                  <v-btn
+                    class="float-right"
+                    color="primary"
+                    variant="flat"
+                    type="submit"
+                    :loading="loading"
+                    :disabled="!productPriceFormFilled"
+                  >
+                    {{ $t('Common.Upload') }}
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-card-actions>
+          </v-card>
+        </v-form>
 
-      <v-btn
-        class="float-right"
-        type="submit"
-        :loading="loading"
-        :disabled="productPriceFormFilled"
-        @click="done"
-      >
-        {{ $t('Common.Done') }}
-      </v-btn>
-    </v-col>
-  </v-row>
+        <v-btn
+          class="float-right"
+          type="submit"
+          :loading="loading"
+          :disabled="productPriceFormFilled"
+          @click="done"
+        >
+          {{ $t('Common.Done') }}
+        </v-btn>
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 3">
-    <v-col cols="12">
-      <v-alert
-        type="success"
-        variant="outlined"
-        density="compact"
-        :text="$t('Common.PriceAddedCount', { count: proofPriceNewList.length })"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.AddNewPrices')"
-        prepend-icon="mdi-tag-plus-outline"
-        append-icon="mdi-arrow-right"
-        @click="reloadPage"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.MyDashboard')"
-        prepend-icon="mdi-account-circle"
-        append-icon="mdi-arrow-right"
-        :to="getUserDashboardUrl"
-      />
-    </v-col>
-  </v-row>
+  <!-- Step 3: actions -->
+  <template v-if="step === 3">
+    <v-row>
+      <v-col cols="12">
+        <v-alert
+          type="success"
+          variant="outlined"
+          density="compact"
+          :text="$t('Common.PriceAddedCount', { count: proofPriceNewList.length })"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.AddNewPrices')"
+          prepend-icon="mdi-tag-plus-outline"
+          append-icon="mdi-arrow-right"
+          @click="reloadPage"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.MyDashboard')"
+          prepend-icon="mdi-account-circle"
+          append-icon="mdi-arrow-right"
+          :to="getUserDashboardUrl"
+        />
+      </v-col>
+    </v-row>
+  </template>
 
   <v-snackbar
     v-model="priceSuccessMessage"

--- a/src/views/ProofAddSingle.vue
+++ b/src/views/ProofAddSingle.vue
@@ -5,7 +5,7 @@
         <v-stepper-header>
           <v-stepper-item :title="stepItemList[0].title" :value="stepItemList[0].value" :complete="step > 1" />
           <v-divider />
-          <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step === 2" />
+          <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step > 2" />
         </v-stepper-header>
       </v-stepper>
     </v-col>
@@ -22,38 +22,44 @@
     </v-col>
   </v-row>
 
-  <v-row v-if="step === 1">
-    <v-col cols="12" md="6">
-      <ProofUploadCard :hideRecentProofChoice="true" @done="proofUploadDone($event)" />
-    </v-col>
-  </v-row>
+  <!-- Step 1: proof upload -->
+  <template v-if="step === 1">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofUploadCard :hideRecentProofChoice="true" @done="proofUploadDone($event)" />
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 2">
-    <v-col cols="12">
-      <v-alert
-        type="success"
-        variant="outlined"
-        density="compact"
-        :text="$t('Common.ProofUploadedCount', { count: proofUploadCount })"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.AddNewProof')"
-        prepend-icon="mdi-image-plus"
-        append-icon="mdi-arrow-right"
-        @click="reloadPage"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.MyDashboard')"
-        prepend-icon="mdi-account-circle"
-        append-icon="mdi-arrow-right"
-        :to="getUserDashboardUrl"
-      />
-    </v-col>
-  </v-row>
+  <!-- Step 2: actions -->
+  <template v-if="step === 2">
+    <v-row>
+      <v-col cols="12">
+        <v-alert
+          type="success"
+          variant="outlined"
+          density="compact"
+          :text="$t('Common.ProofUploadedCount', { count: proofUploadCount })"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.AddNewProof')"
+          prepend-icon="mdi-image-plus"
+          append-icon="mdi-arrow-right"
+          @click="reloadPage"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.MyDashboard')"
+          prepend-icon="mdi-account-circle"
+          append-icon="mdi-arrow-right"
+          :to="getUserDashboardUrl"
+        />
+      </v-col>
+    </v-row>
+  </template>
 </template>
 
 <script>

--- a/src/views/ProofPriceTagAddMultiple.vue
+++ b/src/views/ProofPriceTagAddMultiple.vue
@@ -5,60 +5,66 @@
         <v-stepper-header>
           <v-stepper-item :title="stepItemList[0].title" :value="stepItemList[0].value" :complete="step > 1" />
           <v-divider />
-          <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step === 2" />
+          <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step > 2" />
         </v-stepper-header>
       </v-stepper>
     </v-col>
   </v-row>
 
-  <v-row v-if="step === 1">
-    <v-col cols="12" md="6">
-      <ProofUploadCard :typePriceTagOnly="true" :hideRecentProofChoice="true" :multiple="true" :assistedByAI="true" @proof="onProofUploaded($event)" @done="proofUploadDone($event)" />
-    </v-col>
-  </v-row>
+  <!-- Step 1: proof(s) upload -->
+  <template v-if="step === 1">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofUploadCard :typePriceTagOnly="true" :hideRecentProofChoice="true" :multiple="true" :assistedByAI="true" @proof="onProofUploaded($event)" @done="proofUploadDone($event)" />
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 2">
-    <v-col cols="12">
-      <v-alert
-        type="success"
-        variant="outlined"
-        density="compact"
-        :text="$t('Common.ProofUploadedCount', { count: proofUploadCount })"
-      />
-    </v-col>
-    <v-col v-if="firstProofUploaded" cols="12" sm="6" lg="4">
-      <v-card
-        v-if="firstProofUploaded.ready_for_price_tag_validation"
-        :title="$t('Common.ValidatePrices')"
-        prepend-icon="mdi-checkbox-marked-circle-plus-outline"
-        append-icon="mdi-arrow-right"
-        to="/prices/add/validate"
-      />
-      <v-card
-        v-else
-        :title="$t('Common.AddPrices')"
-        prepend-icon="mdi-tag-plus-outline"
-        append-icon="mdi-arrow-right"
-        :to="getPriceAddMultipleProofIdUrl"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.AddNewProofPriceTags')"
-        prepend-icon="mdi-image-plus"
-        append-icon="mdi-arrow-right"
-        @click="reloadPage"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.MyDashboard')"
-        prepend-icon="mdi-account-circle"
-        append-icon="mdi-arrow-right"
-        :to="getUserDashboardUrl"
-      />
-    </v-col>
-  </v-row>
+  <!-- Step 2: actions -->
+  <template v-if="step === 2">
+    <v-row>
+      <v-col cols="12">
+        <v-alert
+          type="success"
+          variant="outlined"
+          density="compact"
+          :text="$t('Common.ProofUploadedCount', { count: proofUploadCount })"
+        />
+      </v-col>
+      <v-col v-if="firstProofUploaded" cols="12" sm="6" lg="4">
+        <v-card
+          v-if="firstProofUploaded.ready_for_price_tag_validation"
+          :title="$t('Common.ValidatePrices')"
+          prepend-icon="mdi-checkbox-marked-circle-plus-outline"
+          append-icon="mdi-arrow-right"
+          to="/prices/add/validate"
+        />
+        <v-card
+          v-else
+          :title="$t('Common.AddPrices')"
+          prepend-icon="mdi-tag-plus-outline"
+          append-icon="mdi-arrow-right"
+          :to="getPriceAddMultipleProofIdUrl"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.AddNewProofPriceTags')"
+          prepend-icon="mdi-image-plus"
+          append-icon="mdi-arrow-right"
+          @click="reloadPage"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.MyDashboard')"
+          prepend-icon="mdi-account-circle"
+          append-icon="mdi-arrow-right"
+          :to="getUserDashboardUrl"
+        />
+      </v-col>
+    </v-row>
+  </template>
 </template>
 
 <script>

--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -9,243 +9,248 @@
           <v-divider />
           <v-stepper-item :title="stepItemList[2].title" :value="stepItemList[2].value" :complete="step > 3" :disabled="disableCleanupStep" />
           <v-divider />
-          <v-stepper-item :title="stepItemList[3].title" :value="stepItemList[3].value" :complete="step === 4" :disabled="disableSummaryStep" />
+          <v-stepper-item :title="stepItemList[3].title" :value="stepItemList[3].value" :complete="step > 4" :disabled="disableSummaryStep" />
         </v-stepper-header>
       </v-stepper>
     </v-col>
   </v-row>
 
-  <v-row v-if="step === 1">
-    <v-col cols="12" md="6">
-      <ProofUploadCard :typePriceTagOnly="true" @proof="onProofUploaded($event)" />
-    </v-col>
-  </v-row>
+  <template v-if="step === 1">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofUploadCard :typePriceTagOnly="true" @proof="onProofUploaded($event)" />
+      </v-col>
+    </v-row>
+  </template>
   
-  <v-row v-if="step === 2">
-    <v-col cols="12">
-      <v-alert v-if="drawCanvasLoaded && !boundingBoxesFromServer.length && !proofWithBoundingBoxesLoading" class="mb-2" type="warning" variant="outlined" density="compact">
-        {{ $t('ContributionAssistant.BoundingBoxesFromServerWarning') }}
-      </v-alert>
-      <v-alert v-if="drawCanvasLoaded && proofWithBoundingBoxesLoading" class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
-        {{ $t('ContributionAssistant.FindBoundingBoxesRunning') }}
-        <v-progress-circular indeterminate />
-      </v-alert>
-      <v-row>
-        <v-col cols="12" lg="6">
-          <h3 class="mb-4">
-            {{ $t('ContributionAssistant.LabelsExtractionSteps.DrawBoundingBoxes') }}
-          </h3>
-          <v-card>
-            <v-card-text>
-              <v-progress-circular v-if="!drawCanvasLoaded" indeterminate />
-              <ContributionAssistantDrawCanvas ref="ContributionAssistantDrawCanvas" :key="proofObject.id" :imageSrc="imageSrc" :boundingBoxesFromServer="boundingBoxesFromServer" @extractedLabels="onExtractedLabels($event)" @loaded="drawCanvasLoaded = true" />
-            </v-card-text>
-            <v-divider />
-            <v-card-actions>
-              <ProofFooterRow :proof="proofObject" :hideActionMenuButton="true" :readonly="true" />
-            </v-card-actions>
-          </v-card>
-        </v-col>
-        <v-col cols="12" lg="6">
-          <h3 class="mb-4">
-            {{ $t('ContributionAssistant.LabelsExtractionSteps.CheckLabels') }}
-          </h3>
-          <v-row>
-            <v-col v-for="(label, index) in extractedLabels" :key="index" cols="6" md="6" xl="4">
-              <ContributionAssistantLabelCard :label="label" @removeLabel="removeLabel(index)" />
-            </v-col>
-          </v-row>
-          <h3 class="mt-4 mb-4">
-            {{ $t('ContributionAssistant.LabelsExtractionSteps.SendLabels') }}
-          </h3>
-          <v-btn class="float-right" color="primary" :block="!$vuetify.display.smAndUp" :disabled="!extractedLabels.length" :loading="processLabelsLoading" @click="processLabels">
-            {{ $t('ContributionAssistant.LabelsExtractionSteps.SendLabelsButton') }}
-          </v-btn>
-        </v-col>
-      </v-row>
-    </v-col>
-  </v-row>
+  <template v-if="step === 2">
+    <v-row>
+      <v-col cols="12">
+        <v-alert v-if="drawCanvasLoaded && !boundingBoxesFromServer.length && !proofWithBoundingBoxesLoading" class="mb-2" type="warning" variant="outlined" density="compact">
+          {{ $t('ContributionAssistant.BoundingBoxesFromServerWarning') }}
+        </v-alert>
+        <v-alert v-if="drawCanvasLoaded && proofWithBoundingBoxesLoading" class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
+          {{ $t('ContributionAssistant.FindBoundingBoxesRunning') }}
+          <v-progress-circular indeterminate />
+        </v-alert>
+        <v-row>
+          <v-col cols="12" lg="6">
+            <h3 class="mb-4">
+              {{ $t('ContributionAssistant.LabelsExtractionSteps.DrawBoundingBoxes') }}
+            </h3>
+            <v-card>
+              <v-card-text>
+                <v-progress-circular v-if="!drawCanvasLoaded" indeterminate />
+                <ContributionAssistantDrawCanvas ref="ContributionAssistantDrawCanvas" :key="proofObject.id" :imageSrc="imageSrc" :boundingBoxesFromServer="boundingBoxesFromServer" @extractedLabels="onExtractedLabels($event)" @loaded="drawCanvasLoaded = true" />
+              </v-card-text>
+              <v-divider />
+              <v-card-actions>
+                <ProofFooterRow :proof="proofObject" :hideActionMenuButton="true" :readonly="true" />
+              </v-card-actions>
+            </v-card>
+          </v-col>
+          <v-col cols="12" lg="6">
+            <h3 class="mb-4">
+              {{ $t('ContributionAssistant.LabelsExtractionSteps.CheckLabels') }}
+            </h3>
+            <v-row>
+              <v-col v-for="(label, index) in extractedLabels" :key="index" cols="6" md="6" xl="4">
+                <ContributionAssistantLabelCard :label="label" @removeLabel="removeLabel(index)" />
+              </v-col>
+            </v-row>
+            <h3 class="mt-4 mb-4">
+              {{ $t('ContributionAssistant.LabelsExtractionSteps.SendLabels') }}
+            </h3>
+            <v-btn class="float-right" color="primary" :block="!$vuetify.display.smAndUp" :disabled="!extractedLabels.length" :loading="processLabelsLoading" @click="processLabels">
+              {{ $t('ContributionAssistant.LabelsExtractionSteps.SendLabelsButton') }}
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 3">
-    <v-col cols="12">
-      <v-row>
-        <v-col
-          v-for="(productPriceForm, index) in productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError"
-          :key="productPriceForm.id"
-          cols="12"
-          md="6"
-          xl="4"
-        >
-          <ContributionAssistantPriceFormCard
-            :class="productPriceForm.id === lastUpdatedPriceTagId ? 'border-success border-dashed' : ''"
-            height="100%"
-            :productPriceForm="productPriceForm"
-            :hideProductBarcodeScannerTab="true"
-            :hideProofDetails="true"
-            :hideUploadAction="true"
-            @updatePriceTagStatus="updatePriceTagStatus($event, productPriceForm)"
-            @validatePriceTag="validatePriceTag(index)"
-          />
-        </v-col>
-      </v-row>
-      <h3 v-if="productPriceFormsWithoutProductOrCategoryAndNoError.length" class="mt-4 mb-4">
-        {{ $t('ContributionAssistant.PricesWithoutProductOrCategory') }}
-      </h3>
-      <v-row v-if="productPriceFormsWithoutProductOrCategoryAndNoError.length">
-        <v-col
-          v-for="productPriceForm in productPriceFormsWithoutProductOrCategoryAndNoError"
-          :key="productPriceForm.id"
-          cols="12"
-          md="6"
-          xl="4"
-        >
-          <ContributionAssistantPriceFormCard
-            :class="productPriceForm.id === lastUpdatedPriceTagId ? 'border-success border-dashed' : ''"
-            height="100%"
-            :productPriceForm="productPriceForm"
-            :hideProductBarcodeScannerTab="true"
-            :hideProofDetails="true"
-            :hideUploadAction="true"
-            @updatePriceTagStatus="updatePriceTagStatus($event, productPriceForm)"
-          />
-        </v-col>
-      </v-row>
-      <h3 v-if="productPriceFormsMarkedAsError.length" class="mt-4 mb-4">
-        {{ $t('ContributionAssistant.PricesMarkedAsError') }}
-      </h3>
-      <v-row v-if="productPriceFormsMarkedAsError.length">
-        <v-col
-          v-for="productPriceForm in productPriceFormsMarkedAsError"
-          :key="productPriceForm.id"
-          cols="12"
-          md="6"
-          xl="4"
-        >
-          <ContributionAssistantPriceFormCard
-            :class="productPriceForm.id === lastUpdatedPriceTagId ? 'border-success border-dashed' : ''"
-            height="100%"
-            :productPriceForm="productPriceForm"
-            :hideProductBarcodeScannerTab="true"
-            :hideProofDetails="true"
-            :hideUploadAction="true"
-            @updatePriceTagStatus="updatePriceTagStatus($event, productPriceForm)"
-          />
-        </v-col>
-      </v-row>
-      <h3 v-if="productPriceFormsWithPriceId.length" class="mt-4 mb-4">
-        {{ $t('ContributionAssistant.PricesAlreadyAdded') }}
-      </h3>
-      <v-row v-if="productPriceFormsWithPriceId.length">
-        <v-col
-          v-for="(productPriceForm, index) in productPriceFormsWithPriceId"
-          :key="index"
-          cols="12"
-          md="6"
-          xl="4"
-        >
-          <ContributionAssistantPriceFormCard
-            height="100%"
-            :productPriceForm="productPriceForm"
-            :hideProductBarcodeScannerTab="true"
-            :hideProofDetails="true"
-            :hideActions="true"
-            :disabled="true"
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <v-alert
-            class="mb-2"
-            color="primary"
-            variant="outlined"
-            density="compact"
-            icon="mdi-information"
+  <template v-if="step === 3">
+    <v-row>
+      <v-col cols="12">
+        <v-row>
+          <v-col
+            v-for="(productPriceForm, index) in productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError"
+            :key="productPriceForm.id"
+            cols="12"
+            md="6"
+            xl="4"
           >
-            <p>
-              {{ $t('ContributionAssistant.PriceAddConfirmationMessage', { numberOfPricesAdded: productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length, date: proofObject.date, locationName: locationName }) }}
-            </p>
-          </v-alert>
-          <v-btn class="float-right mt-4" color="primary" :block="!$vuetify.display.smAndUp" :loading="loading" @click="addPrices">
-            {{ $t('Common.UploadMultiplePrices', productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length) }}
-          </v-btn>
-        </v-col>
-      </v-row>
-    </v-col>
-  </v-row>
+            <ContributionAssistantPriceFormCard
+              :class="productPriceForm.id === lastUpdatedPriceTagId ? 'border-success border-dashed' : ''"
+              height="100%"
+              :productPriceForm="productPriceForm"
+              :hideProductBarcodeScannerTab="true"
+              :hideProofDetails="true"
+              :hideUploadAction="true"
+              @updatePriceTagStatus="updatePriceTagStatus($event, productPriceForm)"
+              @validatePriceTag="validatePriceTag(index)"
+            />
+          </v-col>
+        </v-row>
+        <h3 v-if="productPriceFormsWithoutProductOrCategoryAndNoError.length" class="mt-4 mb-4">
+          {{ $t('ContributionAssistant.PricesWithoutProductOrCategory') }}
+        </h3>
+        <v-row v-if="productPriceFormsWithoutProductOrCategoryAndNoError.length">
+          <v-col
+            v-for="productPriceForm in productPriceFormsWithoutProductOrCategoryAndNoError"
+            :key="productPriceForm.id"
+            cols="12"
+            md="6"
+            xl="4"
+          >
+            <ContributionAssistantPriceFormCard
+              :class="productPriceForm.id === lastUpdatedPriceTagId ? 'border-success border-dashed' : ''"
+              height="100%"
+              :productPriceForm="productPriceForm"
+              :hideProductBarcodeScannerTab="true"
+              :hideProofDetails="true"
+              :hideUploadAction="true"
+              @updatePriceTagStatus="updatePriceTagStatus($event, productPriceForm)"
+            />
+          </v-col>
+        </v-row>
+        <h3 v-if="productPriceFormsMarkedAsError.length" class="mt-4 mb-4">
+          {{ $t('ContributionAssistant.PricesMarkedAsError') }}
+        </h3>
+        <v-row v-if="productPriceFormsMarkedAsError.length">
+          <v-col
+            v-for="productPriceForm in productPriceFormsMarkedAsError"
+            :key="productPriceForm.id"
+            cols="12"
+            md="6"
+            xl="4"
+          >
+            <ContributionAssistantPriceFormCard
+              :class="productPriceForm.id === lastUpdatedPriceTagId ? 'border-success border-dashed' : ''"
+              height="100%"
+              :productPriceForm="productPriceForm"
+              :hideProductBarcodeScannerTab="true"
+              :hideProofDetails="true"
+              :hideUploadAction="true"
+              @updatePriceTagStatus="updatePriceTagStatus($event, productPriceForm)"
+            />
+          </v-col>
+        </v-row>
+        <h3 v-if="productPriceFormsWithPriceId.length" class="mt-4 mb-4">
+          {{ $t('ContributionAssistant.PricesAlreadyAdded') }}
+        </h3>
+        <v-row v-if="productPriceFormsWithPriceId.length">
+          <v-col
+            v-for="(productPriceForm, index) in productPriceFormsWithPriceId"
+            :key="index"
+            cols="12"
+            md="6"
+            xl="4"
+          >
+            <ContributionAssistantPriceFormCard
+              height="100%"
+              :productPriceForm="productPriceForm"
+              :hideProductBarcodeScannerTab="true"
+              :hideProofDetails="true"
+              :hideActions="true"
+              :disabled="true"
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-alert
+              class="mb-2"
+              color="primary"
+              variant="outlined"
+              density="compact"
+              icon="mdi-information"
+            >
+              <p>
+                {{ $t('ContributionAssistant.PriceAddConfirmationMessage', { numberOfPricesAdded: productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length, date: proofObject.date, locationName: locationName }) }}
+              </p>
+            </v-alert>
+            <v-btn class="float-right mt-4" color="primary" :block="!$vuetify.display.smAndUp" :loading="loading" @click="addPrices">
+              {{ $t('Common.UploadMultiplePrices', productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length) }}
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 4">
-    <v-col>
-      <v-row>
-        <v-col cols="12">
-          <v-progress-linear
-            v-if="!finishedUploading"
-            v-model="numberOfPricesAdded"
-            :max="productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length"
-            :color="productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length === numberOfPricesAdded ? 'success' : 'primary'"
-            height="25"
-            :striped="productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length !== numberOfPricesAdded"
-            rounded
-          >
-            <strong>{{ $t('Common.PriceAddProgress', { numberOfPricesAdded: numberOfPricesAdded, totalNumberOfPrices: productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length }) }}</strong>
-          </v-progress-linear>
-          <v-alert
-            v-if="finishedUploading"
-            type="success"
-            variant="outlined"
-            density="compact"
-            :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
-          />
-        </v-col>
-      </v-row>
-      <v-row v-if="finishedUploading">
-        <v-col cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.AddNewProof')"
-            prepend-icon="mdi-image-plus"
-            append-icon="mdi-arrow-right"
-            @click="reloadPage"
-          />
-        </v-col>
-        <v-col v-if="proofIdsFromQueryParam && proofIdsFromQueryParam.length > 1" cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.NextProof')"
-            prepend-icon="mdi-image"
-            append-icon="mdi-arrow-right"
-            @click="nextProof"
-          />
-        </v-col>
-        <v-col cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.GoToProof')"
-            prepend-icon="mdi-image"
-            append-icon="mdi-arrow-right"
-            :to="'/proofs/' + proofObject.id"
-          />
-        </v-col>
-        <v-col cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.MyDashboard')"
-            prepend-icon="mdi-account-circle"
-            append-icon="mdi-arrow-right"
-            :to="getUserDashboardUrl"
-          />
-        </v-col>
-      </v-row>
-      <v-row v-if="finishedUploading && nextProofSuggestions.length">
-        <v-col>
-          <h3 class="mb-4">
-            {{ $t('ContributionAssistant.ChooseNextProof') }}
-          </h3>
-          <v-row v-if="nextProofSuggestions.length">
-            <v-col v-for="proof in nextProofSuggestions" :key="proof" cols="12" md="6" lg="4">
-              <ProofCard :proof="proof" :hideProofHeader="true" :hideActionMenuButton="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof" />
-            </v-col>
-          </v-row>
-        </v-col>
-      </v-row>
-    </v-col>
-  </v-row>
+  <!-- Step 4: actions -->
+  <template v-if="step === 4">
+    <v-row>
+      <v-col cols="12">
+        <v-progress-linear
+          v-if="!finishedUploading"
+          v-model="numberOfPricesAdded"
+          :max="productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length"
+          :color="productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length === numberOfPricesAdded ? 'success' : 'primary'"
+          height="25"
+          :striped="productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length !== numberOfPricesAdded"
+          rounded
+        >
+          <strong>{{ $t('Common.PriceAddProgress', { numberOfPricesAdded: numberOfPricesAdded, totalNumberOfPrices: productPriceFormsWithoutPriceIdAndWithProductOrCategoryAndNoError.length }) }}</strong>
+        </v-progress-linear>
+        <v-alert
+          v-if="finishedUploading"
+          type="success"
+          variant="outlined"
+          density="compact"
+          :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
+        />
+      </v-col>
+    </v-row>
+    <v-row v-if="finishedUploading">
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.AddNewProof')"
+          prepend-icon="mdi-image-plus"
+          append-icon="mdi-arrow-right"
+          @click="reloadPage"
+        />
+      </v-col>
+      <v-col v-if="proofIdsFromQueryParam && proofIdsFromQueryParam.length > 1" cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.NextProof')"
+          prepend-icon="mdi-image"
+          append-icon="mdi-arrow-right"
+          @click="nextProof"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.GoToProof')"
+          prepend-icon="mdi-image"
+          append-icon="mdi-arrow-right"
+          :to="'/proofs/' + proofObject.id"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.MyDashboard')"
+          prepend-icon="mdi-account-circle"
+          append-icon="mdi-arrow-right"
+          :to="getUserDashboardUrl"
+        />
+      </v-col>
+    </v-row>
+    <v-row v-if="finishedUploading && nextProofSuggestions.length">
+      <v-col>
+        <h3 class="mb-4">
+          {{ $t('ContributionAssistant.ChooseNextProof') }}
+        </h3>
+        <v-row v-if="nextProofSuggestions.length">
+          <v-col v-for="proof in nextProofSuggestions" :key="proof" cols="12" md="6" lg="4">
+            <ProofCard :proof="proof" :hideProofHeader="true" :hideActionMenuButton="true" :readonly="true" :isSelectable="true" @proofSelected="selectProof" />
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </template>
 
   <v-snackbar
     v-model="labelProcessingErrorMessage"

--- a/src/views/ProofReceiptAdd.vue
+++ b/src/views/ProofReceiptAdd.vue
@@ -5,52 +5,58 @@
         <v-stepper-header>
           <v-stepper-item :title="stepItemList[0].title" :value="stepItemList[0].value" :complete="step > 1" />
           <v-divider />
-          <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step === 2" />
+          <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step > 2" />
         </v-stepper-header>
       </v-stepper>
     </v-col>
   </v-row>
 
-  <v-row v-if="step === 1">
-    <v-col cols="12" md="6">
-      <ProofUploadCard :typeReceiptOnly="true" :hideRecentProofChoice="true" :assistedByAI="true" @proof="onProofUploaded($event)" />
-    </v-col>
-  </v-row>
+  <!-- Step 1: proof upload -->
+  <template v-if="step === 1">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofUploadCard :typeReceiptOnly="true" :hideRecentProofChoice="true" :assistedByAI="true" @proof="onProofUploaded($event)" />
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 2">
-    <v-col cols="12">
-      <v-alert
-        type="success"
-        variant="outlined"
-        density="compact"
-        :text="$t('Common.ProofUploadedCount', { count: 1 })"
-      />
-    </v-col>
-    <v-col v-if="proofUploaded" cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.AddPrices')"
-        prepend-icon="mdi-tag-plus-outline"
-        append-icon="mdi-arrow-right"
-        :to="getReceiptAssistantProofIdsUrl"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.AddNewProofReceipt')"
-        prepend-icon="mdi-image-plus"
-        append-icon="mdi-arrow-right"
-        @click="reloadPage"
-      />
-    </v-col>
-    <v-col cols="12" sm="6" lg="4">
-      <v-card
-        :title="$t('Common.MyDashboard')"
-        prepend-icon="mdi-account-circle"
-        append-icon="mdi-arrow-right"
-        :to="getUserDashboardUrl"
-      />
-    </v-col>
-  </v-row>
+  <!-- Step 2: actions -->
+  <template v-if="step === 2">
+    <v-row>
+      <v-col cols="12">
+        <v-alert
+          type="success"
+          variant="outlined"
+          density="compact"
+          :text="$t('Common.ProofUploadedCount', { count: 1 })"
+        />
+      </v-col>
+      <v-col v-if="proofUploaded" cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.AddPrices')"
+          prepend-icon="mdi-tag-plus-outline"
+          append-icon="mdi-arrow-right"
+          :to="getReceiptAssistantProofIdsUrl"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.AddNewProofReceipt')"
+          prepend-icon="mdi-image-plus"
+          append-icon="mdi-arrow-right"
+          @click="reloadPage"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <v-card
+          :title="$t('Common.MyDashboard')"
+          prepend-icon="mdi-account-circle"
+          append-icon="mdi-arrow-right"
+          :to="getUserDashboardUrl"
+        />
+      </v-col>
+    </v-row>
+  </template>
 </template>
 
 <script>

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -7,98 +7,106 @@
           <v-divider />
           <v-stepper-item :title="stepItemList[1].title" :value="stepItemList[1].value" :complete="step > 2" />
           <v-divider />
-          <v-stepper-item :title="stepItemList[2].title" :value="stepItemList[2].value" :complete="step === 3" />
+          <v-stepper-item :title="stepItemList[2].title" :value="stepItemList[2].value" :complete="step > 3" />
         </v-stepper-header>
       </v-stepper>
     </v-col>
   </v-row>
 
-  <v-row v-if="step === 1">
-    <v-col cols="12" md="6">
-      <ProofUploadCard :typeReceiptOnly="true" :assistedByAI="true" @proof="onProofUploaded($event)" />
-    </v-col>
-  </v-row>
+  <!-- Step 1: proof upload -->
+  <template v-if="step === 1">
+    <v-row>
+      <v-col cols="12" md="6">
+        <ProofUploadCard :typeReceiptOnly="true" :assistedByAI="true" @proof="onProofUploaded($event)" />
+      </v-col>
+    </v-row>
+  </template>
   
-  <v-row v-if="step === 2">
-    <v-col v-if="loadingPredictions" cols="12">
-      <v-alert class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
-        {{ $t('ReceiptAssistant.WaitForExtraction') }}
-        <v-progress-circular indeterminate />
-      </v-alert>
-    </v-col>
-    <v-col v-else-if="!proofHasReceiptPredictionItems" cols="12">
-      <v-alert class="mb-2" type="warning" variant="outlined" density="compact">
-        {{ $t('ReceiptAssistant.NoItemsFound') }}
-      </v-alert>
-    </v-col>
-    <v-col cols="12" lg="4">
-      <ProofCard mode="Uploaded" :proof="proofObject" :hideActionMenuButton="true" :readonly="true" />
-    </v-col>
-    <v-col v-if="!loadingPredictions" cols="12" lg="8">
-      <ReceiptTableCard :proof="proofObject" :receiptItems="receiptItems" :proofPriceExistingList="proofPriceExistingList" @receiptItemsUpdated="receiptItemsUpdated($event)" />
-      <v-row>
-        <v-col>
-          <v-btn v-if="validNewReceiptItems.length !== validReceiptItems.length" class="float-right mt-4 ml-4" color="primary" :block="!$vuetify.display.smAndUp" @click="addPrices(validNewReceiptItems)">
-            {{ $t('ReceiptAssistant.UploadOnlyNewPrices', { nbPrices: validNewReceiptItems.length }) }}
-          </v-btn>
-          <v-btn class="float-right mt-4" color="primary" :block="!$vuetify.display.smAndUp" @click="addPrices(validReceiptItems)">
-            {{ $t('ReceiptAssistant.UploadOrUpdateAllValidPrices', { nbPrices: validReceiptItems.length }) }}
-          </v-btn>
-        </v-col>
-      </v-row>
-    </v-col>
-  </v-row>
+  <template v-if="step === 2">
+    <v-row>
+      <v-col v-if="loadingPredictions" cols="12">
+        <v-alert class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
+          {{ $t('ReceiptAssistant.WaitForExtraction') }}
+          <v-progress-circular indeterminate />
+        </v-alert>
+      </v-col>
+      <v-col v-else-if="!proofHasReceiptPredictionItems" cols="12">
+        <v-alert class="mb-2" type="warning" variant="outlined" density="compact">
+          {{ $t('ReceiptAssistant.NoItemsFound') }}
+        </v-alert>
+      </v-col>
+      <v-col cols="12" lg="4">
+        <ProofCard mode="Uploaded" :proof="proofObject" :hideActionMenuButton="true" :readonly="true" />
+      </v-col>
+      <v-col v-if="!loadingPredictions" cols="12" lg="8">
+        <ReceiptTableCard :proof="proofObject" :receiptItems="receiptItems" :proofPriceExistingList="proofPriceExistingList" @receiptItemsUpdated="receiptItemsUpdated($event)" />
+        <v-row>
+          <v-col>
+            <v-btn v-if="validNewReceiptItems.length !== validReceiptItems.length" class="float-right mt-4 ml-4" color="primary" :block="!$vuetify.display.smAndUp" @click="addPrices(validNewReceiptItems)">
+              {{ $t('ReceiptAssistant.UploadOnlyNewPrices', { nbPrices: validNewReceiptItems.length }) }}
+            </v-btn>
+            <v-btn class="float-right mt-4" color="primary" :block="!$vuetify.display.smAndUp" @click="addPrices(validReceiptItems)">
+              {{ $t('ReceiptAssistant.UploadOrUpdateAllValidPrices', { nbPrices: validReceiptItems.length }) }}
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </template>
 
-  <v-row v-if="step === 3">
-    <v-col>
-      <v-row>
-        <v-col cols="12">
-          <v-progress-linear
-            v-if="!finishedUploading"
-            v-model="numberOfPricesAdded"
-            :max="totalNumberOfPricesToAdd"
-            :color="totalNumberOfPricesToAdd === numberOfPricesAdded ? 'success' : 'primary'"
-            height="25"
-            :striped="totalNumberOfPricesToAdd !== numberOfPricesAdded"
-            rounded
-          />
-          <v-alert
-            v-if="finishedUploading"
-            type="success"
-            variant="outlined"
-            density="compact"
-            :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
-          />
-        </v-col>
-      </v-row>
-      <v-row v-if="finishedUploading">
-        <v-col cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.AddNewProof')"
-            prepend-icon="mdi-image-plus"
-            append-icon="mdi-arrow-right"
-            @click="reloadPage"
-          />
-        </v-col>
-        <v-col cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.GoToProof')"
-            prepend-icon="mdi-image"
-            append-icon="mdi-arrow-right"
-            :to="'/proofs/' + proofObject.id"
-          />
-        </v-col>
-        <v-col cols="12" sm="6" lg="4">
-          <v-card
-            :title="$t('Common.MyDashboard')"
-            prepend-icon="mdi-account-circle"
-            append-icon="mdi-arrow-right"
-            :to="getUserDashboardUrl"
-          />
-        </v-col>
-      </v-row>
-    </v-col>
-  </v-row>
+  <!-- Step 3: actions -->
+  <template v-if="step === 3">
+    <v-row>
+      <v-col>
+        <v-row>
+          <v-col cols="12">
+            <v-progress-linear
+              v-if="!finishedUploading"
+              v-model="numberOfPricesAdded"
+              :max="totalNumberOfPricesToAdd"
+              :color="totalNumberOfPricesToAdd === numberOfPricesAdded ? 'success' : 'primary'"
+              height="25"
+              :striped="totalNumberOfPricesToAdd !== numberOfPricesAdded"
+              rounded
+            />
+            <v-alert
+              v-if="finishedUploading"
+              type="success"
+              variant="outlined"
+              density="compact"
+              :text="$t('Common.PriceAddedCount', { count: numberOfPricesAdded })"
+            />
+          </v-col>
+        </v-row>
+        <v-row v-if="finishedUploading">
+          <v-col cols="12" sm="6" lg="4">
+            <v-card
+              :title="$t('Common.AddNewProof')"
+              prepend-icon="mdi-image-plus"
+              append-icon="mdi-arrow-right"
+              @click="reloadPage"
+            />
+          </v-col>
+          <v-col cols="12" sm="6" lg="4">
+            <v-card
+              :title="$t('Common.GoToProof')"
+              prepend-icon="mdi-image"
+              append-icon="mdi-arrow-right"
+              :to="'/proofs/' + proofObject.id"
+            />
+          </v-col>
+          <v-col cols="12" sm="6" lg="4">
+            <v-card
+              :title="$t('Common.MyDashboard')"
+              prepend-icon="mdi-account-circle"
+              append-icon="mdi-arrow-right"
+              :to="getUserDashboardUrl"
+            />
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </template>
 </template>
 
 <script>


### PR DESCRIPTION
### What

Improvement on the steppers
- move all the HTML code in dedicated <template> tags
  - avoid having to put everything in a surrounding <v-row>
- don't show the "action" step as complete
### Screenshot

|Before|After|
|-|-|
|<img width="417" height="429" alt="image" src="https://github.com/user-attachments/assets/0978ff7e-022e-403a-9395-484c8bd88db1" />|<img width="417" height="429" alt="image" src="https://github.com/user-attachments/assets/61cf452e-4819-4235-8c17-5d47417cedf2" />|
