### PR TITLE
refactor(Proof Upload): in action step, change the default action to primary color

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -169,6 +169,7 @@
 		"About": "About",
 		"Action": "Action",
 		"Actions": "Actions",
+		"ActionsOther": "Other actions",
 		"AddComment": "Add a comment",
 		"AddPrice": "Add a price",
 		"AddPrices": "Add prices",

--- a/src/views/ProofPriceTagAddMultiple.vue
+++ b/src/views/ProofPriceTagAddMultiple.vue
@@ -37,6 +37,7 @@
           :title="$t('Common.ValidatePrices')"
           prepend-icon="mdi-checkbox-marked-circle-plus-outline"
           append-icon="mdi-arrow-right"
+          color="primary"
           to="/prices/add/validate"
         />
         <v-card
@@ -44,6 +45,7 @@
           :title="$t('Common.AddPrices')"
           prepend-icon="mdi-tag-plus-outline"
           append-icon="mdi-arrow-right"
+          color="primary"
           :to="getPriceAddMultipleProofIdUrl"
         />
       </v-col>

--- a/src/views/ProofReceiptAdd.vue
+++ b/src/views/ProofReceiptAdd.vue
@@ -36,9 +36,12 @@
           :title="$t('Common.AddPrices')"
           prepend-icon="mdi-tag-plus-outline"
           append-icon="mdi-arrow-right"
+          color="primary"
           :to="getReceiptAssistantProofIdsUrl"
         />
       </v-col>
+    </v-row>
+    <v-row>
       <v-col cols="12" sm="6" lg="4">
         <v-card
           :title="$t('Common.AddNewProofReceipt')"


### PR DESCRIPTION
### What

Make the default action clearer.
Mentioned in #1827.
Would also help to have some "help text" / "card subtitle text" :)

### Screenshot

||Before|After|
|-|-|-|
|receipt upload|<img width="417" height="429" alt="image" src="https://github.com/user-attachments/assets/61cf452e-4819-4235-8c17-5d47417cedf2" />|<img width="417" height="429" alt="image" src="https://github.com/user-attachments/assets/f84150ad-224e-41eb-bc7d-70ebaf3effe8" />|
|price tag upload||<img width="417" height="429" alt="image" src="https://github.com/user-attachments/assets/3257b2cb-6ce7-4485-95fc-3f3965ddac47" />|
