### PR TITLE
feat(Proof Upload): improve receipt assistant (schema v2)

### DIFF
--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -255,9 +255,11 @@ export default {
           price: predictedData.price || null,
           price_per: categoryPredicted ? "KILOGRAM" : null,
           predicted_product_code: predictedData.predicted_product_code || null,
+          // extra fields
+          currency: this.proof.currency,
         }
       } else {
-        // assume schema version 2.0
+        // assume schema version 2.0 and above
         let pricePer = predictedData.price_per
         if (predictedData.type === constants.PRICE_TYPE_CATEGORY && pricePer == 'LITER') {
           // On Open Prices, we use KILOGRAM for category prices, even for liquids
@@ -285,14 +287,13 @@ export default {
           price_per: pricePer,
           predicted_product_code: predictedData.predicted_product_code || null,
           receipt_quantity: receipt_quantity,
-          // discounted price currently do not work with the receipt assistant
-          // as the currency is not part of the ReceiptItem
-          // price_without_discount: predictedData.price_without_discount || null,
-          // discount_type: predictedData.discount_type || null,
-          // price_is_discounted: predictedData.price_is_discounted || null,
+          price_is_discounted: predictedData.price_is_discounted || null,
+          price_without_discount: predictedData.price_without_discount || null,
+          discount_type: predictedData.discount_type || null,
+          // extra fields
+          currency: this.proof.currency,
         }
       }
-
     },
     setTableRowClass(item) {
       // grey out existing prices


### PR DESCRIPTION
Support the new receipt schema.

See the [backend PR](https://github.com/openfoodfacts/open-prices/pull/1185) for more information.

On a side note, there seem to be a bug when loading a price entry with a discount on the receipt assistant. I think this is independent of the modifications added here, but it has to be checked.

### Screenshots

|Before|After|
|-|-|
|<img width="1188" height="657" alt="image" src="https://github.com/user-attachments/assets/d868aa3f-eb71-44ff-a914-5d3805a6299a" />|<img width="1188" height="657" alt="image" src="https://github.com/user-attachments/assets/f6633f6b-8ec6-4873-9538-d11bff057a22" />|