### PR TITLE
feat(PriceAddValidate): Add user country filter

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -190,6 +190,7 @@ export default {
   ],
   PRICE_TAG_FILTER_LIST: [
     { key: 'proof__owner', value: 'FilterPriceTagWithProofOwner' },
+    { key: 'proof_user_country', value: 'FilterPriceTagWithProofUserCountry' },
     // { key: 'tag_prediction_barcode_valid', value: 'FilterPriceTagWithTagPredictionBarcodeValid' },
     { key: 'tag_prediction_product_exists', value: 'FilterPriceTagWithTagPredictionProductExists' },
     // { key: 'tag_prediction_category_tag_valid', value: 'FilterPriceTagWithTagPredictionCategoryTagValid' },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -302,6 +302,7 @@
 		"FilterPriceMoreThan30DaysHide": "Hide prices older than 30 days",
 		"FilterProofWithPriceCountHide": "Hide proofs with prices",
 		"FilterPriceTagWithProofOwner": "Show only my proofs",
+		"FilterPriceTagWithProofUserCountry": "Show only proofs from my country",
 		"FilterPriceTagWithTagPredictionBarcodeValid": "With a valid barcode",
 		"FilterPriceTagWithTagPredictionProductExists": "With a valid product",
 		"FilterPriceTagWithTagPredictionCategoryTagValid": "With a valid category tag",

--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -80,6 +80,9 @@ export default {
     username() {
       return this.appStore.user.username
     },
+    userCountry() {
+      return this.appStore.user.country
+    },
     getApiSize() {
       // reduce size to speed up the loading
       if (!this.$vuetify.display.smAndUp) return 2
@@ -97,6 +100,9 @@ export default {
       }
       if (this.currentFilterList.includes('proof__owner')) {
         defaultParams['proof__owner'] = this.username
+      }
+      if (this.currentFilterList.includes('proof_user_country')) {
+        defaultParams['proof__location__osm_address_country_code'] = this.userCountry
       }
       if (this.currentFilterList.includes('tag_prediction_product_exists')) {
         defaultParams['tags__contains'] = 'prediction-product-exists'


### PR DESCRIPTION
### What
- Allows users to only display price tags with proof matching their country
- See required backend PR: https://github.com/openfoodfacts/open-prices/pull/1186

### Screenshots
<img width="666" height="314" alt="image" src="https://github.com/user-attachments/assets/ec9911f8-1edc-422c-a70c-c8cd2fb8e55c" />

### Notes
- Ideally, we would let user select the country they want to filter by, but that would require more substantial changes to the current filtering UI (select/autocomplete)