### PR TITLE
fix(Receipt Assistant): load max 100 predicted receipt items (instead of max 25)

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -73,7 +73,7 @@ function extraPriceCreateOrUpdateFiltering(data) {
 export default {
   /**
    * OPEN PRICES API
-  */ 
+  */
 
   signIn(username, password) {
     let formData = new FormData()
@@ -164,7 +164,6 @@ export default {
     .then((response) => response.json())
   },
 
-  // will return only the user's proofs
   getProofs(params = {}) {
     const store = useAppStore()
     const defaultParams = {page: 1, size: 10, order_by: '-created'}
@@ -178,7 +177,6 @@ export default {
     .then((response) => response.json())
   },
 
-  // will return only the user's proof
   getProofById(proofId) {
     const store = useAppStore()
     const url = `${import.meta.env.VITE_OPEN_PRICES_API_URL}/proofs/${proofId}?${buildURLParams()}`
@@ -533,7 +531,7 @@ export default {
 
   /**
    * OPEN FOOD FACTS API
-  */ 
+  */
 
   openfoodfactsProductSearch(code) {
     const url = `${constants.OFF_API_URL}/${code}.json`
@@ -556,7 +554,7 @@ export default {
 
   /**
    * OPENSTREETMAP API
-  */ 
+  */
 
   /**
    * Nominatim search by query

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -222,7 +222,7 @@ export default {
         if (proofCreatedDate.getTime() < Date.now() - oneDayInMs) {
           maxTries = 1
         }
-        api.getReceiptItems({proof_id: this.proofObject.id}).then(data => {
+        api.getReceiptItems({proof_id: this.proofObject.id, size: 100}).then(data => {
           const receiptItems = data.items
           if (receiptItems.length) {
             callback(receiptItems)


### PR DESCRIPTION
### What

The API already allows a max size of 100.
So for receipt items we can change the max size from 25 to 100.

### Screenshot

|Before|After|
|-|-|
|<img width="162" height="78" alt="image" src="https://github.com/user-attachments/assets/af6d3e8d-482e-4ada-b770-74855c8a167c" />|<img width="162" height="78" alt="image" src="https://github.com/user-attachments/assets/8e99058c-bada-41d4-becb-3e01f26836ab" />|