### PR TITLE
fix(challenge): the api will not load again when return

### DIFF
--- a/src/views/ChallengeList.vue
+++ b/src/views/ChallengeList.vue
@@ -128,7 +128,7 @@ export default {
         })
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars
-      if (utils.getDocumentScrollPercentage() > 90) {
+      if (utils.getDocumentScrollPercentage() > 90 &&!this.loading) {
         this.getChallenges()
       }
     }


### PR DESCRIPTION
### What
- <!-- Describe the Pull Request here -->
Go to challenges page.
Open developer tools.
Click any card.
Go back.
Then the openPricesApi.getChallenges api will load again and turn to a noexisted page 2.
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/6d686a60-f354-430a-a125-a8f53a658209" />

### Fixes bug(s)
- #1997 
### Part of 
- <!-- #1, please use the most granular issue possible -->
