### PR TITLE
fix: duplication of prices

### DIFF
--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -274,8 +274,10 @@ export default {
           price: receiptItems[i].price || receiptItems[i].predicted_data.price,
           product_name: receiptItems[i].product_name || receiptItems[i].predicted_data.product_name
         }
-        if (receiptItems[i].price_id) {
-          openPricesApi.updatePrice(receiptItems[i].price_id, priceData).then((price) => {
+        // Check and use an exisiting price with the same product code to avoid duplicates
+        const priceId = receiptItems[i].price_id || this.proofPriceExistingList.find(exisitingPrice => exisitingPrice.product_code === priceData.product_code)?.id
+        if (priceId) {
+          openPricesApi.updatePrice(priceId, priceData).then((price) => {
             this.numberOfPricesAdded += 1
             this.updateOrAddReceiptItem(receiptItems[i].id, price.id)
           })


### PR DESCRIPTION
### What
Prevent creating duplicate prices when updating receipt items.

When adding prices from receipt items, the code now first checks if:
1. The receipt item already has a linked price (`price_id`)
2. A price already exists in `proofPriceExistingList` for the same product

If an existing price is found, it is reused instead of creating a new one. This avoids duplicate price entries for the same product and proof.

### Fixes bug(s)
Fixes #2069 