### PR TITLE
fix(CreateOffProduct): vertical crop mode text in mobile view

### DIFF
--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -262,18 +262,31 @@
         <v-divider />
         <v-card-actions>
           <v-row>
-            <v-col>
+            <v-col cols="6">
               <v-btn
                 color="primary"
                 variant="flat"
                 type="submit"
                 :disabled="shownProofIndex === 0"
+                block
                 @click="previousProof()"
               >
                 {{ $t('CreateOffProduct.PreviousProof') }}
               </v-btn>
             </v-col>
-            <v-col>
+            <v-col cols="6">
+              <v-btn
+                color="primary"
+                variant="flat"
+                type="submit"
+                :disabled="shownProofIndex === priceList.length - 1"
+                block
+                @click="nextProof()"
+              >
+                {{ $t('CreateOffProduct.NextProof') }}
+              </v-btn>
+            </v-col>
+            <v-col cols="12" class="d-flex justify-center">
               <v-switch
                 v-model="imageEditMode"
                 density="compact"
@@ -282,17 +295,6 @@
                 :true-value="true"
                 hide-details="auto"
               />
-            </v-col>
-            <v-col>
-              <v-btn
-                color="primary"
-                variant="flat"
-                type="submit"
-                :disabled="shownProofIndex === priceList.length - 1"
-                @click="nextProof()"
-              >
-                {{ $t('CreateOffProduct.NextProof') }}
-              </v-btn>
             </v-col>
           </v-row>
         </v-card-actions>


### PR DESCRIPTION
### What
Improves the layout of proof navigation on small screens. Places **Previous Proof** and **Next Proof** buttons on one row and shifts **Enable crop mode** to the row below since they are not from the same class of buttons and UI. 
Consequentially it also changes the UI of the desktop version as well, but it is personally i think it is better UX for different classes of interactions to be on different rows. 
### Screenshot
#### Mobile
<img width="430" height="865" alt="image" src="https://github.com/user-attachments/assets/407a84a8-cc86-4294-a542-6a7e0dbb3445" />

#### Desktop
<img width="1887" height="938" alt="image" src="https://github.com/user-attachments/assets/6aa6abc3-59d9-44b6-9206-e948c9226d51" />


### Fixes bug(s)
Fixes #2070 