### PR TITLE
fix: display names in English and sort alphabetically

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -36,8 +36,8 @@
           <v-autocomplete
             v-model="appStore.user.country"
             :label="$t('Common.Country')"
-            :items="countryList"
-            item-title="name"
+            :items="localizedCountryList"
+            item-title="localizedName"
             item-value="code"
             hide-details="auto"
           />
@@ -48,7 +48,7 @@
           <v-autocomplete
             v-model="appStore.user.language"
             :label="$t('Common.Language')"
-            :items="languageList"
+            :items="sortedLanguageList" 
             item-title="native"
             item-value="code"
             hide-details="auto"
@@ -210,9 +210,6 @@ export default {
     return {
       OFF_CROWDIN_URL: constants.OFF_CROWDIN_URL,
       theme: useTheme(),
-      countryList: [...countryList].sort((a, b) =>
-        a.name.localeCompare(b.name)
-      ),
       languageList,
       // currencyList,
       priceListDisplayList: constants.DISPLAY_LIST,
@@ -223,8 +220,34 @@ export default {
   },
   computed: {
     ...mapStores(useAppStore),
+  localizedCountryList() {
+    const fullLocale = this.$i18n.locale
+    const baseLocale = fullLocale.split('-')[0] || 'en'
+
+    const regionNames = new Intl.DisplayNames([baseLocale], { type: 'region' })
+    const collator = new Intl.Collator(fullLocale)
+
+    return [...countryList]
+      .map(country => ({
+        ...country,
+        localizedName:
+          regionNames.of(country.code) || country.name
+      }))
+      .sort((a, b) =>
+        collator.compare(a.localizedName, b.localizedName)
+      )
+  },
+  sortedLanguageList() {
+    const collator = new Intl.Collator(undefined, {
+      sensitivity: 'base'
+    })
+
+    return [...languageList].sort((a, b) =>
+      collator.compare(a.native, b.native)
+    )
+  },
     currencyList() {
-      return [...new Set(this.countryList
+      return [...new Set(countryList
         .map(country => country.currency)
         .flat()
         .filter(currency => currency !== null && currency.length !== 0))]

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -37,7 +37,7 @@
             v-model="appStore.user.country"
             :label="$t('Common.Country')"
             :items="countryList"
-            item-title="native"
+            item-title="name"
             item-value="code"
             hide-details="auto"
           />
@@ -210,7 +210,9 @@ export default {
     return {
       OFF_CROWDIN_URL: constants.OFF_CROWDIN_URL,
       theme: useTheme(),
-      countryList,
+      countryList: [...countryList].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      ),
       languageList,
       // currencyList,
       priceListDisplayList: constants.DISPLAY_LIST,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -221,11 +221,10 @@ export default {
   computed: {
     ...mapStores(useAppStore),
   localizedCountryList() {
-    const fullLocale = this.$i18n.locale
-    const baseLocale = fullLocale.split('-')[0] || 'en'
+    const locale = this.$i18n.locale || 'en'
 
-    const regionNames = new Intl.DisplayNames([baseLocale], { type: 'region' })
-    const collator = new Intl.Collator(fullLocale)
+    const regionNames = new Intl.DisplayNames([locale], { type: 'region' })
+    const collator = new Intl.Collator(locale)
 
     return [...countryList]
       .map(country => ({
@@ -238,7 +237,9 @@ export default {
       )
   },
   sortedLanguageList() {
-    const collator = new Intl.Collator(undefined, {
+    const locale = this.$i18n.locale || 'en'
+
+    const collator = new Intl.Collator(locale, {
       sensitivity: 'base'
     })
 


### PR DESCRIPTION
## Summary
Improves the country selector by displaying and sorting country names based on the user's preferred language.

## Changes
- Localized country names using Intl.DisplayNames
- Applied locale-aware sorting using Intl.Collator
- Removed dependency on fixed English names
- Added fallback handling for unsupported locales
- Ensured language list is consistently sorted

## Result
- Country names now appear in the user's selected language
- Sorting adapts correctly to the active locale
- Improved usability and multilingual support

## Screenshots

### Before
<img width="728" height="765" alt="Screenshot 2026-03-28 185501" src="https://github.com/user-attachments/assets/7c61c399-9c9f-428c-875e-9f99d7e8892b" />
<img width="747" height="814" alt="Screenshot 2026-03-28 185610" src="https://github.com/user-attachments/assets/f41a0573-50be-4a3e-a554-17273c8d3664" />

### After
<img width="1428" height="640" alt="Screenshot 2026-03-29 135933" src="https://github.com/user-attachments/assets/347d12dd-7ace-4eec-8450-66f4fb3f35cc" />
<img width="1451" height="643" alt="Screenshot 2026-03-29 135951" src="https://github.com/user-attachments/assets/cb000f63-1737-46da-abe4-8b650e3c514c" />


## Notes
- UI text translations rely on i18n keys (fallback to English if missing)
- Country names are handled via browser Intl APIs
- Closes #2098

