### PR TITLE
refactor(Settings): for country input, use JSON localized data

### DIFF
--- a/src/components/PriceCategoryChip.vue
+++ b/src/components/PriceCategoryChip.vue
@@ -28,10 +28,10 @@ export default {
     ...mapStores(useAppStore),
   },
   mounted() {
-    this.getCategoryTagLocalizedName(this.priceCategory)
+    this.setPriceCategoryLocalizedName(this.priceCategory)
   },
   methods: {
-    getCategoryTagLocalizedName(categoryId) {
+    setPriceCategoryLocalizedName(categoryId) {
       data_utils.getLocaleCategoryTagName(this.appStore.getUserLanguage, categoryId).then((categoryName) => {
         this.priceCategoryLocalizedName = categoryName
       })

--- a/src/components/PriceLabels.vue
+++ b/src/components/PriceLabels.vue
@@ -29,10 +29,10 @@ export default {
     ...mapStores(useAppStore),
   },
   mounted() {
-    this.getLabelTagLocalizedList(this.priceLabels)
+    this.setPriceLabelsLocalized(this.priceLabels)
   },
   methods: {
-    getLabelTagLocalizedList(labelIds) {
+    setPriceLabelsLocalized(labelIds) {
       labelIds.forEach(labelId => {
         data_utils.getLocaleLabelTag(this.appStore.getUserLanguage, labelId).then((label) => {
           this.priceLabelsLocalized.push(label)

--- a/src/components/PriceOrigins.vue
+++ b/src/components/PriceOrigins.vue
@@ -28,10 +28,10 @@ export default {
     ...mapStores(useAppStore),
   },
   mounted() {
-    this.getOriginTagLocalizedList(this.priceOrigins)
+    this.setPriceOriginsLocalized(this.priceOrigins)
   },
   methods: {
-    getOriginTagLocalizedList(originIds) {
+    setPriceOriginsLocalized(originIds) {
       originIds.forEach(originId => {
         data_utils.getLocaleOriginTag(this.appStore.getUserLanguage, originId).then((origin) => {
           this.priceOriginsLocalized.push(origin)

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -124,9 +124,9 @@ export default {
   emits: ['filled'],
   data() {
     return {
-      categoryTags: [],  // list of category tags for autocomplete  // see initPriceMultipleForm
-      originTags: [],  // list of origins tags for autocomplete  // see initPriceMultipleForm
-      labelTags: [],  // list of labels tags for checkboxes  // see initPriceMultipleForm
+      categoryTags: [],  // list of category tags for autocomplete  // see mounted
+      originTags: [],  // list of origins tags for autocomplete  // see mounted
+      labelTags: [],  // list of labels tags for checkboxes  // see mounted
       barcodeScannerDialog: false,
     }
   },
@@ -172,21 +172,30 @@ export default {
         this.productForm.product_code = this.$route.query.code
       }
     }
-    data_utils.getLocaleCategoryTags(this.appStore.getUserLanguage).then((module) => {
-      this.categoryTags = module.default
-    })
-    data_utils.getLocaleOriginTags(this.appStore.getUserLanguage).then((module) => {
-      this.originTags = module.default
-    })
-    data_utils.getLocaleLabelTags(this.appStore.getUserLanguage).then((module) => {
-      this.labelTags = module.default
-    })
+    this.setCategoryTags()
+    this.setOriginTags()
+    this.setLabelTags()
     this.productForm.type = this.productForm.type ? this.productForm.type : (this.productForm.product_code ? constants.PRICE_TYPE_PRODUCT : this.appStore.user.last_product_product_used)
     if (this.productForm.product_code) {
       this.getProduct(this.productForm.product_code)
     }
   },
   methods: {
+    setCategoryTags() {
+      data_utils.getLocaleCategoryTags(this.appStore.getUserLanguage).then((module) => {
+        this.categoryTags = module.default
+      })
+    },
+    setOriginTags() {
+      data_utils.getLocaleOriginTags(this.appStore.getUserLanguage).then((module) => {
+        this.originTags = module.default
+      })
+    },
+    setLabelTags() {
+      data_utils.getLocaleLabelTags(this.appStore.getUserLanguage).then((module) => {
+        this.labelTags = module.default
+      })
+    },
     showBarcodeScannerDialog() {
       this.barcodeScannerDialog = true
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -54,9 +54,9 @@
           <v-autocomplete
             v-model="appStore.user.country"
             :label="$t('Common.Country')"
-            :items="countryList"
-            item-title="native"
-            item-value="code"
+            :items="countryTags"
+            item-title="name"
+            item-value="country_code_2"
             hide-details="auto"
           />
           <!-- Price list display -->
@@ -204,6 +204,7 @@ import languageList from '../i18n/data/languages.json'
 import countryList from '../i18n/data/countries.json'
 import localeManager from '../i18n/localeManager.js'
 import constants from '../constants'
+import data_utils from '../utils/data.js'
 
 export default {
   data() {
@@ -211,7 +212,8 @@ export default {
       theme: useTheme(),
       languageList,
       OFF_CROWDIN_URL: constants.OFF_CROWDIN_URL,
-      countryList,
+      countryTags: [],  // list of country tags for autocomplete  // see mounted
+      countryList,  // still needed for currencies
       // currencyList,
       priceListDisplayList: constants.DISPLAY_LIST,
       locationSelectorDisplayList: constants.LOCATION_SELECTOR_DISPLAY_LIST,
@@ -234,7 +236,11 @@ export default {
     },
     'appStore.user.language': function (newLanguage, oldLanguage) {  // eslint-disable-line no-unused-vars
       localeManager.changeLanguage(newLanguage)
+      this.setCountryTags()
     },
+  },
+  mounted() {
+    this.setCountryTags()
   },
   methods: {
     getThemeInfo(themeName) {
@@ -248,6 +254,11 @@ export default {
         icon: constants.THEME_DARK_ICON,
         label: this.$t('Common.ThemeDark')
       }
+    },
+    setCountryTags() {
+      data_utils.getLocaleCountryTags(this.appStore.getUserLanguage).then((module) => {
+        this.countryTags = module.default
+      })
     }
   },
 }


### PR DESCRIPTION
### What

Following #2102 we now have a list of countries with their localized name for all 150 languages.

In this PR, we display the list of country choices in the user's selected language.
And when the language changes, so does the list.

Closes #2098

### Screenshots

|Before|After|
|-|-|
|<img width="593" height="379" alt="image" src="https://github.com/user-attachments/assets/d59e22e3-3317-485d-877e-7341f916c1a3" />|<img width="593" height="379" alt="image" src="https://github.com/user-attachments/assets/4048e020-7c45-4285-b5cf-41f268564638" />|