### PR TITLE
refactor(Settings): for localized country input, order alphabetically (instead of contry_code)

### DIFF
--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -125,7 +125,7 @@
             </div>
             <v-autocomplete
               v-model="productForm.product_language"
-              :items="Languages"
+              :items="languageList"
               item-title="native"
               item-value="code"
               density="compact"
@@ -176,7 +176,7 @@
               <v-autocomplete
                 v-model="productForm.countries"
                 density="compact"
-                :items="Countries"
+                :items="countryList"
                 item-title="native"
                 item-value="code"
                 variant="outlined"
@@ -359,8 +359,8 @@ import openPricesApi from '../services/openPricesApi'
 import constants from '../constants'
 import proof_utils from '../utils/proof.js'
 import utils from '../utils'
-import Languages from '../i18n/data/languages.json'
-import Countries from '../i18n/data/countries.json'
+import languageList from '../i18n/data/languages.json'
+import countryList from '../i18n/data/countries.json'
 import "vue-zoomable/dist/style.css"
 
 export default {
@@ -389,8 +389,8 @@ export default {
       zoomLevel: 1,
       loading: false,
       panLevel: {x: 0, y: 0},
-      Languages,
-      Countries,
+      languageList,
+      countryList,
       currentOrder: '-created',
       currentFilterList: [],
       productTotal: 0

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -201,7 +201,7 @@ import { useTheme } from 'vuetify'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
 import languageList from '../i18n/data/languages.json'
-import countryList from '../i18n/data/countries.json'
+import countryList from '../i18n/data/countries.json'  // still needed for currencies
 import localeManager from '../i18n/localeManager.js'
 import constants from '../constants'
 import data_utils from '../utils/data.js'
@@ -213,7 +213,6 @@ export default {
       languageList,
       OFF_CROWDIN_URL: constants.OFF_CROWDIN_URL,
       countryTags: [],  // list of country tags for autocomplete  // see mounted
-      countryList,  // still needed for currencies
       // currencyList,
       priceListDisplayList: constants.DISPLAY_LIST,
       locationSelectorDisplayList: constants.LOCATION_SELECTOR_DISPLAY_LIST,
@@ -224,7 +223,7 @@ export default {
   computed: {
     ...mapStores(useAppStore),
     currencyList() {
-      return [...new Set(this.countryList
+      return [...new Set(countryList
         .map(country => country.currency)
         .flat()
         .filter(currency => currency !== null && currency.length !== 0))]
@@ -257,7 +256,7 @@ export default {
     },
     setCountryTags() {
       data_utils.getLocaleCountryTags(this.appStore.getUserLanguage).then((module) => {
-        this.countryTags = module.default
+        this.countryTags = module.default.sort((a, b) => a.name.localeCompare(b.name))
       })
     }
   },


### PR DESCRIPTION
### What

Following #2128 we now use the country JSON localized data.
But that list is ordered by country_code.

Here we order by name instead.

Closes #2098
