### PR TITLE
fix(CI): bump Node heap size limit to fix vite build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ The translation for all openfoodfacts GitHub repositories, including this one, i
 
 In Crowdin, after selecting the target language, add `open-prices-frontend` as a filter to check the translations that only belong to this GitHub repository.
 
-
 ## Help with developing
 
 ### Installation
@@ -30,6 +29,8 @@ We use the [yarn](https://yarnpkg.com/getting-started/install) for package manag
 ```sh
 yarn build
 ```
+
+The build script sets `NODE_OPTIONS=--max-old-space-size=8192` to give Vite/Rollup enough heap for production bundling. This frontend includes a large generated locale data set under `src/data`, and the default Node.js heap limit can otherwise fail with `JavaScript heap out of memory` during build.
 
 ### Lint
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "build-staging": "vite build --mode staging",
-    "build-prod": "vite build --mode prod",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
+    "build-staging": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build --mode staging",
+    "build-prod": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build --mode prod",
     "preview": "vite preview",
     "lint": "eslint",
     "lint:fix": "eslint --fix",


### PR DESCRIPTION
### What

Following new JSON data generated in #2102, and how we import them in #2122

`vite build` was failing due to `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`

> I chose 8192 because the failing build was already reaching about 4 GB of V8 heap before crashing. Setting the limit to 8 GB gives roughly 2x headroom, which is usually enough to get a large Rollup/Vite production build through chunk generation without being unnecessarily extreme.
