### PR TITLE
ci(Release Please): avoid having the component name in the release version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,8 @@
 {
     "packages": {
         ".": {
-            "release-type": "node"
+            "release-type": "node",
+            "include-component-in-tag": false
         }
     },
     "changelog-sections": [


### PR DESCRIPTION
### What

Following #2135
Improve the release please config to avoid prefixing the release version with the package name
(it had changed `v1.161.0` to `open-prices-v1.161.0`)
