### PR TITLE
refactor(Auth): API: stop sending domain cookies to the API, they conflict with the token authentication

### DIFF
--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -74,7 +74,7 @@ function extraPriceCreateOrUpdateFiltering(data) {
  * 2. to ensure cookies are not sent to the API. Why?
  * - Open Prices backend API allows both cookie & token authentication
  * - but Open Prices frontend (this app) only uses token authentication
- * - sending both can lead to issues (the cookie likely coming from another OFF domain or env)
+ * - sending both can lead to issues (e.g. the cookie coming from Django admin)
  */
 function fetchOpenPrices(endpointWithParams, options) {
   const URLWithParams = `${import.meta.env.VITE_OPEN_PRICES_API_URL}${endpointWithParams}`

--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -72,8 +72,8 @@ function extraPriceCreateOrUpdateFiltering(data) {
  * Wrapper around fetch
  * 1. to avoid repeating VITE_OPEN_PRICES_API_URL
  * 2. to ensure cookies are not sent to the API. Why?
- * - Open Prices API allows both cookie & token authentication
- * - but Open Prices Frontend only uses token authentication
+ * - Open Prices backend API allows both cookie & token authentication
+ * - but Open Prices frontend (this app) only uses token authentication
  * - sending both can lead to issues (the cookie likely coming from another OFF domain or env)
  */
 function fetchOpenPrices(endpointWithParams, options) {

--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -68,10 +68,20 @@ function extraPriceCreateOrUpdateFiltering(data) {
   return filteredData
 }
 
-
+/**
+ * Wrapper around fetch
+ * 1. to avoid repeating VITE_OPEN_PRICES_API_URL
+ * 2. to ensure cookies are not sent to the API. Why?
+ * - Open Prices API allows both cookie & token authentication
+ * - but Open Prices Frontend only uses token authentication
+ * - sending both can lead to issues (the cookie likely coming from another OFF domain or env)
+ */
 function fetchOpenPrices(endpointWithParams, options) {
   const URLWithParams = `${import.meta.env.VITE_OPEN_PRICES_API_URL}${endpointWithParams}`
-  return fetch(URLWithParams, options)
+  return fetch(URLWithParams, {
+    ...options,
+    credentials: 'omit'
+  })
 }
 
 


### PR DESCRIPTION
### What

The frontend's authentication mecanism with Open Prices API should be ONLY via token.
But with other OFF domains, we sometimes have cookies persisted.
And when sent to the Open Prices API, they are checked first instead of the token...

### Solution

Only interact with the Open Prices API using token. Remove cookies from the calls.
By overrding `fetchOpenPrices` method created in #2150

### Linked issue

#230