### PR TITLE
refactor(Auth): on signOut, clear is_moderator info

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -65,6 +65,7 @@ export const useAppStore = defineStore('app', {
     signOut() {
       this.user.username = null
       this.user.token = null
+      this.user.is_moderator = false
     },
     addRecentLocation(location) {
       this.user.recent_locations = utils.addObjectToArray(this.user.recent_locations, location, true)


### PR DESCRIPTION
### What

In #1768 we started storing the `is_moderator` info
But we forgot to clear it on signOut