### PR TITLE
refactor(LocationSelectorDialog): remove 'Results' title and show the list of cards directly (like the BarcodeScannerDialog)

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -33,7 +33,7 @@
           </v-tabs-window-item>
 
           <v-tabs-window-item value="type">
-            <v-form class="mb-2" @submit.prevent="barcodeSearchOrSend">
+            <v-form class="mb-4" @submit.prevent="barcodeSearchOrSend">
               <v-text-field
                 ref="barcodeManualInput"
                 v-model="barcodeManualForm.barcode"
@@ -51,6 +51,8 @@
                 </template>
               </v-text-field>
             </v-form>
+
+            <!-- results -->
             <ProductCard v-for="product in productSearchResultList" :key="product" :product="product" :hideCategoriesAndLabels="true" :hideActionMenuButton="true" :readonly="true" elevation="1" @click="barcodeSend(product.code)" />
 
             <div v-if="barcodeManualInputSimilarBarcodeList.length">

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -42,7 +42,7 @@
           </v-tabs-window-item>
 
           <v-tabs-window-item value="osm">
-            <v-form @submit.prevent="locationOsmSearch">
+            <v-form class="mb-4" @submit.prevent="locationOsmSearch">
               <v-text-field
                 ref="locationOsmSearchInput"
                 v-model="locationOsmSearchForm.q"
@@ -67,41 +67,33 @@
               </i18n-t>
             </p>
 
-            <v-sheet v-if="results !== null">
-              <h3 class="mt-4 mb-1">
-                <i18n-t keypath="LocationSelector.Result" tag="span">
-                  <template #resultNumber>
-                    <small>{{ results.length }}</small>
+            <!-- results -->
+            <v-row v-if="results.length">
+              <v-col cols="12" sm="6">
+                <LocationCard v-for="(location, index) in results" :key="index" :location="location" :hideLocationFooterRow="true" :readonly="true" class="mb-2" width="100%" elevation="1" @click="selectLocation(location)" />
+              </v-col>
+              <v-col cols="12" sm="6" style="min-height:400px">
+                <LeafletMap :locations="results" :showActions="true" @locationSelected="selectLocation" />
+              </v-col>
+            </v-row>
+
+            <p v-else>
+              <v-alert class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
+                {{ $t('LocationSelector.NoResultHelpKeywords') }}
+              </v-alert>
+              <v-alert class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
+                <i18n-t keypath="LocationSelector.NoResultHelpOSM" tag="span">
+                  <template #osm_name>
+                    {{ OSM_NAME }}
+                  </template>
+                  <template #osm_url>
+                    <a :href="OSM_URL" target="_blank">
+                      {{ OSM_URL }}
+                    </a>
                   </template>
                 </i18n-t>
-              </h3>
-              <v-row v-if="results.length">
-                <v-col cols="12" sm="6">
-                  <LocationCard v-for="(location, index) in results" :key="index" :location="location" :hideLocationFooterRow="true" :readonly="true" class="mb-2" width="100%" elevation="1" @click="selectLocation(location)" />
-                </v-col>
-                <v-col cols="12" sm="6" style="min-height:400px">
-                  <LeafletMap :locations="results" :showActions="true" @locationSelected="selectLocation" />
-                </v-col>
-              </v-row>
-
-              <p v-else>
-                <v-alert class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
-                  {{ $t('LocationSelector.NoResultHelpKeywords') }}
-                </v-alert>
-                <v-alert class="mb-2" color="primary" variant="outlined" density="compact" icon="mdi-information">
-                  <i18n-t keypath="LocationSelector.NoResultHelpOSM" tag="span">
-                    <template #osm_name>
-                      {{ OSM_NAME }}
-                    </template>
-                    <template #osm_url>
-                      <a :href="OSM_URL" target="_blank">
-                        {{ OSM_URL }}
-                      </a>
-                    </template>
-                  </i18n-t>
-                </v-alert>
-              </p>
-            </v-sheet>
+              </v-alert>
+            </p>
           </v-tabs-window-item>
 
           <v-tabs-window-item value="online">


### PR DESCRIPTION
### What

src/components/LocationSelectorDialog.vue
- remove some (useless) text
- add margin between the form and the results

### Screenshot

|Before|After|
|-|-|
|<img width="1198" height="919" alt="image" src="https://github.com/user-attachments/assets/1cfbb59e-fa4e-42cb-8975-3b2d64639a1b" />|<img width="1198" height="919" alt="image" src="https://github.com/user-attachments/assets/f2588daf-750d-43af-8405-a87691b82c54" />|