### PR TITLE
fix(CreateOffProduct): digit-only barcodes are allowed

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,10 @@ function isNumber(value) {
   return !isNaN(parseFloat(value)) && isFinite(value)
 }
 
+function numbersOnly(value) {
+  return value.replace(/\D/g, '')
+}
+
 function toArray(value) {
   if (Array.isArray(value)) {
     return value
@@ -115,6 +119,7 @@ export default {
   debounce,
   getDocumentScrollPercentage,
   isNumber,
+  numbersOnly,
   toArray,
   slugify,
   isURL,

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,10 @@ function isNumber(value) {
   return !isNaN(parseFloat(value)) && isFinite(value)
 }
 
-function numbersOnly(value) {
+/**
+ * Remove all non-digit characters from a string
+ */
+function numericOnly(value) {
   return value.replace(/\D/g, '')
 }
 
@@ -119,7 +122,7 @@ export default {
   debounce,
   getDocumentScrollPercentage,
   isNumber,
-  numbersOnly,
+  numericOnly,
   toArray,
   slugify,
   isURL,

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -29,11 +29,12 @@
             </div>
             <v-text-field
               v-model="productForm.product_code"
+              type="text"
+              inputmode="numeric"
               density="compact"
               variant="outlined"
-              type="text"
-              inputmode="decimal"
               persistent-hint
+              @update:modelValue="newValue => productForm.product_code = numbersOnly(newValue)"
             />
           </v-card-text>
           <v-divider />
@@ -45,6 +46,7 @@
                   color="primary"
                   variant="flat"
                   type="submit"
+                  :disabled="!productForm.product_code"
                 >
                   {{ $t('Common.Select') }}
                 </v-btn>
@@ -445,6 +447,9 @@ export default {
     this.setCountryTags()
   },
   methods: {
+    numbersOnly(value) {
+      return utils.numbersOnly(value)
+    },
     fieldRequired(v) {
       return !!v || this.$t('Common.FieldIsRequired')
     },

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -34,7 +34,7 @@
               density="compact"
               variant="outlined"
               persistent-hint
-              @update:modelValue="newValue => productForm.product_code = numbersOnly(newValue)"
+              @update:modelValue="newValue => productForm.product_code = numericOnly(newValue)"
             />
           </v-card-text>
           <v-divider />
@@ -447,8 +447,8 @@ export default {
     this.setCountryTags()
   },
   methods: {
-    numbersOnly(value) {
-      return utils.numbersOnly(value)
+    numericOnly(value) {
+      return utils.numericOnly(value)
     },
     fieldRequired(v) {
       return !!v || this.$t('Common.FieldIsRequired')


### PR DESCRIPTION
### What

CreateOffProduct barcode input
- new rule `numericOnly`
- disable submit button if form is empty

Closes #2071