### PR TITLE
refactor(Price Card): when product is missing, turn default image to red

### DIFF
--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -5,7 +5,7 @@
         <v-col v-if="!hideProductImage" class="pr-0" style="max-width:20%;">
           <v-img v-if="product && product.image_url" :src="product.image_url" max-height="100px" @click="goToProduct()" />
           <v-img v-else-if="product && product.source || price.category_tag" :src="productImageDefault" width="100px" style="filter: invert(0.9);" />
-          <v-img v-else :src="productImageDefault" width="100px" style="filter: invert(25%) sepia(50%) saturate(2000%) hue-rotate(350deg);" />
+          <v-img v-else :src="productImageDefault" width="100px" style="filter: invert(57%) sepia(22%) saturate(6809%) hue-rotate(314deg) brightness(96%) contrast(68%);" />
         </v-col>
         <v-col :style="hideProductImage ? '' : 'max-width:80%'">
           <h3 v-if="!hideProductTitle" id="product-title" role="link" tabindex="0" @click="goToProduct()" @keydown.enter="goToProduct()">

--- a/src/components/PriceCard.vue
+++ b/src/components/PriceCard.vue
@@ -4,7 +4,8 @@
       <v-row>
         <v-col v-if="!hideProductImage" class="pr-0" style="max-width:20%;">
           <v-img v-if="product && product.image_url" :src="product.image_url" max-height="100px" @click="goToProduct()" />
-          <v-img v-else :src="productImageDefault" width="100px" style="filter:invert(.9);" />
+          <v-img v-else-if="product && product.source || price.category_tag" :src="productImageDefault" width="100px" style="filter: invert(0.9);" />
+          <v-img v-else :src="productImageDefault" width="100px" style="filter: invert(25%) sepia(50%) saturate(2000%) hue-rotate(350deg);" />
         </v-col>
         <v-col :style="hideProductImage ? '' : 'max-width:80%'">
           <h3 v-if="!hideProductTitle" id="product-title" role="link" tabindex="0" @click="goToProduct()" @keydown.enter="goToProduct()">

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -5,7 +5,7 @@
         <v-col class="pr-0" style="max-width:20%;">
           <v-img v-if="product.image_url" :src="product.image_url" max-height="100px" @click="clickProduct()" />
           <v-img v-else-if="product.source" :src="productImageDefault" width="100px" style="filter: invert(0.9);" />
-          <v-img v-else :src="productImageDefault" width="100px" style="filter: invert(25%) sepia(50%) saturate(2000%) hue-rotate(350deg);" />
+          <v-img v-else :src="productImageDefault" width="100px" style="filter: invert(57%) sepia(22%) saturate(6809%) hue-rotate(314deg) brightness(96%) contrast(68%);" />
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -4,7 +4,8 @@
       <v-row>
         <v-col class="pr-0" style="max-width:20%;">
           <v-img v-if="product.image_url" :src="product.image_url" max-height="100px" @click="clickProduct()" />
-          <v-img v-else :src="productImageDefault" width="100px" style="filter:invert(.9);" />
+          <v-img v-else-if="product.source" :src="productImageDefault" width="100px" style="filter: invert(0.9);" />
+          <v-img v-else :src="productImageDefault" width="100px" style="filter: invert(25%) sepia(50%) saturate(2000%) hue-rotate(350deg);" />
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>


### PR DESCRIPTION
### What

Currently there's little difference between an existing product without an image, and an unknown product (apart from the `ProductMissingChip` and maybe the name set to the barcode).

The idea here is to change the default icon color

### Thoughts

There's probably better to do here, for instance an alternate image ?

### Screenshot

|Before|After|
|-|-|
|<img width="403" height="374" alt="image" src="https://github.com/user-attachments/assets/7a76543e-052f-45db-b805-166d23680361" />|<img width="403" height="374" alt="image" src="https://github.com/user-attachments/assets/982514ba-f0e1-44da-aeac-c13377e21218" />|

in https://github.com/openfoodfacts/open-prices-frontend/pull/2161/commits/88f2acbb1ccdb7a2e5f10903040fb6b0c36a79ee the color was improved