### PR TITLE
refactor(CreateOffProduct): improve barcode input UI (full width)

### DIFF
--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -14,51 +14,33 @@
   </v-row>
 
   <v-row v-if="step === 1">
-    <v-col cols="12" md="6">
+    <v-col cols="12">
       <v-form @submit.prevent="onProductCodeSelected">
         <v-card
-          class="mb-4"
           :title="$t('Common.BarcodeType')"
           prepend-icon="mdi-tag-plus-outline"
           height="100%"
         >
           <v-divider />
           <v-card-text>
-            <div class="text-body-2">
-              {{ $t('AddPriceSingle.ProductInfo.ProductBarcode') }}
-            </div>
             <v-text-field
               v-model="productForm.product_code"
+              :label="$t('AddPriceSingle.ProductInfo.ProductBarcode')"
               type="text"
               inputmode="numeric"
-              density="compact"
-              variant="outlined"
               persistent-hint
               @update:modelValue="newValue => productForm.product_code = numericOnly(newValue)"
-            />
+            >
+              <template #append-inner>
+                <v-btn color="primary" icon="mdi-plus" :disabled="!productForm.product_code" @click="onProductCodeSelected" />
+              </template>
+            </v-text-field>
           </v-card-text>
-          <v-divider />
-          <v-card-actions>
-            <v-row>
-              <v-col>
-                <v-btn
-                  class="float-right"
-                  color="primary"
-                  variant="flat"
-                  type="submit"
-                  :disabled="!productForm.product_code"
-                >
-                  {{ $t('Common.Select') }}
-                </v-btn>
-              </v-col>
-            </v-row>
-          </v-card-actions>
         </v-card>
       </v-form>
     </v-col>
-    <v-col cols="12" md="6">
+    <v-col cols="12">
       <v-card
-        class="mb-4"
         :title="$t('CreateOffProduct.SelectUnknownProductGuide')"
         prepend-icon="mdi-tag-plus-outline"
         height="100%"

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -28,7 +28,7 @@
               :label="$t('AddPriceSingle.ProductInfo.ProductBarcode')"
               type="text"
               inputmode="numeric"
-              persistent-hint
+              hide-details="auto"
               @update:modelValue="newValue => productForm.product_code = numericOnly(newValue)"
             >
               <template #append-inner>


### PR DESCRIPTION
### What

Simplify the barcode input
- full width
- reduce height

### Why

to give more width to the product list below, and in a futur PR
- load less prices
- start displaying images

### Screenshot

|Before|After|
|-|-|
|<img width="1201" height="372" alt="image" src="https://github.com/user-attachments/assets/67c07030-9e83-4959-abe3-02e6498d4d07" />|<img width="1201" height="537" alt="image" src="https://github.com/user-attachments/assets/4847b94b-f783-470f-b70b-05cc67a8227a" />|