### PR TITLE
refactor(Locations): improve fallback to png logo (or default)

### DIFF
--- a/src/components/LocationBrandLogoImg.vue
+++ b/src/components/LocationBrandLogoImg.vue
@@ -1,6 +1,6 @@
 <template>
   <v-img
-    v-if="logo && !fallbackToDefault"
+    v-if="logoDisplayed"
     :src="currentSrc"
     :width="width"
     :height="height"
@@ -41,6 +41,9 @@ export default {
     }
   },
   computed: {
+    logoDisplayed() {
+      return this.logo && !this.fallbackToDefault
+    },
     currentSrc() {
       if (!this.logo) return null
       return this.tryPngInsteadOfSvg ? `${this.logo}.png` : `${this.logo}.svg`

--- a/src/components/LocationBrandLogoImg.vue
+++ b/src/components/LocationBrandLogoImg.vue
@@ -1,6 +1,6 @@
 <template>
   <v-img
-    v-if="logo"
+    v-if="logo && !fallbackToDefault"
     :src="currentSrc"
     :width="width"
     :height="height"
@@ -19,7 +19,6 @@
 import constants from '../constants'
 
 export default {
-  name: 'LocationBrandLogoImg',
   props: {
     logo: {
       type: String,
@@ -36,23 +35,23 @@ export default {
   },
   data() {
     return {
-      triedPng: false,
+      tryPngInsteadOfSvg: false,
+      fallbackToDefault: false,
       locationImageDefault: constants.LOCATION_IMAGE_DEFAULT_URL,
     }
   },
   computed: {
     currentSrc() {
       if (!this.logo) return null
-      return this.triedPng ? `${this.logo}.png` : `${this.logo}.svg`
+      return this.tryPngInsteadOfSvg ? `${this.logo}.png` : `${this.logo}.svg`
     }
   },
   methods: {
-    onError(e) {
-      if (!this.triedPng && this.logo) {
-        this.triedPng = true
-        e.target.src = `${this.logo}.png`
+    onError() {
+      if (!this.tryPngInsteadOfSvg && this.logo) {
+        this.tryPngInsteadOfSvg = true
       } else {
-        e.target.src = this.locationImageDefault
+        this.fallbackToDefault = true
       }
     }
   }


### PR DESCRIPTION
### What

Following #2099

The console was printing lots of errors.
And if both svg & png were not found, it wasn't falling back to the default image.

### Screenshot

|Before|After|
|-|-|
|<img width="1204" height="500" alt="image" src="https://github.com/user-attachments/assets/4828ad73-4c2e-40c5-adbd-54a831fab225" />|<img width="1204" height="500" alt="image" src="https://github.com/user-attachments/assets/5cb08855-a973-4ba6-bac6-a4970a5c14d9" />|