### PR TITLE
feat(CreateOffProduct): option to use user own account

### DIFF
--- a/src/services/keycloakService.js
+++ b/src/services/keycloakService.js
@@ -1,18 +1,19 @@
 import Keycloak from 'keycloak-js'
+const url = import.meta.env.VITE_KEYCLOAK_URL
+let keycloak = null
+if (url) {
+  keycloak = new Keycloak({
+    url: url,
+    realm: import.meta.env.VITE_KEYCLOAK_REALM,
+    clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID
+  })
+}
 
 export default {
   init(callback) {
-    const url = import.meta.env.VITE_KEYCLOAK_URL
-    if (!url) {
-      // keycloak is not configured
-      return callback(null, 'Keycloak: URL is not configured')
+    if (keycloak.didInitialize) {
+      return callback(keycloak, null)
     }
-    const keycloak = new Keycloak({
-      url: url,
-      realm: import.meta.env.VITE_KEYCLOAK_REALM,
-      clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID
-    })
-    
     keycloak.init()
       .then(() => {
         callback(keycloak, null)

--- a/src/store.js
+++ b/src/store.js
@@ -25,7 +25,8 @@ export const useAppStore = defineStore('app', {
       price_list_display_default_mode: constants.DISPLAY_LIST[0].key,
       location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,
       barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key,
-      barcode_scanner_library: constants.BARCODE_SCANNER_DISPLAY_LIST[0].key
+      barcode_scanner_library: constants.BARCODE_SCANNER_DISPLAY_LIST[0].key,
+      use_own_account_to_create_off_products: false
     },
   }),
   getters: {

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -353,6 +353,7 @@ import proof_utils from '../utils/proof.js'
 import utils from '../utils'
 import data_utils from '../utils/data.js'
 import "vue-zoomable/dist/style.css"
+import keycloakService from '../services/keycloakService'
 
 export default {
   components: {
@@ -388,6 +389,7 @@ export default {
       zoomLevel: 1,
       loading: false,
       panLevel: {x: 0, y: 0},
+      token: null,
     }
   },
   computed: {
@@ -426,20 +428,42 @@ export default {
     }
   },
   mounted() {
-    this.currentFilterList = utils.toArray(this.$route.query[constants.FILTER_PARAM]) || this.currentFilterList
-    this.currentOrder = this.$route.query[constants.ORDER_PARAM] || this.currentOrder
-    if (this.$route.query.product_code) {
-      this.productForm.product_code = this.$route.query.product_code
-      this.onProductCodeSelected()
+    if (this.appStore.user.use_own_account_to_create_off_products) {
+      keycloakService.init((keycloak, error) => {
+        if (error) {
+          alert(error)
+          return
+        }
+        if (keycloak !== null) {
+          if (keycloak.authenticated) {
+            this.token = keycloak.token
+            this.onInit()
+          } else {
+            keycloak.login({
+              redirectUri: window.location.origin + '/sign-in?next=' + window.location.pathname
+            })
+          }
+        }
+      })
+    } else {
+      this.onInit()
     }
-    if (this.$route.query.flavor) {
-      this.productForm.flavor = this.$route.query.flavor
-    }
-    this.getMissingProductsWithPrices()
-    this.setCountryTags()
-    this.getChallenges()
   },
   methods: {
+    onInit() {
+      this.currentFilterList = utils.toArray(this.$route.query[constants.FILTER_PARAM]) || this.currentFilterList
+      this.currentOrder = this.$route.query[constants.ORDER_PARAM] || this.currentOrder
+      if (this.$route.query.product_code) {
+        this.productForm.product_code = this.$route.query.product_code
+        this.onProductCodeSelected()
+      }
+      if (this.$route.query.flavor) {
+        this.productForm.flavor = this.$route.query.flavor
+      }
+      this.getMissingProductsWithPrices()
+      this.setCountryTags()
+      this.getChallenges()
+    },
     numericOnly(value) {
       return utils.numericOnly(value)
     },
@@ -565,6 +589,7 @@ export default {
       let inputData = {
         flavor: this.productForm.flavor,
         product_language_code: this.productForm.product_language,
+        user_access_token: this.token,
         update_params: {
           ...this.productForm,
           categories: this.productForm.categories.join(','),
@@ -580,7 +605,8 @@ export default {
             inputData = {
               image_data_base64: drawnImageBase64,
               flavor: this.productForm.flavor,
-              product_language_code: this.productForm.product_language
+              product_language_code: this.productForm.product_language,
+              user_access_token: this.token
             }
             openPricesApi.updateOffProductImage(this.productForm.product_code, inputData)
               .then(() => {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -190,6 +190,17 @@
             density="compact"
             hide-details="auto"
           />
+          <!-- Create Off Product -->
+          <h3 class="mt-4 mb-1">
+            {{ $t('Router.CreateOffProduct.Title') }}
+          </h3>
+          <v-switch
+            v-model="appStore.user.use_own_account_to_create_off_products"
+            color="success"
+            :label="$t('CreateOffProduct.UseOwnAccountToCreateOffProduct')"
+            density="compact"
+            hide-details="auto"
+          />
         </v-card-text>
       </v-card>
     </v-col>


### PR DESCRIPTION
### What
- Still WIP
- With keycloak, we have the capabilities to author modifications to Open Food Facts to the actual user instead of the default open-prices user
- On product opener, this is done by simply feeding the keycloak access_token to the product creation query via default header `Authorization: Bearer <access_token>` (undocumented, but works !)
- On open prices, this call is currently done on the backend
- Access tokens have a very short lifespan (5 minutes), so we cannot store them on backend.
- This PR adds a mechanism to retrieve a fresh acces_token on the frontend, and send it with the create product query
- The downside of this is that users will most likely need to relog every time they use the experiment, since keycloak sessions are also short (30 minutes of inactivity)
- Thus, by default this feature is hidden behind a settings flag, and only users that really want to author their changes will change it.

If we're ok with this behavior, PR still needs:
- Cleanup
- Checking that the new keycloak init didn't break stuff, especially on installs where keycloak isn't configured (local)
- Add a proper translation for the new setting (and maybe move it outside "dev mode")
- An update to the backend to support the new `user_access_token` param
    - This might require a change to the python SDK, since it is unable to auth queries with tokens at the moment (only supports username/password or session cookies) -> Seen with raphael0202, it's an acceptable change to the sdk.