### PR TITLE
fix(Price Validation Assistant): filter price tag based on PRICE_TAG_EXTRACTION predictions

### DIFF
--- a/src/utils/proof.js
+++ b/src/utils/proof.js
@@ -18,7 +18,12 @@ function getProofTypeIcon(proofType) {
  * Needed as input for the ContributionAssistantPriceFormCard
  */
 function handlePriceTag(priceTag) {
-  const priceTagPrediction = priceTag['predictions'][0]
+  // Only keep predictions of type 'PRICE_TAG_EXTRACTION'
+  const priceTagPredictions = priceTag['predictions'].filter(prediction => prediction.type === 'PRICE_TAG_EXTRACTION')
+  if (!priceTagPredictions.length) {
+    throw new Error(`No PRICE_TAG_EXTRACTION prediction found for this price tag: ${priceTag.id}`)
+  }
+  const priceTagPrediction = priceTagPredictions[0]
   const label = priceTagPrediction['data']
   const barcodeString = label.barcode ? barcode_utils.cleanBarcode(label.barcode.toString()) : ''
 

--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -180,7 +180,7 @@ export default {
           this.loading = false
           for (let i = 0; i < data.items.length; i++) {
             // only validate price tags with predictions
-            if (data.items[i]['predictions'].length > 0) {
+            if (data.items[i]['predictions'].filter(prediction => prediction.type === 'PRICE_TAG_EXTRACTION').length > 0) {
               this.handlePriceTag(data.items[i])
             }
           }


### PR DESCRIPTION
Until now, we expected each price tag to have at most 1 prediction, of type PRICE_TAG_EXTRACTION. As we introduced a new price tag prediction type in https://github.com/openfoodfacts/open-prices/pull/1284, we now need to filter price tag predictions based on type.