### PR TITLE
fix(Proofs): fix bug when changing receipt to price tag if owner_consumption was set

### DIFF
--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -37,14 +37,14 @@ function filterBodyWithAllowedKeys(data, allowedKeys) {
 
 function extraPriceCreateOrUpdateFiltering(data) {
   let filteredData = {...data}
-  // product-only rules
+  // product only rules
   if (filteredData.type == constants.PRICE_TYPE_PRODUCT) {
     delete filteredData.price_per
     delete filteredData.category_tag
     delete filteredData.origins_tags
     delete filteredData.labels_tags
   }
-  // category-only rules
+  // category only rules
   else if (filteredData.type == constants.PRICE_TYPE_CATEGORY) {
     delete filteredData.product_code
     delete filteredData.product
@@ -72,7 +72,14 @@ function extraProofCreateOrUpdateFiltering(data) {
     delete filteredData.receipt_price_count
     delete filteredData.receipt_price_total
     delete filteredData.receipt_online_delivery_costs
+  }
+  // price tag only rules
+  if (filteredData.type === constants.PROOF_TYPE_PRICE_TAG) {
     filteredData.owner_consumption = null
+  }
+  // non price tag rules
+  else {
+    delete filteredData.ready_for_price_tag_validation
   }
   return filteredData
 }

--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -65,6 +65,18 @@ function extraPriceCreateOrUpdateFiltering(data) {
   return filteredData
 }
 
+function extraProofCreateOrUpdateFiltering(data) {
+  let filteredData = {...data}
+  // non-receipt rules
+  if (filteredData.type !== constants.PROOF_TYPE_RECEIPT) {
+    delete filteredData.receipt_price_count
+    delete filteredData.receipt_price_total
+    delete filteredData.receipt_online_delivery_costs
+    filteredData.owner_consumption = null
+  }
+  return filteredData
+}
+
 /**
  * Wrapper around fetch
  * 1. to avoid repeating the URL prefix (VITE_OPEN_PRICES_API_URL)
@@ -137,7 +149,9 @@ export default {
   createProof(image, inputData, source = null) {
     const store = useAppStore()
     // build body
-    const data = filterBodyWithAllowedKeys(inputData, PROOF_CREATE_FIELDS)
+    let data = filterBodyWithAllowedKeys(inputData, PROOF_CREATE_FIELDS)
+    data = extraProofCreateOrUpdateFiltering(data)
+    // build form
     let formData = new FormData()
     formData.append('file', image, image.name)
     formData.append('type', data.type)
@@ -204,7 +218,8 @@ export default {
 
   updateProof(proofId, inputData = {}) {
     // build body
-    const data = filterBodyWithAllowedKeys(inputData, PROOF_UPDATE_FIELDS)
+    let data = filterBodyWithAllowedKeys(inputData, PROOF_UPDATE_FIELDS)
+    data = extraProofCreateOrUpdateFiltering(data)
     // API call
     const endpointWithParams = `/proofs/${proofId}?${buildURLParams()}`
     return fetchOpenPrices(endpointWithParams, {


### PR DESCRIPTION
### What

I was facing an issue where I couldn't change the type of a proof I uploaded..
More specifically, changing from Receipt --> Price Tag.
The error was that owner_consumption wasn't reset, and the API was returning an error...

Fixed by adding a `extraProofCreateOrUpdateFiltering` method (similar to existing `extraPriceCreateOrUpdateFiltering`)