### PR TITLE
fix(Price Validation): Avoid loading price tags without extraction prediction (fixes blank screen)

### DIFF
--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -92,7 +92,7 @@ export default {
       let defaultParams = {
         proof__ready_for_price_tag_validation: true,
         status__isnull: true,
-        prediction_count__gte: 2, // at least 2 predictions : PRICE_TAG_CLF & PRICE_TAG_EXTRACTION
+        prediction_count__gte: 2, // at least 2 predictions: PRICE_TAG_CLF & PRICE_TAG_EXTRACTION
         created__lte: this.currentDateTime,
         order_by: this.currentOrder,
         size: this.getApiSize,

--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -92,7 +92,7 @@ export default {
       let defaultParams = {
         proof__ready_for_price_tag_validation: true,
         status__isnull: true,
-        prediction_count__gte: 1,
+        prediction_count__gte: 2, // at least 2 predictions : PRICE_TAG_CLF & PRICE_TAG_EXTRACTION
         created__lte: this.currentDateTime,
         order_by: this.currentOrder,
         size: this.getApiSize,


### PR DESCRIPTION
### What
- Following https://github.com/openfoodfacts/open-prices-frontend/pull/2174 we had a display error with price tags loaded but not including the price extraction prediction
- When the first 4 loaded price tags were concerned, nothing was shown to users, and they had no way of scrolling to load more price tags
- Luckily, we have a filter on the API to only fetch price tag that have a given number of prediction, it was set to one before (PRICE_TAG_EXTRACTION), this PR sets it to the expect 2 (PRICE_TAG_CLF & PRICE_TAG_EXTRACTION)

