### PR TITLE
refactor(Stats): new Challenge sections. add Price & Proof count in challenges

### DIFF
--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -124,6 +124,12 @@
     <v-col cols="6" sm="4" md="3" lg="2">
       <StatCard :value="stats.challenge_count" :subtitle="$t('Stats.Total')" to="/challenges" />
     </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_in_challenge_count" :subtitle="$t('Common.Prices')" />
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.proof_in_challenge_count" :subtitle="$t('Common.Proofs')" />
+    </v-col>
   </v-row>
 
   <v-row>
@@ -265,6 +271,8 @@ export default {
         user_count: 0,
         user_with_price_count: 0,
         challenge_count: 0,
+        price_in_challenge_count: 0,
+        proof_in_challenge_count: 0,
         product_created_count: 0,
         updated: null,
       },

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -139,8 +139,8 @@
         {{ $t('Common.Experiments') }}
       </h2>
     </v-col>
-    <v-col cols="6" sm="4">
-      <StatCard :value="stats.price_tag_status_linked_to_price_count" :subtitle="$t('Stats.PricesLinkedToPriceTag')" />
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.price_tag_status_linked_to_price_count" :subtitle="$t('UserSettings.PriceValidation')" />
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
       <StatCard :value="stats.product_created_count" :subtitle="$t('Common.ProductsCreated')" />

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -117,12 +117,21 @@
   <v-row>
     <v-col cols="12" class="pb-0">
       <h2 class="text-h6">
-        <v-icon size="x-small" icon="mdi-test-tube" />
-        {{ $t('Common.Experiments') }}
+        <v-icon size="x-small" icon="mdi-trophy-variant" />
+        {{ $t('Common.Challenges') }}
       </h2>
     </v-col>
     <v-col cols="6" sm="4" md="3" lg="2">
-      <StatCard :value="stats.challenge_count" :subtitle="$t('Common.Challenges')" to="/challenges" />
+      <StatCard :value="stats.challenge_count" :subtitle="$t('Stats.Total')" to="/challenges" />
+    </v-col>
+  </v-row>
+
+  <v-row>
+    <v-col cols="12" class="pb-0">
+      <h2 class="text-h6">
+        <v-icon size="x-small" icon="mdi-test-tube" />
+        {{ $t('Common.Experiments') }}
+      </h2>
     </v-col>
     <v-col cols="6" sm="4">
       <StatCard :value="stats.price_tag_status_linked_to_price_count" :subtitle="$t('Stats.PricesLinkedToPriceTag')" />


### PR DESCRIPTION
### What

Improve the stats page
- new challenge section
- rename the "price validation" count

### Screenshot

<img width="900" height="263" alt="image" src="https://github.com/user-attachments/assets/1fbcf2fc-6491-4049-9c85-406876e88eb8" />
