### PR TITLE
refactor(Location Card): Use the new `osm_brand_logo_url` for OP locations

### DIFF
--- a/src/components/LocationBrandLogoImg.vue
+++ b/src/components/LocationBrandLogoImg.vue
@@ -35,7 +35,7 @@ export default {
   },
   data() {
     return {
-      tryPngInsteadOfSvg: false,
+      trySvgInsteadOfPng: false,  // default to png, and try svg if png fails
       fallbackToDefault: false,
       locationImageDefault: constants.LOCATION_IMAGE_DEFAULT_URL,
     }
@@ -46,13 +46,13 @@ export default {
     },
     currentSrc() {
       if (!this.logo) return null
-      return this.tryPngInsteadOfSvg ? `${this.logo}.png` : `${this.logo}.svg`
+      return this.trySvgInsteadOfPng ? `${this.logo}.svg` : `${this.logo}.png`
     }
   },
   methods: {
     onError() {
-      if (!this.tryPngInsteadOfSvg && this.logo) {
-        this.tryPngInsteadOfSvg = true
+      if (!this.trySvgInsteadOfPng && this.logo) {
+        this.trySvgInsteadOfPng = true
       } else {
         this.fallbackToDefault = true
       }

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -194,7 +194,8 @@ function getLocationBrandLogoPathName(locationObject) {
     nameCleaned = utils.slugify(locationObject.name)
   // OP
   } else if (locationObject.osm_brand) {
-    nameCleaned = utils.slugify(locationObject.osm_brand)
+    // See https://github.com/openfoodfacts/open-prices/issues/1148
+    return locationObject.osm_brand_logo_url.replace('.png', '').replace('.svg', '')
   }
   if (nameCleaned) {
     nameCleaned = `${BRAND_URL_PREFIX}${nameCleaned}`


### PR DESCRIPTION
### What

Closes #318

- for Locations coming from Open Prices backend, we display the logo available in the field `osm_brand_logo_url`
- and we default to `.png`