### PR TITLE
refactor(Product Detail): if unknown, show only 1 banner to add the product

### DIFF
--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -8,8 +8,10 @@
 
   <v-row v-if="productOrCategoryNotFound" class="mt-0">
     <v-col cols="12" sm="6">
-      <ProductNotFoundAlert v-if="productNotFound" :productCode="productId" />
-      <CreateOpenFoodFactsProductPromoBanner v-if="productNotFound && priceTotal" class="mt-3" :productCode="productId" />
+      <template v-if="!productNotFound">
+        <CreateOpenFoodFactsProductPromoBanner v-if="priceTotal" class="mt-3" :productCode="productId" />
+        <ProductNotFoundAlert v-else :productCode="productId" />
+      </template>
       <CategoryNotFoundAlert v-else-if="categoryNotFound" :categoryTag="productId" />
     </v-col>
   </v-row>
@@ -76,9 +78,9 @@ export default {
   components: {
     ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
     CategoryCard: defineAsyncComponent(() => import('../components/CategoryCard.vue')),
+    CreateOpenFoodFactsProductPromoBanner: defineAsyncComponent(() => import('../components/CreateOpenFoodFactsProductPromoBanner.vue')),
     ProductNotFoundAlert: defineAsyncComponent(() => import('../components/ProductNotFoundAlert.vue')),
     CategoryNotFoundAlert: defineAsyncComponent(() => import('../components/CategoryNotFoundAlert.vue')),
-    CreateOpenFoodFactsProductPromoBanner: defineAsyncComponent(() => import('../components/CreateOpenFoodFactsProductPromoBanner.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),


### PR DESCRIPTION
### What

Following #1959 and the creation 
For an unknown product, improve the display of the banners pushing to create it.

Closes #2076

### Screenshot

||Before|After|
|-|-|-|
|product with 0 prices|<img width="897" height="296" alt="image" src="https://github.com/user-attachments/assets/b49c9ad5-6f13-4c89-b2a4-2decc1cc26f5" />|same|
|product with at least 1 price|<img width="897" height="440" alt="image" src="https://github.com/user-attachments/assets/c7e37180-6f49-4b3e-9e9e-8825dc6dea8a" />|<img width="897" height="367" alt="image" src="https://github.com/user-attachments/assets/c748ef98-f35c-48f9-b974-24d789605696" />|