### PR TITLE
fix(ui): hide unknown brand chip when product is in readonly mode

### DIFF
--- a/src/components/ProductBrands.vue
+++ b/src/components/ProductBrands.vue
@@ -5,7 +5,7 @@
         {{ brand }}
       </v-chip>
     </template>
-    <v-chip v-else label size="small" density="comfortable" @click="showProductBrandsDialog">
+    <v-chip v-else-if="!readonly" label size="small" density="comfortable" @click="showProductBrandsDialog">
       <i>{{ $t('ProductCard.BrandTotal', { count: productBrandsList.length }) }}</i>
     </v-chip>
     <ProductBrandsDialog
@@ -15,7 +15,7 @@
       @close="productBrandsDialog = false"
     />
   </template>
-  <v-chip v-else label size="small" density="comfortable" prepend-icon="mdi-help" color="warning">
+  <v-chip v-else-if="!readonly" label size="small" density="comfortable" prepend-icon="mdi-help" color="warning">
     <i class="text-lowercase">{{ $t('Common.Brand') }}</i>
     <v-tooltip activator="parent" open-on-click location="top">
       {{ $t('ProductCard.BrandMissing') }}


### PR DESCRIPTION
## Problem
When a product has no brand, a "? brand" chip is displayed 
with a warning color and help icon. This looks broken and 
confusing to users browsing the app.

## Fix
Hide the unknown brand chip when the component is in readonly 
mode (i.e. when just browsing, not editing).
## Related Issue
Fixes openfoodfacts/openfoodfacts-explorer#1409