### PR TITLE
feat(Proofs): when uploading, add alert message to avoid closing the page

### DIFF
--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -41,6 +41,16 @@
         >
           <strong>{{ $t('Common.ProofUploadProgress', { numberOfProofsUploaded: proofObjectList.length, totalNumberOfProofs: proofImageList.length }) }}</strong>
         </v-progress-linear>
+        <v-alert
+          class="mt-4"
+          type="warning"
+          variant="tonal"
+          border="start"
+          density="comfortable"
+          icon="mdi-alert"
+        >
+          {{ $t('AddProof.ProofUploadProgressWarning') }}
+        </v-alert>
       </v-sheet>
     </v-card-text>
     <v-divider v-if="step === 1" />

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -44,10 +44,8 @@
         <v-alert
           class="mt-4"
           type="warning"
-          variant="tonal"
-          border="start"
-          density="comfortable"
-          icon="mdi-alert"
+          variant="outlined"
+          density="compact"
         >
           {{ $t('AddProof.ProofUploadProgressWarning') }}
         </v-alert>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -746,7 +746,7 @@
 		"ReceiptAIWarning": "AI will run on your receipt to extract prices.",
 		"PromoProofPriceTagAddMultiple": "To upload multiple price tags (same shop location and date), click here!",
 		"PromoReceiptAssistant": "Experiment: try the new receipt assistant to automatically extract prices from your receipts!",
-    "ProofUploadProgressWarning": "Do not close this tab or refresh the page while your photos are uploading!"
+    "ProofUploadProgressWarning": "Do not close this tab or refresh the page while your pictures are uploading!"
 	},
 	"ProofCard": {
 		"Proof": "Proof",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -745,7 +745,8 @@
 		"ReceiptAllowAI": "Allow running AI on your receipt to extract prices",
 		"ReceiptAIWarning": "AI will run on your receipt to extract prices.",
 		"PromoProofPriceTagAddMultiple": "To upload multiple price tags (same shop location and date), click here!",
-		"PromoReceiptAssistant": "Experiment: try the new receipt assistant to automatically extract prices from your receipts!"
+		"PromoReceiptAssistant": "Experiment: try the new receipt assistant to automatically extract prices from your receipts!",
+    "ProofUploadProgressWarning": "Do not close this tab or refresh the page while your photos are uploading!"
 	},
 	"ProofCard": {
 		"Proof": "Proof",


### PR DESCRIPTION
### What
Added a small alert during proof uploads informing users not to close or refresh the tab while photos are being uploaded. The alert is shown during the upload progress step inside the upload card. This approach is better than creating separate methods to handle background uploads on different platforms. 

Also creates a new entry in `i18n`. 

### Screenshot
<img width="572" height="193" alt="image" src="https://github.com/user-attachments/assets/4d7146cc-bca0-4d15-97ee-42fe84f61176" />

### Fixes bug(s)

~~Closes~~ Related to #2078 
