### PR TITLE
perf(Location Selector): only store the 10 most recent locations

### DIFF
--- a/src/components/LocationInputRow.vue
+++ b/src/components/LocationInputRow.vue
@@ -57,7 +57,11 @@ export default {
   computed: {
     ...mapStores(useAppStore),
     recentLocations() {
-      return this.appStore.getRecentLocations(this.maxRecentLocations)
+      const recentLocations = this.appStore.getRecentLocations
+      if (this.maxRecentLocations) {
+        return recentLocations.slice(0, this.maxRecentLocations)
+      }
+      return recentLocations
     },
     locationFormFilled() {
       let keysOSM = ['location_osm_id', 'location_osm_type']

--- a/src/components/LocationInputRow.vue
+++ b/src/components/LocationInputRow.vue
@@ -57,11 +57,7 @@ export default {
   computed: {
     ...mapStores(useAppStore),
     recentLocations() {
-      const recentLocations = this.appStore.getRecentLocations
-      if (this.maxRecentLocations) {
-        return recentLocations.slice(0, this.maxRecentLocations)
-      }
-      return recentLocations
+      return this.appStore.getRecentLocations
     },
     locationFormFilled() {
       let keysOSM = ['location_osm_id', 'location_osm_type']

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -188,7 +188,7 @@ export default {
       return this.$vuetify.display.smAndUp ? '80%' : '100%'
     },
     recentLocations() {
-      return this.appStore.getRecentLocations()
+      return this.appStore.getRecentLocations
     },
     locationOnlineFormFilled() {
       return !!this.locationOnlineForm.website_url && this.urlRules.every(rule => rule(this.locationOnlineForm.website_url) === true)

--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,10 @@ import { defineStore } from 'pinia'
 import constants from './constants'
 import utils from './utils.js'
 
+
+const RECENT_LOCATIONS_MAX_SIZE = 10
+
+
 export const useAppStore = defineStore('app', {
   state: () => ({
     user: {
@@ -30,7 +34,7 @@ export const useAppStore = defineStore('app', {
   }),
   getters: {
     getRecentLocations: (state) => {
-      return state.user.recent_locations || []
+      return state.user.recent_locations
     },
     getUserLanguage: (state) => {
       return state.user.language
@@ -64,6 +68,10 @@ export const useAppStore = defineStore('app', {
     },
     addRecentLocation(location) {
       this.user.recent_locations = utils.addObjectToArray(this.user.recent_locations, location, true)
+      // Only store the 10 most recent locations
+      if (this.user.recent_locations.length > RECENT_LOCATIONS_MAX_SIZE) {
+        this.user.recent_locations = this.user.recent_locations.slice(0, RECENT_LOCATIONS_MAX_SIZE)
+      }
     },
     removeRecentLocation(location) {
       this.user.recent_locations = utils.removeObjectFromArray(this.user.recent_locations, location)

--- a/src/store.js
+++ b/src/store.js
@@ -30,12 +30,7 @@ export const useAppStore = defineStore('app', {
   }),
   getters: {
     getRecentLocations: (state) => {
-      return (limit=null) => {
-        if (limit && state.user.recent_locations.length && state.user.recent_locations.length > limit) {
-          return state.user.recent_locations.slice(0, limit)
-        }
-        return state.user.recent_locations
-      }
+      return state.user.recent_locations || []
     },
     getUserLanguage: (state) => {
       return state.user.language

--- a/src/views/ProofPriceTagAssistant.vue
+++ b/src/views/ProofPriceTagAssistant.vue
@@ -325,7 +325,7 @@ export default {
       ]
     },
     locationName() {
-      const recentLocations = this.appStore.getRecentLocations()
+      const recentLocations = this.appStore.getRecentLocations
       const location = recentLocations.find((location) => location.properties && location.properties.osm_id === this.proofObject.location_osm_id)
       if (location) {
         if (location.type === 'ONLINE') return location.website_url


### PR DESCRIPTION
### What

Since the very beginning of the project, we store selected locations in a `store.recent_locations`.
And we display the full list in the `LocationSelectorDialog` "Recent" tab

But for some users the list becomes very big. And slow to display..

Here we limit the storage (and thus display) to only the 10 last locations used
- faster display
- smaller browser storage
- favorite locations around the corner: #2222
