### PR TITLE
feat(Location Selector): allow users to set locations as favorites + new tab

### DIFF
--- a/src/components/LocationCard.vue
+++ b/src/components/LocationCard.vue
@@ -10,13 +10,16 @@
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>
-            <v-col :cols="!isSelected ? '12' : '10'" @click="clickLocation()">
+            <v-col :cols="!showActionButton ? '12' : '10'" @click="clickLocation()">
               <h3>{{ getLocationTitle }}</h3>
               <p>{{ getLocationSubtitle }}</p>
               <LocationDetailsRow v-if="showLocationDetailsRow" class="mt-0" :location="location" :hideLocationOSMID="hideLocationOSMID" :hideCountryCity="hideCountryCity" />
             </v-col>
-            <v-col v-if="isSelected" cols="2" class="pl-0">
+            <v-col v-if="showEditButton" cols="2" class="pl-0">
               <v-btn class="float-right" icon="mdi-pencil" size="small" density="comfortable" variant="text" :title="$t('Common.Edit')" @click="clickLocation()" />
+            </v-col>
+            <v-col v-else-if="showFavoriteButton" cols="2" class="pl-0">
+              <v-btn class="float-right" :icon="isFavoriteLocation ? 'mdi-star' : 'mdi-star-outline'" size="small" density="comfortable" variant="text" :title="location.is_favorite ? $t('Common.FavoritesRemove') : $t('Common.FavoritesAdd')" @click.stop="toggleFavorite()" />
             </v-col>
           </v-row>
         </v-col>
@@ -46,6 +49,10 @@ export default {
       required: true
     },
     isSelected: {
+      type: Boolean,
+      default: false
+    },
+    showFavoriteButton: {
       type: Boolean,
       default: false
     },
@@ -94,7 +101,15 @@ export default {
     getLocationBrandLogoPathName() {
       return geo_utils.getLocationBrandLogoPathName(this.location)
     },
-    // Removed brandLogoSrc as it is no longer needed
+    showEditButton() {
+      return this.isSelected
+    },
+    showActionButton() {
+      return this.showEditButton || this.showFavoriteButton
+    },
+    isFavoriteLocation() {
+      return this.appStore.isFavoriteLocation(this.location)
+    },
     showLocationDetailsRow() {
       return !this.isTypeONLINE
     },
@@ -113,6 +128,13 @@ export default {
       }
       this.$router.push({ path: `/locations/${this.location.id}` })
     },
+    toggleFavorite() {
+      if (this.appStore.isFavoriteLocation(this.location)) {
+        this.appStore.removeFavoriteLocation(this.location)
+      } else {
+        this.appStore.addFavoriteLocation(this.location)
+      }
+     },
   }
 }
 </script>

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -21,11 +21,31 @@
         </v-tabs>
 
         <v-tabs-window v-model="currentDisplay" disabled>
+          <v-tabs-window-item value="favorite">
+            <template v-if="favoriteLocations.length">
+              <v-row>
+                <v-col v-for="(location, index) in favoriteLocations" :key="index" cols="12" sm="6">
+                  <LocationCard class="mb-2" :location="location" :hideLocationFooterRow="true" :showFavoriteButton="true" :readonly="true" height="100%" width="100%" elevation="1" @click="selectLocation(location)" />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col cols="12">
+                  <v-btn size="small" color="primary" @click="clearFavoriteLocations">
+                    {{ $t('Common.Clear') }}
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </template>
+            <p v-else>
+              {{ $t('LocationSelector.FavoriteLocations', favoriteLocations.length) }}
+            </p>
+          </v-tabs-window-item>
+
           <v-tabs-window-item value="recent">
             <template v-if="recentLocations.length">
               <v-row>
                 <v-col v-for="(location, index) in recentLocations" :key="index" cols="12" sm="6">
-                  <LocationCard class="mb-2" :location="location" :hideLocationFooterRow="true" :readonly="true" height="100%" width="100%" elevation="1" @click="selectLocation(location)" />
+                  <LocationCard class="mb-2" :location="location" :hideLocationFooterRow="true" :showFavoriteButton="true" :readonly="true" height="100%" width="100%" elevation="1" @click="selectLocation(location)" />
                 </v-col>
               </v-row>
               <v-row>
@@ -187,6 +207,9 @@ export default {
     dialogWidth() {
       return this.$vuetify.display.smAndUp ? '80%' : '100%'
     },
+    favoriteLocations() {
+      return this.appStore.getFavoriteLocations
+     },
     recentLocations() {
       return this.appStore.getRecentLocations
     },
@@ -202,9 +225,9 @@ export default {
   },
   watch: {
     currentDisplay(value) {
-      if (value === constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key) {
+      if (value === constants.LOCATION_SELECTOR_DISPLAY_LIST[2].key) {  // Physical
         window.setTimeout(() => this.$refs.locationOsmSearchInput.focus(), 200)
-      } else if (value === constants.LOCATION_SELECTOR_DISPLAY_LIST[2].key) {
+      } else if (value === constants.LOCATION_SELECTOR_DISPLAY_LIST[3].key) {  // Online
         window.setTimeout(() => this.$refs.locationOnlineFormInput.focus(), 200)
       }
     }
@@ -250,8 +273,8 @@ export default {
       this.$emit('location', location)
       this.close()
     },
-    removeRecentLocation(location) {
-      this.appStore.removeRecentLocation(location)
+    clearFavoriteLocations() {
+      this.appStore.clearFavoriteLocations()
     },
     clearRecentLocations() {
       this.appStore.clearRecentLocations()

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -9,12 +9,12 @@
         </v-col>
         <v-col style="max-width:80%;">
           <v-row>
-            <v-col :cols="!isSelected ? '12' : '10'">
+            <v-col :cols="!showActionButton ? '12' : '10'">
               <h3 id="product-title" role="link" tabindex="0" @click="clickProduct()" @keydown.enter="clickProduct()">
                 {{ getProductTitle() }}
               </h3>
             </v-col>
-            <v-col v-if="isSelected" cols="2" class="pl-0">
+            <v-col v-if="showActionButton" cols="2" class="pl-0">
               <v-btn class="float-right" icon="mdi-pencil" size="small" density="comfortable" variant="text" :title="$t('Common.Edit')" @click="clickProduct()" />
             </v-col>
           </v-row>
@@ -92,6 +92,9 @@ export default {
     },
     hasProductSource() {
       return !!this.product.source
+    },
+    showActionButton() {
+      return this.isSelected
     },
   },
   methods: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -259,12 +259,13 @@ export default {
     { key: 'photon' },
   ],
   LOCATION_SELECTOR_DISPLAY_LIST: [
-    { key: 'recent', value: 'Recent', valueSmallScreen: '', icon: 'mdi-history' },  // Recent
+    { key: 'favorite', value: 'Favorite', valueSmallScreen: '', icon: 'mdi-star' },
+    { key: 'recent', value: 'Recent', valueSmallScreen: '', icon: 'mdi-history' },
     { key: 'osm', value: 'Physical', valueSmallScreen: 'Physical', icon: LOCATION_TYPE_OSM_ICON },
     { key: 'online', value: 'Online', valueSmallScreen: 'Online', icon: LOCATION_TYPE_ONLINE_ICON },
   ],
   PRODUCT_SELECTOR_DISPLAY_LIST: [
-    // { key: 'recent', value: 'Recent', valueSmallScreen: '', icon: 'mdi-history' },  // Recent
+    // { key: 'recent', value: 'Recent', valueSmallScreen: '', icon: 'mdi-history' },
     { key: 'scan', value: 'BarcodeScan', valueSmallScreen: 'BarcodeScanShort', icon: 'mdi-barcode-scan' },
     { key: 'type', value: 'BarcodeType', valueSmallScreen: 'BarcodeTypeShort', icon: 'mdi-numeric' },
   ],

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -301,6 +301,9 @@
 		"Edit": "Edit",
 		"End": "End",
 		"ErrorServer": "Error: server error",
+		"Favorite": "Favorite",
+		"FavoritesAdd": "Add to favorites",
+		"FavoritesRemove": "Remove from favorites",
 		"FieldIsRequired": "Field is required",
 		"FilterNoun": "Filter",
 		"FilterVerb": "Filter",
@@ -654,6 +657,7 @@
 		"PoweredBy": {
 			"text": "powered by {url}"
 		},
+		"FavoriteLocations": "No favorite locations | Favorite location {favoriteLocationNumber} | Favorite locations {favoriteLocationNumber}",
 		"RecentLocations": "No recent locations | Recent location {recentLocationNumber}| Recent locations {recentLocationNumber}",
 		"Result": "Result {resultNumber} | Results {resultNumber}",
 		"SearchByName": "Search for your shop by name and city",

--- a/src/store.js
+++ b/src/store.js
@@ -14,6 +14,7 @@ export const useAppStore = defineStore('app', {
       is_moderator: false,
       last_product_type_used: constants.PRICE_TYPE_PRODUCT,  // or 'BARCODE'
       last_currency_used: import.meta.env.VITE_DEFAULT_CURRENCY,  // 'EUR'
+      favorite_locations: [],
       recent_locations: [],
       language: import.meta.env.VITE_DEFAULT_LOCALE, // 'en'
       country: import.meta.env.VITE_DEFAULT_COUNTRY,  // 'FR',
@@ -27,12 +28,15 @@ export const useAppStore = defineStore('app', {
       drawer_display_experiments: true,
       preferedTheme: null,
       price_list_display_default_mode: constants.DISPLAY_LIST[0].key,
-      location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[1].key,
+      location_finder_default_mode: constants.LOCATION_SELECTOR_DISPLAY_LIST[2].key,  // Physical
       barcode_scanner_default_mode: constants.PRODUCT_SELECTOR_DISPLAY_LIST[0].key,
       barcode_scanner_library: constants.BARCODE_SCANNER_DISPLAY_LIST[0].key
     },
   }),
   getters: {
+    getFavoriteLocations: (state) => {
+      return state.user.favorite_locations || []
+    },
     getRecentLocations: (state) => {
       return state.user.recent_locations
     },
@@ -66,6 +70,9 @@ export const useAppStore = defineStore('app', {
       this.user.token = null
       this.user.is_moderator = false
     },
+    isRecentLocation(location) {
+      return this.user.recent_locations.some(recentLocation => recentLocation.id === location.id)
+    },
     addRecentLocation(location) {
       this.user.recent_locations = utils.addObjectToArray(this.user.recent_locations, location, true)
       // Only store the 10 most recent locations
@@ -78,6 +85,18 @@ export const useAppStore = defineStore('app', {
     },
     clearRecentLocations() {
       this.user.recent_locations = []
+    },
+    isFavoriteLocation(location) {
+      return this.user.favorite_locations.some(favoriteLocation => favoriteLocation.id === location.id)
+    },
+    addFavoriteLocation(location) {
+      this.user.favorite_locations = utils.addObjectToArray(this.user.favorite_locations, location, true)
+    },
+    removeFavoriteLocation(location) {
+      this.user.favorite_locations = utils.removeObjectFromArray(this.user.favorite_locations, location)
+    },
+    clearFavoriteLocations() {
+      this.user.favorite_locations = []
     },
     setLanguage(language) {
       this.user.language = language


### PR DESCRIPTION
### What

Introducting favorite locations.

Only from the Location Selector for now
- new tab that lists favorites
- from the recent tab, users can add favorites
- each favorite can be un-toggled

### Screenshot

||Image|
|-|-|
|desktop|<img width="1049" height="417" alt="image" src="https://github.com/user-attachments/assets/54798d78-ad19-483d-a1a4-0cc597b9d64a" />|
|smartphone|<img width="441" height="625" alt="image" src="https://github.com/user-attachments/assets/227e3188-1f8e-4f11-9d80-7b974ef09de2" />|