### PR TITLE
refactor(Location Selector): reduce the size of icon-only tabs (on small screens)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -68,6 +68,11 @@
     padding-inline-end: 12px !important;
 }
 
+.v-tab.v-btn {
+    /* allow icon-only tabs to shrink */
+    min-width: unset !important;
+}
+
 .chip-group {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -14,9 +14,9 @@
           contain
           max-height="50%"
         />
-        <v-tabs v-model="currentDisplay">
+        <v-tabs v-model="currentDisplay" :grow="!$vuetify.display.smAndUp">
           <v-tab v-for="item in displayItems" :key="item.key" :value="item.key">
-            <v-icon start>
+            <v-icon :start="$vuetify.display.smAndUp || !!item.valueSmallScreen">
               {{ item.icon }}
             </v-icon>
             <span v-if="$vuetify.display.smAndUp">{{ $t('Common.' + item.value) }}</span>

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -8,9 +8,9 @@
       <v-divider />
 
       <v-card-text>
-        <v-tabs v-model="currentDisplay">
+        <v-tabs v-model="currentDisplay" :grow="!$vuetify.display.smAndUp">
           <v-tab v-for="item in displayItems" :key="item.key" :value="item.key">
-            <v-icon start>
+            <v-icon :start="$vuetify.display.smAndUp || !!item.valueSmallScreen">
               {{ item.icon }}
             </v-icon>
             <span v-if="$vuetify.display.smAndUp">{{ $t('Common.' + item.value) }}</span>


### PR DESCRIPTION
### What

Make icon-only (no label) tabs smaller
Also improve center alignment if no label

### Screenshot

|Before|After|
|-|-|
|<img width="437" height="265" alt="image" src="https://github.com/user-attachments/assets/654a764c-4288-45bd-8053-6f985f01bacc" />|<img width="437" height="265" alt="image" src="https://github.com/user-attachments/assets/3806afa8-1a9a-463c-bee1-0e6eea26d896" />|