### PR TITLE
feat(Home): new dynamic `SurveyBanner` + link to current Gamification survey

### DIFF
--- a/src/components/SurveyBanner.vue
+++ b/src/components/SurveyBanner.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-banner
+    icon="mdi-comment-quote-outline"
+    bg-color="primary"
+    rounded
+    density="compact"
+  >
+    <v-banner-text>
+      <i18n-t keypath="Surveys.HelpFeatures" tag="h3" class="text-h6 mb-1">
+        <template #op_name>
+          {{ APP_NAME }}
+        </template>
+      </i18n-t>
+      <p>
+        <a :href="survey.url" target="_blank">
+          {{ $t(`Surveys.Survey${survey.name}`) }}
+        </a>
+      </p>
+    </v-banner-text>
+  </v-banner>
+</template>
+
+<script>
+import constants from '../constants'
+
+export default {
+  props: {
+    survey: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  data() {
+    return {
+      APP_NAME: constants.APP_NAME,
+    }
+  }
+}
+</script>

--- a/src/data/surveys.json
+++ b/src/data/surveys.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "Gamification",
+        "start_date": "2026-06-05",
+        "end_date": "2026-06-20",
+        "url": "https://framaforms.org/gamification-in-open-prices-1780570507"
+    }
+]

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1009,6 +1009,10 @@
 		"PricesProofsPerSource": "Prices and proofs per source",
 		"LastUpdated": "Last updated on {date}"
 	},
+	"Surveys": {
+		"HelpFeatures": "Help us build the next features in {op_name}!",
+		"SurveyGamification": "Take our 1-minute gamification survey."
+	},
 	"UserDashboard": {
 		"LatestPrices": "Latest prices",
 		"LatestProofs": "Latest proofs",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -20,13 +20,13 @@
     <v-col cols="6" sm="4" md="3" lg="2">
       <StatCard :value="totalPriceCount" :subtitle="$t('Common.Total')" />
     </v-col>
+    <v-col v-if="currentSurvey" cols="12" class="pt-0">
+      <SurveyBanner :survey="currentSurvey" />
+    </v-col>
+    <v-col v-if="currentChallenge" cols="12" class="pt-0">
+      <ChallengeCurrentPromoBanner :challenge="currentChallenge" />
+    </v-col>
   </v-row>
-
-  <br v-if="currentChallenge">
-
-  <ChallengeCurrentPromoBanner v-if="currentChallenge" :challenge="currentChallenge" />
-
-  <br>
 
   <v-row>
     <v-col v-for="price in latestPriceList" :key="price" cols="12" sm="6" md="4" xl="3">
@@ -55,10 +55,12 @@ import { useAppStore } from '../store'
 import openPricesApi from '../services/openPricesApi'
 import constants from '../constants'
 import date_utils from '../utils/date.js'
+import Surveys from '../data/surveys.json'
 
 export default {
   components: {
     StatCard: defineAsyncComponent(() => import('../components/StatCard.vue')),
+    SurveyBanner: defineAsyncComponent(() => import('../components/SurveyBanner.vue')),
     ChallengeCurrentPromoBanner: defineAsyncComponent(() => import('../components/ChallengeCurrentPromoBanner.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue'))
   },
@@ -71,6 +73,7 @@ export default {
       todayPriceCount: null,
       totalPriceCount: null,
       loading: false,
+      currentSurvey: null,
       currentChallenge: null,
     }
   },
@@ -87,9 +90,19 @@ export default {
   mounted() {
     this.getPrices()
     this.getTodayPriceCount()
+    this.getCurrentSurvey()
     this.getCurrentChallenge()
   },
   methods: {
+    getCurrentSurvey() {
+      const now = new Date()
+
+      this.currentSurvey = Surveys.find(survey => {
+        const startDate = new Date(survey.start_date)
+        const endDate = new Date(survey.end_date)
+        return now >= startDate && now <= endDate
+      })
+    },
     getCurrentChallenge() {
       openPricesApi.getChallenges({ status: 'ONGOING', order_by: '-created', size: 1 })
       .then((data) => {


### PR DESCRIPTION
### What

We have an ongoing "Gamification" survey running: https://github.com/openfoodfacts/open-prices/discussions/399#discussioncomment-17191183
Add a promo banner on the home page.

### How

- Basic `SurveyBanner.vue` component, reusing the style of existing components.
- `surveys.json` to store past and ongoing surveys
- dynamic display in the Home page, depending if there is an ongoing survey

### Screenshot

<img width="891" height="455" alt="Screenshot from 2026-06-13 15-09-20" src="https://github.com/user-attachments/assets/f80ed5f9-0742-4336-a9f0-77d837c21be8" />
