### PR TITLE
feat(ProofUpload): Upload as drafts first

### DIFF
--- a/src/components/ProofImageInputRow.vue
+++ b/src/components/ProofImageInputRow.vue
@@ -12,7 +12,7 @@
           <v-menu scroll-strategy="close" :disabled="loading">
             <template #activator="{ props }">
               <v-btn v-bind="props" class="text-body-2" block spaced="end" prepend-icon="mdi-image" append-icon="mdi-menu-down" :class="hasProofImageSelected ? 'border-success' : 'border-error'">
-                <span v-if="hasProofImageSelected">{{ $t('Common.PictureSelectedCount', { count: proofImagePreviewList.length }) }}</span>
+                <span v-if="hasProofImageSelected">{{ $t('Common.PictureSelectedCount', { count: numberProofsSelected }) }}</span>
                 <span v-else-if="multiple">{{ $t('Common.PictureSelectMultiple') }}</span>
                 <span v-else>{{ $t('Common.PictureSelect') }}</span>
               </v-btn>
@@ -47,30 +47,6 @@
         </v-col>
       </v-row>
 
-      <v-row v-if="showProofImagePreviewList" class="mt-0">
-        <v-col v-for="(proofImagePreview, index) in proofImagePreviewList" :key="proofImagePreview" cols="6">
-          <v-card class="d-flex flex-column" height="100%">
-            <v-card-text class="flex-grow-1 pa-2">
-              <v-img :src="proofImagePreview" max-height="200px" />
-            </v-card-text>
-            <v-divider />
-            <v-card-actions>
-              <v-btn v-if="!$vuetify.display.smAndUp" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Delete')" @click="removeImage(index)" />
-              <v-btn
-                v-else
-                color="error"
-                variant="outlined"
-                prepend-icon="mdi-delete"
-                size="small"
-                @click="removeImage(index)"
-              >
-                {{ $t('Common.Delete') }}
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-col>
-      </v-row>
-
       <UserRecentProofsDialog
         v-if="userRecentProofsDialog"
         v-model="userRecentProofsDialog"
@@ -86,7 +62,6 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import constants from '../constants'
-import proof_utils from '../utils/proof.js'
 
 export default {
   components: {
@@ -119,6 +94,10 @@ export default {
     multiple: {
       type: Boolean,
       default: false
+    },
+    numberProofsSelected: {
+      type: Number,
+      default: 0
     }
   },
   emits: ['proofList'],
@@ -127,7 +106,6 @@ export default {
       PROOF_TYPE_RECEIPT: constants.PROOF_TYPE_RECEIPT,
       // data
       proofImageList: [],
-      proofImagePreviewList: [],
       userRecentProofsDialog: false,
       loading: false
     }
@@ -143,11 +121,8 @@ export default {
       return this.proofTypeFormFilled && (this.proofImageForm.type === constants.PROOF_TYPE_RECEIPT)
     },
     hasProofImageSelected() {
-      return Array.isArray(this.proofImageList) ? this.proofImageList.length : !!this.proofImageList
+      return this.numberProofsSelected > 0
     },
-    showProofImagePreviewList() {
-      return !this.hideProofImagePreview && this.proofImagePreviewList.length
-    }
   },
   watch: {
     proofImageList: {
@@ -156,7 +131,6 @@ export default {
         if (!Array.isArray(newProofImageList)) {
           newProofImageList = [newProofImageList]
         }
-        this.proofImagePreviewList = newProofImageList.map(proofImage => this.getLocalProofUrl(proofImage))
         this.$emit('proofList', newProofImageList)
       },
       // deep: true
@@ -166,27 +140,10 @@ export default {
     recentProofSelected(proof) {
       this.proofImageList = [proof]
     },
-    removeImage(index) {
-      if (!Array.isArray(this.proofImageList)) {
-        // Only one proof was selected with v-file-input, so we clear everything
-        this.clearProof()
-      } else {
-        this.proofImageList.splice(index, 1)
-        this.proofImagePreviewList.splice(index, 1)
-        this.$emit('proofList', this.proofImageList)
-      }
-    },
     clearProof() {
       this.proofImageList = []
-      this.proofImagePreviewList = []
       this.proofImageForm.proof_id = null
     },
-    getLocalProofUrl(blob) {
-      if (blob.image_thumb_path) {
-        return proof_utils.getImageFullUrl(blob.image_thumb_path)
-      }
-      return URL.createObjectURL(blob)
-    }
   }
 }
 </script>

--- a/src/components/ProofImagePreviewList.vue
+++ b/src/components/ProofImagePreviewList.vue
@@ -1,0 +1,91 @@
+<template>
+  <v-row class="mt-0">
+    <v-col v-for="(proof, index) in proofObjectPreviewList" :key="proof" cols="6">
+      <v-card class="d-flex flex-column" height="100%">
+        <v-card-text class="flex-grow-1 pa-2">
+          <v-img :src="proof.image_thumb_path || proof.image_placeholder" max-height="200px">
+            <template v-if="proof.image_placeholder">
+              <div class="d-flex align-center justify-center fill-height">
+                <v-progress-circular
+                  color="grey-lighten-4"
+                  indeterminate
+                />
+              </div>
+            </template>
+          </v-img>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions v-if="allProofsHaveBeenUploaded">
+          <v-btn v-if="!$vuetify.display.smAndUp" color="error" variant="outlined" icon="mdi-delete" size="small" density="comfortable" :aria-label="$t('Common.Delete')" @click="removeProof(index)" />
+          <v-btn
+            v-else
+            color="error"
+            variant="outlined"
+            prepend-icon="mdi-delete"
+            size="small"
+            @click="removeProof(index)"
+          >
+            {{ $t('Common.Delete') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import proof_utils from '../utils/proof.js'
+
+export default {
+  props: {
+    proofObjectList: {
+      type: Array,
+      default: () => ([])
+    },
+  },
+  emits: ['removeProof'],
+  data() {
+    return {
+      proofObjectPreviewList: [],
+    }
+  },
+  computed: {
+    allProofsHaveBeenUploaded() {
+      return this.proofObjectPreviewList.every(proof => proof.image_thumb_path)
+    }
+  },
+  watch: {
+    proofObjectList: {
+      handler(newProofObjectList, oldProofObjectList) {  // eslint-disable-line no-unused-vars
+        if (!this.proofObjectPreviewList.length) {
+          this.proofObjectPreviewList = newProofObjectList.map(proof => {
+            return {
+              image_placeholder: URL.createObjectURL(proof.blob),
+              localId: proof.localId
+            }
+          })
+        } else {
+          for (let i = 0; i < this.proofObjectPreviewList.length; i++) {
+            const correspondingProof = newProofObjectList.find(proof => proof.localId === this.proofObjectPreviewList[i].localId)
+            if (correspondingProof?.image_thumb_path) {
+              this.proofObjectPreviewList[i] = {
+                image_thumb_path: proof_utils.getImageFullUrl(correspondingProof.image_thumb_path),
+                localId: correspondingProof.localId
+              }
+            }
+          }
+        }
+      },
+      immediate: true,
+      deep: true
+    }
+  },
+  methods: {
+    removeProof(index) {
+      const removedLocalId = this.proofObjectPreviewList[index].localId
+      this.proofObjectPreviewList.splice(index, 1)
+      this.$emit('removeProof', removedLocalId)
+    }
+  },
+}
+</script>

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -26,20 +26,21 @@
         </v-row>
         <ProofTypeInputRow :class="showTopAlertOrBanner ? 'mt-0' : ''" :proofTypeForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" />
         <LocationInputRow class="mt-0" :locationForm="proofForm" @location="locationObject = $event" />
-        <ProofImageInputRow class="mt-0" :proofImageForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" @proofList="proofImageList = $event" />
+        <ProofImageInputRow class="mt-0" :proofImageForm="proofForm" :typePriceTagOnly="typePriceTagOnly" :typeReceiptOnly="typeReceiptOnly" :hideRecentProofChoice="hideRecentProofChoice" :multiple="multiple" :numberProofsSelected="proofDraftsList.length" @proofList="proofImageList = $event" />
+        <ProofImagePreviewList v-if="proofDraftsList.length" class="mt-0" :proofObjectList="proofDraftsList" @removeProof="removeProof" />
         <ProofMetadataInputRow class="mt-0" :proofMetadataForm="proofForm" :proofType="proofForm.type" :multiple="multiple" :assistedByAI="assistedByAI" :locationType="locationObject?.type" />
       </v-sheet>
       <v-sheet v-else-if="step === 2">
         <v-progress-linear
           v-model="proofObjectList.length"
-          :max="proofImageList.length"
-          :color="proofImageList.length === proofObjectList.length ? 'success' : 'primary'"
+          :max="proofDraftsList.length"
+          :color="proofDraftsList.length === proofObjectList.length ? 'success' : 'primary'"
           height="25"
           :indeterminate="proofObjectList.length ? false : true"
-          :striped="proofImageList.length !== proofObjectList.length"
+          :striped="proofDraftsList.length !== proofObjectList.length"
           rounded
         >
-          <strong>{{ $t('Common.ProofUploadProgress', { numberOfProofsUploaded: proofObjectList.length, totalNumberOfProofs: proofImageList.length }) }}</strong>
+          <strong>{{ $t('Common.ProofUploadProgress', { numberOfProofsUploaded: proofObjectList.length, totalNumberOfProofs: proofDraftsList.length }) }}</strong>
         </v-progress-linear>
         <v-alert
           class="mt-4"
@@ -60,10 +61,10 @@
         variant="flat"
         type="submit"
         :block="!$vuetify.display.smAndUp"
-        :disabled="!proofFormFilled"
-        @click="uploadProofList"
+        :disabled="!readyToFinalize"
+        @click="finalizeDraftProofs"
       >
-        <span v-if="multiple && proofImageList.length">{{ $t('Common.UploadMultipleProofs', { count: proofImageList.length }) }}</span>
+        <span v-if="multiple && proofDraftsList.length">{{ $t('Common.UploadMultipleProofs', { count: proofDraftsList.length }) }}</span>
         <span v-else>{{ $t('Common.Upload') }}</span>
       </v-btn>
     </v-card-actions>
@@ -116,6 +117,7 @@ export default {
     ProofTypeInputRow: defineAsyncComponent(() => import('../components/ProofTypeInputRow.vue')),
     LocationInputRow: defineAsyncComponent(() => import('../components/LocationInputRow.vue')),
     ProofImageInputRow: defineAsyncComponent(() => import('../components/ProofImageInputRow.vue')),
+    ProofImagePreviewList: defineAsyncComponent(() => import('../components/ProofImagePreviewList.vue')),
     ProofMetadataInputRow: defineAsyncComponent(() => import('../components/ProofMetadataInputRow.vue')),
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),
   },
@@ -171,7 +173,8 @@ export default {
       proofSelectedSuccessMessage: false,
       proofSuccessMessage: false,
       proofImageList: [],  // images to upload
-      proofObjectList: [],  // images uploaded
+      proofDraftsList: [],  // images uploaded as drafts
+      proofObjectList: [],  // images uploaded (drafts finalized)
       loading: false,
     }
   },
@@ -196,7 +199,7 @@ export default {
       return this.proofIsTypePriceTag || this.proofIsTypeReceipt
     },
     proofImageFormFilled() {
-      return !!this.proofImageList.length
+      return !!this.proofDraftsList.length
     },
     proofLocationFormFilled() {
       let keysOSM = ['location_osm_id', 'location_osm_type']
@@ -209,6 +212,9 @@ export default {
     },
     proofFormFilled() {
       return this.proofTypeFormFilled && this.proofImageFormFilled && this.proofLocationFormFilled && this.proofMetadataFormFilled
+    },
+    readyToFinalize() {
+      return this.proofDraftsList.every(proof => proof.id) && this.proofFormFilled
     },
     proofCardShowImageThumb() {
       return this.multiple ? true : false
@@ -224,7 +230,7 @@ export default {
       this.proofForm.proof_id = newProofObjectList[0].id
       this.proofForm.location_id = newProofObjectList[0].location_id
       // all proofs uploaded
-      if (this.proofObjectList.length === this.proofImageList.length) {
+      if (this.proofObjectList.length === this.proofDraftsList.length) {
         this.step = 3
         this.$emit('done', this.proofObjectList.length)
       }
@@ -290,6 +296,7 @@ export default {
             }
           }
         })
+        this.uploadProofsAsDrafts()
       }
     },
     compressProof(proofImage) {
@@ -304,15 +311,23 @@ export default {
         console.log(JSON.stringify(error))
       })
     },
-    uploadProofList() {
-      this.step = 2
+    uploadProofsAsDrafts() {
+      this.proofDraftsList = this.proofImageList.map((proofImage, index) => {
+        return {
+          localId: index,
+          blob: proofImage
+        }
+      })
       // chain uploads sequentially
-      this.proofImageList.reduce((promise, proofImage) => {
+      this.proofDraftsList.reduce((promise, proof, index) => {
         return promise.then(() =>
-          this.uploadProof(proofImage)
+          this.uploadProofAsDraft(proof.blob, this.proofForm.type)
             .then((data) => {
               if (data.id) {
-                this.proofObjectList = this.proofObjectList.concat(data)
+                this.proofDraftsList[index] = {
+                  ...data,
+                  localId: proof.localId
+                }
               }
             })
             .catch((error) => {
@@ -321,13 +336,13 @@ export default {
         )
       }, Promise.resolve())
     },
-    uploadProof(proofImage) {
+    uploadProofAsDraft(proofImage, type) {
       this.loading = true
       return new Promise((resolve, reject) => {  // eslint-disable-line no-unused-vars
         this.compressProof(proofImage)
           .then((proofImageCompressed) => {
             openPricesApi
-              .createProof(proofImageCompressed, this.proofForm, this.$route.path)
+              .createDraftProof(proofImageCompressed, type)
               .then((data) => {
                 this.loading = false
                 if (data.id) {
@@ -343,9 +358,47 @@ export default {
                 this.loading = false
               })
           })
-          // .finally(() => {
-          //   console.log('Compress complete')
-          // })
+      })
+    },
+    removeProof(localId) {
+      this.proofDraftsList = this.proofDraftsList.filter(proof => proof.localId !== localId)
+    },
+    finalizeDraftProofs() {
+      this.step = 2
+      // chain uploads sequentially
+      this.proofDraftsList.reduce((promise, proofDraft) => {
+        return promise.then(() =>
+          this.finalizeDraftProof(proofDraft)
+            .then((data) => {
+              if (data.id) {
+                this.proofObjectList = this.proofObjectList.concat(data)
+              }
+            })
+            .catch((error) => {
+              console.log(JSON.stringify(error))
+            })
+        )
+      }, Promise.resolve())
+    },
+    finalizeDraftProof(proofDraft) {
+      this.loading = true
+      return new Promise((resolve, reject) => {  // eslint-disable-line no-unused-vars
+        openPricesApi
+          .finalizeDraftProof(proofDraft.id, this.proofForm, this.$route.path)
+          .then((data) => {
+            this.loading = false
+            if (data.id) {
+              resolve(data)
+            } else {
+              alert(`Error: ${JSON.stringify(data)}`)
+              console.log(JSON.stringify(data))
+            }
+          })
+          .catch((error) => {
+            alert(`Error: ${JSON.stringify(error)}`)
+            console.log(JSON.stringify(error))
+            this.loading = false
+          })
       })
     },
   }

--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -113,6 +113,40 @@ function fetchOpenPrices(endpointWithParams, options, withToken = false) {
   })
 }
 
+function fillCreateProofFormData(formData, data) {
+  if (data.location_id) {
+    formData.append('location_id', data.location_id ? data.location_id : '')
+  }
+  if (data.location_osm_id && data.location_osm_type) {
+    formData.append('location_osm_id', data.location_osm_id ? data.location_osm_id : '')
+    formData.append('location_osm_type', data.location_osm_type ? data.location_osm_type : '')
+  }
+  formData.append('date', data.date ? data.date : '')
+  formData.append('currency', data.currency ? data.currency : '')
+  if (data.type === constants.PROOF_TYPE_RECEIPT) {
+    if (data.receipt_price_count) {
+      formData.append('receipt_price_count', data.receipt_price_count)
+    }
+    if (data.receipt_price_total) {
+      formData.append('receipt_price_total', data.receipt_price_total)
+    }
+    if (data.receipt_online_delivery_costs) {
+      formData.append('receipt_online_delivery_costs', data.receipt_online_delivery_costs)
+    }
+    if (data.owner_consumption === true || data.owner_consumption === false) {
+      formData.append('owner_consumption', data.owner_consumption)
+    }
+    if (data.owner_comment) {
+      formData.append('owner_comment', data.owner_comment)
+    }
+  }
+  else if (data.type === constants.PROOF_TYPE_PRICE_TAG) {
+    if (data.ready_for_price_tag_validation) {
+      formData.append('ready_for_price_tag_validation', data.ready_for_price_tag_validation)
+    }
+  }
+  return formData
+}
 
 export default {
   signIn(username, password) {
@@ -162,37 +196,7 @@ export default {
     let formData = new FormData()
     formData.append('file', image, image.name)
     formData.append('type', data.type)
-    if (data.location_id) {
-      formData.append('location_id', data.location_id ? data.location_id : '')
-    }
-    if (data.location_osm_id && data.location_osm_type) {
-      formData.append('location_osm_id', data.location_osm_id ? data.location_osm_id : '')
-      formData.append('location_osm_type', data.location_osm_type ? data.location_osm_type : '')
-    }
-    formData.append('date', data.date ? data.date : '')
-    formData.append('currency', data.currency ? data.currency : '')
-    if (data.type === constants.PROOF_TYPE_RECEIPT) {
-      if (data.receipt_price_count) {
-        formData.append('receipt_price_count', data.receipt_price_count)
-      }
-      if (data.receipt_price_total) {
-        formData.append('receipt_price_total', data.receipt_price_total)
-      }
-      if (data.receipt_online_delivery_costs) {
-        formData.append('receipt_online_delivery_costs', data.receipt_online_delivery_costs)
-      }
-      if (data.owner_consumption === true || data.owner_consumption === false) {
-        formData.append('owner_consumption', data.owner_consumption)
-      }
-      if (data.owner_comment) {
-        formData.append('owner_comment', data.owner_comment)
-      }
-    }
-    else if (data.type === constants.PROOF_TYPE_PRICE_TAG) {
-      if (data.ready_for_price_tag_validation) {
-        formData.append('ready_for_price_tag_validation', data.ready_for_price_tag_validation)
-      }
-    }
+    formData = fillCreateProofFormData(formData, data)
     // update store
     if (data.currency) {
       store.setLastCurrencyUsed(data.currency)
@@ -201,6 +205,39 @@ export default {
     const endpointWithParams = `/proofs/upload?${buildURLParams({'app_page': source})}`
     return fetchOpenPrices(endpointWithParams, {
       method: 'POST',
+      body: formData,
+    }, true)
+    .then((response) => response.json())
+  },
+
+  createDraftProof(image, type) {
+    let formData = new FormData()
+    formData.append('file', image, image.name)
+    formData.append('type', type)
+    const endpointWithParams = `/proofs/drafts/upload?${buildURLParams()}`
+    return fetchOpenPrices(endpointWithParams, {
+      method: 'POST',
+      body: formData,
+    }, true)
+    .then((response) => response.json())
+  },
+
+  finalizeDraftProof(proofId, inputData = {}, source = null) {
+    const store = useAppStore()
+    // build body
+    let data = filterBodyWithAllowedKeys(inputData, PROOF_CREATE_FIELDS)
+    data = extraProofCreateOrUpdateFiltering(data)
+    // build form
+    let formData = new FormData()
+    formData = fillCreateProofFormData(formData, data)
+    // update store
+    if (data.currency) {
+      store.setLastCurrencyUsed(data.currency)
+    }
+    // API call
+    const endpointWithParams = `/proofs/drafts/${proofId}?${buildURLParams({'app_page': source})}`
+    return fetchOpenPrices(endpointWithParams, {
+      method: 'PATCH',
       body: formData,
     }, true)
     .then((response) => response.json())


### PR DESCRIPTION
### What
- Proposed implementation of the proof draft system
- As soon as proofs are selected, they are uploaded as drafts
- Revamped the proof displaying list, to show drafts currently being uploaded
- Replaced old upload button with drafts finalize

### Screenshot
<img width="1903" height="912" alt="Screenshot 2026-07-05 at 16-24-44 Add proofs (price tags) Open Prices" src="https://github.com/user-attachments/assets/61c91fce-0b77-4503-8943-0d4b9934e53e" />

### Notes
Fundamentally, using drafts do not currently give any benefits to users, so merging this PR might not be the best idea until said benefits are figured out.