### PR TITLE
refactor(User Card): new badge_count chip

### DIFF
--- a/src/components/BadgeCountChip.vue
+++ b/src/components/BadgeCountChip.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-chip label size="small" density="comfortable">
+    <v-icon start :icon="badgeIcon" />
+    <span v-if="withLabel" id="badge-count">{{ $t('Common.BadgeCount', { count: count }) }}</span>
+    <span v-else id="badge-count">{{ count }}</span>
+  </v-chip>
+</template>
+
+<script>
+import constants from '../constants'
+
+export default {
+  props: {
+    count: {
+      type: Number,
+      default: null
+    },
+    withLabel: {
+      type: Boolean,
+      default: false
+    },
+  },
+  data() {
+    return {
+      badgeIcon: constants.BADGE_ICON,
+    }
+  }
+}
+</script>

--- a/src/components/UserFooterRow.vue
+++ b/src/components/UserFooterRow.vue
@@ -9,6 +9,7 @@
         <ProductCountChip :count="user.product_count" :withLabel="true" />
         <ProofCountChip :count="user.proof_count" :withLabel="true" :to="getUserProofListUrl" />
         <ChallengeCountChip :count="user.challenge_count" :withLabel="true" />
+        <BadgeCountChip :count="user.badge_count" :withLabel="true" />
       </span>
     </v-col>
     <v-col v-if="!hideActionMenuButton" cols="1">
@@ -29,6 +30,7 @@ export default {
     ProductCountChip: defineAsyncComponent(() => import('../components/ProductCountChip.vue')),
     ProofCountChip: defineAsyncComponent(() => import('../components/ProofCountChip.vue')),
     ChallengeCountChip: defineAsyncComponent(() => import('../components/ChallengeCountChip.vue')),
+    BadgeCountChip: defineAsyncComponent(() => import('../components/BadgeCountChip.vue')),
     UserActionMenuButton: defineAsyncComponent(() => import('../components/UserActionMenuButton.vue'))
   },
   props: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -177,6 +177,7 @@ export default {
   USER_CONSUMPTION_ICON: USER_CONSUMPTION_ICON,
   USER_COMMUNITY: USER_COMMUNITY,
   USER_COMMENT_ICON: 'mdi-comment-text-outline',
+  BADGE_ICON: 'mdi-medal-outline',
   BADGE_IMAGE_DEFAULT_URL: '/icon-mdi-medal-outline.svg',
   // filter
   PRODUCT_FILTER_LIST: [

--- a/src/views/BadgeList.vue
+++ b/src/views/BadgeList.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-medal-outline">
+      <v-chip label variant="text" :prepend-icon="badgeIcon">
         {{ $t('Common.BadgeCount', { count: badgeTotal }) }}
       </v-chip>
       <template v-if="!loading">
@@ -26,6 +26,7 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import openPricesApi from '../services/openPricesApi'
+import constants from '../constants'
 
 export default {
   components: {
@@ -34,6 +35,7 @@ export default {
   },
   data() {
     return {
+      badgeIcon: constants.BADGE_ICON,
       // data
       badgeList: [],
       badgeTotal: null,


### PR DESCRIPTION
### What

Following https://github.com/openfoodfacts/open-prices/pull/1378 (User.badge_count in the backend).
We display it in the UserCard

### Screenshot

<img width="481" height="388" alt="image" src="https://github.com/user-attachments/assets/f034b5d2-d037-4e99-84ed-8184b2133fd3" />
