### PR TITLE
refactor(Stats): new badge_count stat

### DIFF
--- a/src/components/BadgeCountChip.vue
+++ b/src/components/BadgeCountChip.vue
@@ -1,6 +1,6 @@
 <template>
   <v-chip label size="small" density="comfortable">
-    <v-icon start :icon="badgeIcon" />
+    <v-icon start :icon="BADGE_ICON" />
     <span v-if="withLabel" id="badge-count">{{ $t('Common.BadgeCount', { count: count }) }}</span>
     <span v-else id="badge-count">{{ count }}</span>
   </v-chip>
@@ -22,7 +22,7 @@ export default {
   },
   data() {
     return {
-      badgeIcon: constants.BADGE_ICON,
+      BADGE_ICON: constants.BADGE_ICON,
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -185,6 +185,8 @@
 		"Added": "Added",
 		"AdditionalInfo": "Additional information",
 		"All": "All",
+		"Badge": "Badge",
+		"Badges": "Badges",
 		"BadgeCount": "{count} badges | {count} badge | {count} badges",
 		"Barcode": "Barcode",
 		"Barcodes": "Barcodes",

--- a/src/views/BadgeList.vue
+++ b/src/views/BadgeList.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" :prepend-icon="badgeIcon">
+      <v-chip label variant="text" :prepend-icon="BADGE_ICON">
         {{ $t('Common.BadgeCount', { count: badgeTotal }) }}
       </v-chip>
       <template v-if="!loading">
@@ -35,7 +35,7 @@ export default {
   },
   data() {
     return {
-      badgeIcon: constants.BADGE_ICON,
+      BADGE_ICON: constants.BADGE_ICON,
       // data
       badgeList: [],
       badgeTotal: null,

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -135,6 +135,18 @@
   <v-row>
     <v-col cols="12" class="pb-0">
       <h2 class="text-h6">
+        <v-icon size="x-small" :icon="BADGE_ICON" />
+        {{ $t('Common.Badges') }}
+      </h2>
+    </v-col>
+    <v-col cols="6" sm="4" md="3" lg="2">
+      <StatCard :value="stats.badge_count" :subtitle="$t('Stats.Total')" to="/badges" />
+    </v-col>
+  </v-row>
+
+  <v-row>
+    <v-col cols="12" class="pb-0">
+      <h2 class="text-h6">
         <v-icon size="x-small" icon="mdi-test-tube" />
         {{ $t('Common.Experiments') }}
       </h2>
@@ -268,9 +280,11 @@ export default {
         proof_source_api_count: 0,
         proof_source_other_count: 0,
         price_tag_status_linked_to_price_count: 0,
-        user_count: 0,
+        user_count: 0,  // not displayed
         user_with_price_count: 0,
         challenge_count: 0,
+        badge_count: 0,
+        badge_with_user_count: 0,  // not displayed
         price_in_challenge_count: 0,
         proof_in_challenge_count: 0,
         product_created_count: 0,
@@ -282,6 +296,7 @@ export default {
       OBF_ICON: constants.OBF_ICON,
       OPF_ICON: constants.OPF_ICON,
       OPFF_ICON: constants.OPFF_ICON,
+      BADGE_ICON: constants.BADGE_ICON,
     }
   },
   mounted() {


### PR DESCRIPTION
### What

Following https://github.com/openfoodfacts/open-prices/pull/1379 (TotalStats.badge_count field)
We add the number to the stats page. With a link to the BadgeList page (following #2258)


### Screenshot

<img width="601" height="266" alt="image" src="https://github.com/user-attachments/assets/0e86689c-43a5-4de3-b2c3-fd519341541e" />

