### PR TITLE
refactor(Moderation): show the total count and the loaded count

### DIFF
--- a/src/components/ModerationAlert.vue
+++ b/src/components/ModerationAlert.vue
@@ -1,14 +1,14 @@
 <template>
   <template v-if="source === 'dashboard'">
-    <v-alert data-name="user-moderator-alert" color="primary" variant="outlined" density="compact" icon="mdi-shield-account">
+    <v-alert data-name="user-moderator-alert" color="primary" variant="outlined" density="compact" :icon="MODERATION_ICON">
       {{ $t('Common.UserIsModerator') }}
     </v-alert>
   </template>
   <template v-else-if="source === 'price'">
-    <v-alert v-if="action === 'edit'" data-name="user-price-edit-moderator-alert" color="primary" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-if="action === 'edit'" data-name="user-price-edit-moderator-alert" color="primary" density="compact" variant="outlined" :icon="MODERATION_ICON">
       {{ $t('Common.UserIsModeratorCanEditPrice') }}
     </v-alert>
-    <v-alert v-else-if="action === 'delete'" data-name="user-price-delete-moderator-alert" color="primary" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-else-if="action === 'delete'" data-name="user-price-delete-moderator-alert" color="primary" density="compact" variant="outlined" :icon="MODERATION_ICON">
       {{ $t('Common.UserIsModeratorCanDeletePrice') }}
     </v-alert>
     <v-alert v-else data-name="user-not-price-owner-alert" color="primary" variant="outlined" density="compact" icon="mdi-account-off">
@@ -16,10 +16,10 @@
     </v-alert>
   </template>
   <template v-else-if="source === 'proof'">
-    <v-alert v-if="action === 'edit'" data-name="user-proof-edit-moderator-alert" color="primary" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-if="action === 'edit'" data-name="user-proof-edit-moderator-alert" color="primary" density="compact" variant="outlined" :icon="MODERATION_ICON">
       {{ $t('Common.UserIsModeratorCanEditProof') }}
     </v-alert>
-    <v-alert v-else-if="action === 'delete'" data-name="user-proof-delete-moderator-alert" color="primary" density="compact" variant="outlined" icon="mdi-shield-account">
+    <v-alert v-else-if="action === 'delete'" data-name="user-proof-delete-moderator-alert" color="primary" density="compact" variant="outlined" :icon="MODERATION_ICON">
       {{ $t('Common.UserIsModeratorCanDeleteProof') }}
     </v-alert>
     <v-alert v-else data-name="user-not-proof-owner-alert" color="primary" variant="outlined" density="compact" icon="mdi-account-off">
@@ -29,6 +29,8 @@
 </template>
 
 <script>
+import constants from '../constants'
+
 export default {
   props: {
     source: {
@@ -40,6 +42,11 @@ export default {
       type: String,
       default: '',
       examples: ['edit', 'delete']
+    }
+  },
+  data() {
+    return {
+      MODERATION_ICON: constants.MODERATION_ICON
     }
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,6 +34,7 @@ const LOCATION_TYPE_ONLINE_ICON = 'mdi-web'
 const USER_CONSUMPTION = 'CONSUMPTION'
 const USER_CONSUMPTION_ICON = 'mdi-cart-outline'
 const USER_COMMUNITY = 'COMMUNITY'
+const MODERATION_ICON = 'mdi-shield-account'
 const OSM_NAME = 'OpenStreetMap'
 
 export default {
@@ -284,6 +285,7 @@ export default {
   ],
   // moderation
   // see https://github.com/openfoodfacts/open-prices/blob/main/open_prices/moderation/models.py for reasons
+  MODERATION_ICON: MODERATION_ICON,
   MODERATION_FLAG_REASON_LIST: [
     { key: 'WRONG_TYPE', value: 'ModerationFlagReasonWrongType', restrictTo: null },
     { key: 'WRONG_PRICE_VALUE', value: 'ModerationFlagReasonWrongPriceValue', restrictTo: ['price'] },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -463,6 +463,7 @@
 		"Recent": "Recent",
 		"Re-open": "Re-open",
 		"ReportProblem": "Report a problem",
+		"ReportCount": "{count} reports | {count} report | {count} reports",
 		"Reset": "Reset",
 		"Resolved": "Resolved",
 		"Reuses": "Reuses",

--- a/src/views/ModerationDashboard.vue
+++ b/src/views/ModerationDashboard.vue
@@ -1,5 +1,16 @@
 <template>
   <v-row>
+    <v-col>
+      <v-chip label variant="text" :prepend-icon="MODERATION_ICON">
+        {{ $t('Common.ReportCount', { count: flagTotal }) }}
+      </v-chip>
+      <template v-if="!loading">
+        <LoadedCountChip :loadedCount="flagList.length" :totalCount="flagTotal" />
+      </template>
+    </v-col>
+  </v-row>
+
+  <v-row class="mt-0">
     <v-col cols="12">
       <v-data-table :headers="tableHeaders" :items="flagList" :items-per-page="tablePageLimit" class="elevation-1" fixed-header hide-default-footer mobile-breakpoint="md" :mobile="null" :disable-sort="true" density="comfortable">
         <template #[`item.object`]="{ item }">
@@ -37,16 +48,19 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import openPricesApi from '../services/openPricesApi'
+import constants from '../constants'
 import utils from '../utils.js'
 
 export default {
   components: {
+    LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     ModerationReasonChip: defineAsyncComponent(() => import('../components/ModerationReasonChip.vue')),
     ModerationStatusChip: defineAsyncComponent(() => import('../components/ModerationStatusChip.vue')),
     RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
   },
   data() {
     return {
+      MODERATION_ICON: constants.MODERATION_ICON,
       // data
       flagList: [],
       flagTotal: null,


### PR DESCRIPTION
### What

Small improvements on the moderation page
- show the total count
- show the `LoadedCountChip`
- set the icon in the constants to simplify reuse

### Screenshot

<img width="1207" height="285" alt="image" src="https://github.com/user-attachments/assets/26efa6a6-7156-4a3a-b83c-08281d4e3a49" />
