### PR TITLE
refactor(Moderation): hide closed reports by default. New filter menu to include them

### DIFF
--- a/src/components/FilterMenu.vue
+++ b/src/components/FilterMenu.vue
@@ -78,7 +78,7 @@ export default {
     kind: {
       type: String,
       default: 'product',
-      examples: ['product', 'productCreate', 'price', 'proof', 'priceTag', 'location', 'country', 'user']
+      examples: ['product', 'productCreate', 'price', 'proof', 'priceTag', 'location', 'country', 'user', 'flag']
     },
     currentFilterList: {
       type: Array,
@@ -114,13 +114,14 @@ export default {
     return {
       // default filters
       productFilterList: constants.PRODUCT_FILTER_LIST,
+      productCreateFilterList: constants.PRODUCT_CREATE_FILTER_LIST,
       priceFilterList: constants.PRICE_FILTER_LIST,
       proofFilterList: constants.PROOF_FILTER_LIST,
       priceTagFilterList: constants.PRICE_TAG_FILTER_LIST,
       locationFilterList: constants.LOCATION_FILTER_LIST,
       countryFilterList: constants.LOCATION_COUNTRY_FILTER_LIST,
       userFilterList: constants.USER_FILTER_LIST,
-      productCreateFilterList: constants.PRODUCT_CREATE_FILTER_LIST,
+      flagFilterList: constants.FLAG_FILTER_LIST,
       // other filters
       productSourceList: constants.PRODUCT_SOURCE_LIST,
       priceTypeList: constants.PRICE_TYPE_LIST,

--- a/src/constants.js
+++ b/src/constants.js
@@ -212,6 +212,9 @@ export default {
   USER_FILTER_LIST: [
     { key: 'hide_price_count_gte_1', value: 'FilterUserWithPriceCountHide' },
   ],
+  FLAG_FILTER_LIST: [
+    { key: 'show_closed', value: 'FilterFlagShowClosed' },
+  ],
   // order
   PRODUCT_ORDER_LIST: [
     { key: '-price_count', value: 'OrderPriceCountDESC', icon: 'mdi-tag-multiple-outline' },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -328,6 +328,7 @@
 		"FilterPriceTagWithTagInvalidInclude": "Include prices flagged as invalid (AI)",
 		"FilterLocationWithPriceCountHide": "Hide locations with prices",
 		"FilterUserWithPriceCountHide": "Hide contributors with prices",
+		"FilterFlagShowClosed": "Include closed reports",
 		"Fix": "Fix",
 		"FAQ": "FAQ",
 		"FrequentlyAskedQuestions": "Frequently asked questions",

--- a/src/views/ModerationDashboard.vue
+++ b/src/views/ModerationDashboard.vue
@@ -6,6 +6,7 @@
       </v-chip>
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="flagList.length" :totalCount="flagTotal" />
+        <FilterMenu kind="flag" :currentFilterList="currentFilterList" @update:currentFilterList="updateFilterList($event)" />
       </template>
     </v-col>
   </v-row>
@@ -54,6 +55,7 @@ import utils from '../utils.js'
 export default {
   components: {
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
+    FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     ModerationReasonChip: defineAsyncComponent(() => import('../components/ModerationReasonChip.vue')),
     ModerationStatusChip: defineAsyncComponent(() => import('../components/ModerationStatusChip.vue')),
     RelativeDateTimeChip: defineAsyncComponent(() => import('../components/RelativeDateTimeChip.vue')),
@@ -77,16 +79,28 @@ export default {
       ],
       tablePageLimit: -1,  // all items
       // filter & order
+      currentFilterList: [],
       currentOrder: '-id'
     }
   },
   computed: {
     getFlagsParams() {
       let defaultParams = { order_by: this.currentOrder, page: this.flagPage }
+      if (!this.currentFilterList.includes('show_closed')) {
+        defaultParams['status'] = 'OPEN'
+      }
       return defaultParams
     }
   },
+  watch: {
+    $route (newRoute, oldRoute) { // only called when query changes to avoid having an API call when the path changes
+      if (oldRoute.path === newRoute.path && JSON.stringify(oldRoute.query) !== JSON.stringify(newRoute.query)) {
+        this.initFlagList()
+      }
+    }
+  },
   mounted() {
+    this.currentFilterList = utils.toArray(this.$route.query[constants.FILTER_PARAM]) || this.currentFilterList
     this.initFlagList()
     // load more
     this.handleDebouncedScroll = utils.debounce(this.handleScroll, 100)
@@ -121,6 +135,11 @@ export default {
         .then(() => {
           this.initFlagList()
         })
+    },
+    updateFilterList(newFilterList) {
+      this.currentFilterList = newFilterList
+      this.$router.push({ query: { ...this.$route.query, [constants.FILTER_PARAM]: this.currentFilterList } })
+      // this.initFlagList() will be called in watch $route
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars
       if (utils.getDocumentScrollPercentage() > 90) {


### PR DESCRIPTION
### What

Small improvements on the moderation page (following #2268)
- add the `FilterMenu` component
- show only OPEN reports by default
- filter menu item to include CLOSED as well

### Screenshot

<img width="1207" height="285" alt="image" src="https://github.com/user-attachments/assets/5baef332-3aa8-4f80-869e-630dd79b2f34" />

