### PR TITLE
refactor(Count Chips): new generic `CountTextChip` component. use everywhere possible

### DIFF
--- a/src/components/CountTextChip.vue
+++ b/src/components/CountTextChip.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-chip label variant="text" :prepend-icon="getKindIcon">
+    {{ $t(`Common.${getKindTitlecase}Count`, { count: count }) }}
+  </v-chip>
+</template>
+
+<script>
+import constants from '../constants'
+import utils from '../utils'
+
+export default {
+  props: {
+    kind: {
+      type: String,
+      default: null,
+      examples: ['price', 'product', 'proof', 'location', 'user', 'currency', 'country', 'challenge', 'badge']
+    },
+    count: {
+      type: Number,
+      default: null
+    }
+  },
+  computed: {
+    getKindTitlecase() {
+      return utils.toTitleCase(this.kind)
+    },
+    getKindIcon() {
+      return constants[`${this.kind.toUpperCase()}_ICON`]
+    }
+  }
+}
+</script>

--- a/src/components/CountTextChip.vue
+++ b/src/components/CountTextChip.vue
@@ -13,7 +13,7 @@ export default {
     kind: {
       type: String,
       default: null,
-      examples: ['price', 'product', 'proof', 'location', 'user', 'currency', 'country', 'challenge', 'badge']
+      examples: ['price', 'product', 'proof', 'location', 'user', 'currency', 'country', 'challenge', 'badge', 'report']
     },
     count: {
       type: Number,

--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -8,9 +8,7 @@
       <v-divider />
 
       <v-card-title>
-        <v-chip label variant="text" prepend-icon="mdi-image">
-          {{ $t('Common.ProofCount', { count: userProofTotal }) }}
-        </v-chip>
+        <CountTextChip kind="proof" :count="userProofTotal" />
         <template v-if="!loading">
           <LoadedCountChip :loadedCount="userProofList.length" :totalCount="userProofTotal" />
           <FilterMenu v-if="!hideFilterMenu" kind="proof" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleProofType($event)" />
@@ -46,6 +44,7 @@ import constants from '../constants'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,7 @@ const USER_CONSUMPTION = 'CONSUMPTION'
 const USER_CONSUMPTION_ICON = 'mdi-cart-outline'
 const USER_COMMUNITY = 'COMMUNITY'
 const MODERATION_ICON = 'mdi-shield-account'
+const REPORT_ICON = 'mdi-flag'
 const CHALLENGE_ICON = 'mdi-trophy-variant'
 const BADGE_ICON = 'mdi-medal-outline'
 const CURRENCY_ICON = 'mdi-cash'
@@ -314,6 +315,7 @@ export default {
   // moderation
   // see https://github.com/openfoodfacts/open-prices/blob/main/open_prices/moderation/models.py for reasons
   MODERATION_ICON: MODERATION_ICON,
+  REPORT_ICON: REPORT_ICON,
   MODERATION_FLAG_TYPE_LIST: [
     { key: 'PROOF', value: 'Proof', icon: PROOF_ICON },
     { key: 'PRICE', value: 'Price', icon: PRICE_ICON },

--- a/src/views/BadgeList.vue
+++ b/src/views/BadgeList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" :prepend-icon="BADGE_ICON">
-        {{ $t('Common.BadgeCount', { count: badgeTotal }) }}
-      </v-chip>
+      <CountTextChip kind="badge" :count="badgeTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="badgeList.length" :totalCount="badgeTotal" />
       </template>
@@ -26,16 +24,15 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import openPricesApi from '../services/openPricesApi'
-import constants from '../constants'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     BadgeCard: defineAsyncComponent(() => import('../components/BadgeCard.vue')),
   },
   data() {
     return {
-      BADGE_ICON: constants.BADGE_ICON,
       // data
       badgeList: [],
       badgeTotal: null,

--- a/src/views/ChallengeList.vue
+++ b/src/views/ChallengeList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-trophy-variant">
-        {{ $t('Common.ChallengeCount', { count: challengeTotal }) }}
-      </v-chip>
+      <CountTextChip kind="challenge" :count="challengeTotal" />
     </v-col>
   </v-row>
 
@@ -72,6 +70,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     ChallengeCard: defineAsyncComponent(() => import('../components/ChallengeCard.vue')),
     ChallengeNewFormAlert: defineAsyncComponent(() => import('../components/ChallengeNewFormAlert.vue')),

--- a/src/views/ChallengePriceList.vue
+++ b/src/views/ChallengePriceList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-tag-multiple-outline">
-        {{ $t('Common.PriceCount', { count: priceTotal }) }}
-      </v-chip>
+      <CountTextChip kind="price" :count="priceTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="priceList.length" :totalCount="priceTotal" />
         <FilterMenu kind="price" :currentFilterList="currentFilterList" :currentType="currentType" :currentKind="currentKind" :showKind="true" @update:currentFilterList="updateFilterList($event)" @update:currentType="togglePriceType($event)" @update:currentKind="togglePriceKind($event)" />
@@ -34,6 +32,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),

--- a/src/views/ChallengeProofList.vue
+++ b/src/views/ChallengeProofList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-image">
-        {{ $t('Common.ProofCount', { count: proofTotal }) }}
-      </v-chip>
+      <CountTextChip kind="proof" :count="proofTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="proofList.length" :totalCount="proofTotal" />
         <FilterMenu kind="proof" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleProofType($event)" />
@@ -41,6 +39,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/CountryList.vue
+++ b/src/views/CountryList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-map-marker-outline">
-        {{ $t('Common.CountryCount', { count: countryList.length }) }}
-      </v-chip>
+      <CountTextChip kind="country" :count="countryList.length" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="countryList.length" :totalCount="countryTotal" />
         <FilterMenu kind="country" :currentFilterList="currentFilterList" @update:currentFilterList="updateFilterList($event)" />
@@ -33,6 +31,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -49,9 +49,7 @@
         <v-card-text>
           <v-row>
             <v-col class="pt-0 pb-0">
-              <v-chip label variant="text" prepend-icon="mdi-database-outline">
-                {{ $t('Common.ProductCount', { count: productTotal }) }}
-              </v-chip>
+              <CountTextChip kind="product" :count="productTotal" />
               <FilterMenu kind="productCreate" :currentFilterList="currentFilterList" @update:currentFilterList="updateFilterList($event)" />
               <OrderMenu v-if="!currentFilterList.includes('price__owner')" kind="productCreate" :currentOrder="currentOrder" @update:currentOrder="updateOrder($event)" />
             </v-col>
@@ -357,6 +355,7 @@ import "vue-zoomable/dist/style.css"
 export default {
   components: {
     ContributionAssistantDrawCanvas: defineAsyncComponent(() => import('../components/ContributionAssistantDrawCanvas.vue')),
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     ProductCard: defineAsyncComponent(() => import('../components/ProductCard.vue')),
     VueZoomable: defineAsyncComponent(() => import('vue-zoomable')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-map-marker-outline">
-        {{ $t('Common.LocationCount', { count: locationTotal }) }}
-      </v-chip>
+      <CountTextChip kind="location" :count="locationTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="locationList.length" :totalCount="locationTotal" />
         <FilterMenu kind="location" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleLocationType($event)" />
@@ -33,6 +31,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/LocationProofList.vue
+++ b/src/views/LocationProofList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-image">
-        {{ $t('Common.ProofCount', { count: proofTotal }) }}
-      </v-chip>
+      <CountTextChip kind="proof" :count="proofTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="proofList.length" :totalCount="proofTotal" />
         <FilterMenu kind="proof" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleProofType($event)" />
@@ -41,6 +39,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/ModerationDashboard.vue
+++ b/src/views/ModerationDashboard.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" :prepend-icon="MODERATION_ICON">
-        {{ $t('Common.ReportCount', { count: flagTotal }) }}
-      </v-chip>
+      <CountTextChip kind="report" :count="flagTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="flagList.length" :totalCount="flagTotal" />
         <FilterMenu kind="flag" :currentFilterList="currentFilterList" :currentType="currentType" :currentKind="currentKind" :showKind="true" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleFlagType($event)" @update:currentKind="toggleFlagKind($event)" />
@@ -55,6 +53,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),
@@ -64,7 +63,6 @@ export default {
   },
   data() {
     return {
-      MODERATION_ICON: constants.MODERATION_ICON,
       // data
       flagList: [],
       flagTotal: null,

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-tag-outline">
-        {{ $t('Common.PriceCount', { count: priceTotal }) }}
-      </v-chip>
+      <CountTextChip kind="price" :count="priceTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="priceList.length" :totalCount="priceTotal" />
         <FilterMenu kind="price" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="togglePriceType($event)" />
@@ -33,6 +31,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     PriceCard: defineAsyncComponent(() => import('../components/PriceCard.vue'))

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-database-outline">
-        {{ $t('Common.ProductCount', { count: productTotal }) }}
-      </v-chip>
+      <CountTextChip kind="product" :count="productTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="productList.length" :totalCount="productTotal" />
         <FilterMenu kind="product" :currentFilterList="currentFilterList" :currentSource="currentSource" @update:currentFilterList="updateFilterList($event)" @update:currentSource="toggleProductSource($event)" />
@@ -33,6 +31,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/ProofList.vue
+++ b/src/views/ProofList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-image">
-        {{ $t('Common.ProofCount', { count: proofTotal }) }}
-      </v-chip>
+      <CountTextChip kind="proof" :count="proofTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="proofList.length" :totalCount="proofTotal" />
         <FilterMenu kind="proof" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleProofType($event)" />
@@ -32,6 +30,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     ProofCard: defineAsyncComponent(() => import('../components/ProofCard.vue')),

--- a/src/views/UserBadgeList.vue
+++ b/src/views/UserBadgeList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" :prepend-icon="BADGE_ICON">
-        {{ $t('Common.BadgeCount', { count: userBadgeTotal }) }}
-      </v-chip>
+      <CountTextChip kind="badge" :count="userBadgeTotal" />
     </v-col>
   </v-row>
 
@@ -23,16 +21,15 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import openPricesApi from '../services/openPricesApi'
-import constants from '../constants'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     BadgeCard: defineAsyncComponent(() => import('../components/BadgeCard.vue')),
   },
   data() {
     return {
       username: this.$route.params.username,
-      BADGE_ICON: constants.BADGE_ICON,
       // data
       userBadgeList: [],
       userBadgeTotal: null,

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-tag-multiple-outline">
-        {{ $t('Common.PriceCount', { count: priceTotal }) }}
-      </v-chip>
+      <CountTextChip kind="price" :count="priceTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="priceList.length" :totalCount="priceTotal" />
         <FilterMenu kind="price" :currentFilterList="currentFilterList" :currentType="currentType" :currentKind="currentKind" :showKind="true" @update:currentFilterList="updateFilterList($event)" @update:currentType="togglePriceType($event)" @update:currentKind="togglePriceKind($event)" />
@@ -51,6 +49,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-image">
-        {{ $t('Common.ProofCount', { count: proofTotal }) }}
-      </v-chip>
+      <CountTextChip kind="proof" :count="proofTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="proofList.length" :totalCount="proofTotal" />
         <FilterMenu kind="proof" :currentFilterList="currentFilterList" :currentType="currentType" :currentKind="currentKind" :showKind="true" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleProofType($event)" @update:currentKind="toggleProofKind($event)" />
@@ -58,6 +56,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-account">
-        {{ $t('UserList.UserTotal', { count: userTotal }) }}
-      </v-chip>
+      <CountTextChip kind="user" :count="userTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="userList.length" :totalCount="userTotal" />
         <FilterMenu kind="user" :currentFilterList="currentFilterList" @update:currentFilterList="updateFilterList($event)" />
@@ -33,6 +31,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     UserCard: defineAsyncComponent(() => import('../components/UserCard.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),

--- a/src/views/UserProofList.vue
+++ b/src/views/UserProofList.vue
@@ -1,9 +1,7 @@
 <template>
   <v-row>
     <v-col>
-      <v-chip label variant="text" prepend-icon="mdi-image">
-        {{ $t('Common.ProofCount', { count: proofTotal }) }}
-      </v-chip>
+      <CountTextChip kind="proof" :count="proofTotal" />
       <template v-if="!loading">
         <LoadedCountChip :loadedCount="proofList.length" :totalCount="proofTotal" />
         <FilterMenu kind="proof" :currentFilterList="currentFilterList" :currentType="currentType" @update:currentFilterList="updateFilterList($event)" @update:currentType="toggleProofType($event)" />
@@ -41,6 +39,7 @@ import utils from '../utils.js'
 
 export default {
   components: {
+    CountTextChip: defineAsyncComponent(() => import('../components/CountTextChip.vue')),
     LoadedCountChip: defineAsyncComponent(() => import('../components/LoadedCountChip.vue')),
     FilterMenu: defineAsyncComponent(() => import('../components/FilterMenu.vue')),
     OrderMenu: defineAsyncComponent(() => import('../components/OrderMenu.vue')),


### PR DESCRIPTION
### What

Similar to #2276 (`CountChip` component)
Here we create a similar component, that helps us replace code in many pages
- generic icons
- generic names & translations

### Screenshot

<img width="163" height="105" alt="image" src="https://github.com/user-attachments/assets/b5148351-ea8f-47a0-9137-4f2151bca7bb" />

