### PR TITLE
fix(Location Selector): fix how we detect if a location is favorite or not

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import constants from './constants'
 import utils from './utils.js'
+import geo_utils from './utils/geo.js'
 
 
 const RECENT_LOCATIONS_MAX_SIZE = 10
@@ -71,7 +72,7 @@ export const useAppStore = defineStore('app', {
       this.user.is_moderator = false
     },
     isRecentLocation(location) {
-      return this.user.recent_locations.some(recentLocation => recentLocation.id === location.id)
+      return this.user.recent_locations.some(recentLocation => geo_utils.getLocationId(recentLocation) === geo_utils.getLocationId(location))
     },
     addRecentLocation(location) {
       this.user.recent_locations = utils.addObjectToArray(this.user.recent_locations, location, true)
@@ -87,7 +88,7 @@ export const useAppStore = defineStore('app', {
       this.user.recent_locations = []
     },
     isFavoriteLocation(location) {
-      return this.user.favorite_locations.some(favoriteLocation => favoriteLocation.id === location.id)
+      return this.user.favorite_locations.some(favoriteLocation => geo_utils.getLocationId(favoriteLocation) === geo_utils.getLocationId(location))
     },
     addFavoriteLocation(location) {
       this.user.favorite_locations = utils.addObjectToArray(this.user.favorite_locations, location, true)


### PR DESCRIPTION
### What

Following #2222
Tentative fix to avoid having all the location cards being displayed as already favorited when they are not.
We were doing the "presence check" on the wrong id

