### PR TITLE
refactor(Location Chip): better manage when location is missing

### DIFF
--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -3,7 +3,7 @@
     <v-col :cols="hideActionMenuButton ? '12' : '11'">
       <span class="chip-group">
         <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
-        <LocationChip v-if="!hidePriceLocation" :location="price.location" :locationId="price.location_id" :readonly="readonly" />
+        <LocationChip v-if="!hidePriceLocation" :location="price.location" :locationId="price.location_id" :showErrorIfLocationMissing="true" :readonly="readonly" />
         <UserChip v-if="!hidePriceOwner" :username="price.owner" :readonly="readonly" />
         <DateChip v-if="!hidePriceDate" :date="price.date" :readonly="readonly" />
         <UserCommentChip v-if="price.owner_comment" :comment="price.owner_comment" />

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -245,6 +245,9 @@ function getLocationId(locationObject) {
 }
 
 function getLocationIcon(locationObject) {
+  if (!locationObject) {
+    return constants.LOCATION_UNKNOWN_ICON
+  }
   // Photon location
   if (locationObject.properties) {
     return constants.LOCATION_TYPE_OSM_ICON


### PR DESCRIPTION
### What

When a price (or proof) location is missing, improve the `LocationChip` behavior
- avoid error in `getLocationIcon`
- also display the chip in red in the PrIceFooterRow (was already the case in ProofFooterRow)