### PR TITLE
fix(Date Chip): fix behavior when a datetime is passed (instead of a date)

### DIFF
--- a/src/components/BadgeCard.vue
+++ b/src/components/BadgeCard.vue
@@ -10,7 +10,7 @@
             <v-col cols="12">
               <h3>{{ badge.name }}</h3>
               <p>{{ badge.description }}</p>
-              <DateChip v-if="achievedAt" :date="achievedAt" :class="$t('Common.BadgeAchievementDate')" />
+              <DateChip v-if="achievedAt" :title="$t('Common.BadgeAchievementDate')" :date="achievedAt" :readonly="true" />
             </v-col>
           </v-row>
         </v-col>

--- a/src/components/DateChip.vue
+++ b/src/components/DateChip.vue
@@ -37,6 +37,9 @@ export default {
   computed: {
     dateMissingAndShowError() {
       return !this.date && this.showErrorIfDateMissing
+    },
+    dateShort() {
+      return date_utils.dateShort(this.date)
     }
   },
   methods: {
@@ -47,7 +50,7 @@ export default {
       if (this.readonly || !this.date) {
         return
       }
-      this.$router.push({ path: `/dates/${this.date}` })
+      this.$router.push({ path: `/dates/${this.dateShort}` })
     },
   }
 }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -33,6 +33,14 @@ function currentStartOfDay() {
 }
 
 /**
+ * input: '2023-12-25' or '2023-12-25T17:08:19.021410+01:00'
+ * output: '2023-12-25'
+ */
+function dateShort(dateString) {
+  return dateString?.substring(0, 10)
+}
+
+/**
  * input: '2023-12-25'
  * output: '2023-12-25T00:00:00.000Z'
  */
@@ -148,6 +156,7 @@ export default {
   currentDate,
   currentDateTime,
   currentStartOfDay,
+  dateShort,
   dateStartOfDay,
   dateEndOfDay,
   oneMonthAgoDate,


### PR DESCRIPTION
### What

The `DateChip` currently expects a "short" date.

Improve the behavior when a "long" (datetime) date is passed (for instance in the BadgeCard).

And make the chip readonly in the BadgeCard (created in #2258)