### PR TITLE
refactor(Badge Card): display the metric & threshold in a chip

### DIFF
--- a/src/components/BadgeCard.vue
+++ b/src/components/BadgeCard.vue
@@ -10,6 +10,8 @@
             <v-col cols="12">
               <h3>{{ badge.name }}</h3>
               <p>{{ badge.description }}</p>
+              <CountChip v-if="badge.metric === 'price_count'" class="mr-2" kind="price" :count="badge.threshold" :withLabel="true" />
+              <CountChip v-if="badge.metric === 'proof_count'" class="mr-2" kind="proof" :count="badge.threshold" :withLabel="true" />
               <DateChip v-if="achievedAt" :title="$t('Common.BadgeAchievementDate')" :date="achievedAt" :readonly="true" />
             </v-col>
           </v-row>
@@ -33,8 +35,8 @@ import constants from '../constants'
 
 export default {
   components: {
-    DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
     CountChip: defineAsyncComponent(() => import('../components/CountChip.vue')),
+    DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
   },
   props: {
     badge: {


### PR DESCRIPTION
### What

We created the BadgeCard in #2258

This PR gives more context on the card, by displaying the "metric + threshold"

### Screenshot

|Before|Afer|
|-|-|
|<img width="395" height="246" alt="image" src="https://github.com/user-attachments/assets/37b280b6-2188-42b9-8368-323b28766145" />|<img width="395" height="246" alt="image" src="https://github.com/user-attachments/assets/edc174de-6b2b-4f76-a246-bb1f9d7651f3" />|