### PR TITLE
feat(History Card): show full price/product history if available

### DIFF
--- a/src/components/HistoryCard.vue
+++ b/src/components/HistoryCard.vue
@@ -3,7 +3,7 @@
     <v-card-text class="ml-4">
       <ul>
         <!-- history entries -->
-        <li v-for="history in historyList" :key="history.id">
+        <li v-for="history in historyList" :key="history.history_id">
           <span>{{ getDateTimeFormatted(history.history_date) }} ({{ getRelativeDateTimeFormatted(history.history_date) }})</span>
           <span> - </span>
           <a :href="getUserDetailUrl">{{ history.history_user_id }}</a>
@@ -76,9 +76,11 @@ export default {
   },
   methods: {
     getObjectHistory() {
+      // only fetch history if the object has actually been updated
       if (this.object.created == this.object.updated) return
       openPricesApi.getHistory(this.kind, this.object.id)
         .then(data => {
+          // filter out the object creation entry
           this.historyList = data.filter(entry => entry.history_type !== '+')
         })
         .catch(error => {

--- a/src/components/HistoryCard.vue
+++ b/src/components/HistoryCard.vue
@@ -2,6 +2,24 @@
   <v-card :title="getTitle" data-name="history-card">
     <v-card-text class="ml-4">
       <ul>
+        <!-- history entries -->
+        <li v-for="history in historyList" :key="history.id">
+          <span>{{ getDateTimeFormatted(history.history_date) }} ({{ getRelativeDateTimeFormatted(history.history_date) }})</span>
+          <span> - </span>
+          <a :href="getUserDetailUrl">{{ history.history_user_id }}</a>
+          <span v-if="history.history_change_reason">
+            <span> - </span>
+            <span>{{ history.history_change_reason }}</span>
+          </span>
+          <ul v-if="history.changes" class="ml-4">
+            <li v-for="change in history.changes" :key="change.field">
+              <span>{{ change.field }}: </span>
+              <span class="text-decoration-line-through">{{ change.old }}</span>
+              <span> → </span>
+              <span>{{ change.new }}</span>
+            </li>
+          </ul>
+        </li>
         <!-- object creation -->
         <li>
           <span>{{ getDateTimeFormatted(object.created) }} ({{ getRelativeDateTimeFormatted(object.created) }})</span>
@@ -19,6 +37,7 @@
 </template>
 
 <script>
+import openPricesApi from '../services/openPricesApi'
 import date_utils from '../utils/date.js'
 
 export default {
@@ -31,6 +50,11 @@ export default {
       type: String,
       default: null,
       examples: ['price', 'proof']
+    }
+  },
+  data() {
+    return {
+      historyList: []
     }
   },
   computed: {
@@ -47,7 +71,20 @@ export default {
       return `/users/${this.object.owner}`
     }
   },
+  mounted() {
+    this.getObjectHistory()
+  },
   methods: {
+    getObjectHistory() {
+      if (this.object.created == this.object.updated) return
+      openPricesApi.getHistory(this.kind, this.object.id)
+        .then(data => {
+          this.historyList = data.filter(entry => entry.history_type !== '+')
+        })
+        .catch(error => {
+          console.error('Error fetching full history:', error)
+        })
+    },
     getDateTimeFormatted(dateTimeString) {
       return date_utils.offDateTime(dateTimeString)
     },

--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -535,6 +535,14 @@ export default {
     .then((response) => response.json())
   },
 
+  getHistory(objectType, objectId, params = {}) {
+    const endpointWithParams = `/${objectType}s/${objectId}/history?${buildURLParams({...params})}`
+    return fetchOpenPrices(endpointWithParams, {
+      method: 'GET',
+    })
+    .then((response) => response.json())
+  },
+
   getStats() {
     const endpointWithParams = `/stats?${buildURLParams()}`
     return fetchOpenPrices(endpointWithParams, {


### PR DESCRIPTION
### What

Following #2303
If the price (or proof) has a `created` field different from its `updated` field, then there is probably some history changes.
Fetch them, and display the details.

### Screenshot

|Before|After|
|-|-|
|<img width="594" height="301" alt="image" src="https://github.com/user-attachments/assets/008b48e6-0cee-4409-b500-f658b7131aaa" />|<img width="594" height="437" alt="image" src="https://github.com/user-attachments/assets/e3e9f3cc-24e2-4a6f-9066-a3b30c6ebbe1" />|
