### PR TITLE
refactor(SignIn): sign-in redirect: improve next management (keep params)

### DIFF
--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -174,8 +174,20 @@ export default {
         .catch(this.handleAuthError)
     },
     done() {
-      const path = this.$route.query.next || '/dashboard'
-      this.$router.push({ path: path, query: { signinSuccess: 'true' } })
+      const nextParam = this.$route.query.next
+      let path = '/dashboard'
+      let query = { signinSuccess: 'true' }
+      
+      if (nextParam) {
+        const [nextParamPath, nextParamQuery] = nextParam.split('?')
+        path = nextParamPath || '/dashboard'
+        if (nextParamQuery) {
+          query = Object.fromEntries(new URLSearchParams(nextParamQuery))
+          query.signinSuccess = 'true'
+        }
+      }
+      
+      this.$router.push({ path, query })
     }
   },
 };

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -177,18 +177,21 @@ export default {
       const nextParam = this.$route.query.next
       let path = '/dashboard'
       let query = { signinSuccess: 'true' }
-      
+
+      // see src/router.js > router.beforeEach
       if (nextParam) {
         const [nextParamPath, nextParamQuery] = nextParam.split('?')
-        path = nextParamPath || '/dashboard'
-        if (nextParamQuery) {
-          query = Object.fromEntries(new URLSearchParams(nextParamQuery))
-          query.signinSuccess = 'true'
+        if (nextParamPath) {
+          path = nextParamPath
+          if (nextParamQuery) {
+            query = Object.fromEntries(new URLSearchParams(nextParamQuery))
+            query.signinSuccess = 'true'
+          }
         }
       }
       
       this.$router.push({ path, query })
     }
   },
-};
+}
 </script>


### PR DESCRIPTION
### What

In #1280 we introduced a sign-in redirect using the `next` param
Here we improve it to manage cases where the `next` param has params itself (currently they were stripped down).

cc @odin-h 