### PR TITLE
fix(Origin Chip): remove the link (origin detail page does not exist)

### DIFF
--- a/src/components/OriginTagChip.vue
+++ b/src/components/OriginTagChip.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chip label size="small" density="comfortable" :to="getOriginUrl">
+  <v-chip label size="small" density="comfortable">
     {{ originLocalizedName || origin }}
   </v-chip>
 </template>
@@ -32,9 +32,6 @@ export default {
   },
   computed: {
     ...mapStores(useAppStore),
-    getOriginUrl() {
-      return this.origin && !this.readonly ? `/origins/${this.origin}` : null
-    },
   },
   mounted() {
     this.setOriginLocalizedName(this.origin)


### PR DESCRIPTION
### What

in #2200 we created the `OriginTagChip` but mistakenly added a clickable action/link to a nonexistant Origin detail page
This PR removes the link

Also linked to #2283