### PR TITLE
fix(Price Card): better manage when price currency is missing

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -1,12 +1,15 @@
 <template>
-  <v-chip label size="small" :prepend-icon="CURRENCY_ICON" density="comfortable" :color="currencyMissingAndShowError ? 'error' : 'default'" :to="getCurrencyUrl">
-    <span v-if="currency">{{ currency }}</span>
-    <span v-else-if="currencyMissingAndShowError">
-      <i class="text-lowercase">{{ $t('Common.Currency') }}</i>
-      <v-tooltip activator="parent" open-on-click location="top">
-        {{ $t('Common.CurrencyMissing') }}
-      </v-tooltip>
+  <v-chip label size="small" density="comfortable" :color="currencyMissingAndShowError ? 'error' : 'default'" :to="getCurrencyUrl">
+    <v-icon :start="withLabel" :icon="CURRENCY_ICON" />
+    <span v-if="currency" :title="currency">
+      <span v-if="withLabel">{{ currency }}</span>
     </span>
+    <span v-else-if="currencyMissingAndShowError">
+      <i v-if="withLabel" class="text-lowercase">{{ $t('Common.Currency') }}</i>
+    </span>
+    <v-tooltip v-if="currencyMissingAndShowError" activator="parent" open-on-click location="top">
+      {{ $t('Common.CurrencyMissing') }}
+    </v-tooltip>
   </v-chip>
 </template>
 
@@ -20,6 +23,10 @@ export default {
       default: null
     },
     showErrorIfCurrencyMissing: {
+      type: Boolean,
+      default: false
+    },
+    withLabel: {
       type: Boolean,
       default: false
     },

--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -3,6 +3,7 @@
     <v-col cols="12" class="pt-2 pb-2">
       <span class="mr-1">{{ getPriceValueDisplay(price.price) }}</span>
       <span v-if="showPriceProductPerUnit" class="mr-1">({{ getPricePerUnit(price.price) }})</span>
+      <CurrencyChip v-if="!price.currency" :currency="price.currency" :showErrorIfCurrencyMissing="true" :withLabel="false" :readonly="readonly" />
       <PriceDiscountChip v-if="hasDiscount" class="ml-1 mr-1" :price="price" />
       <PriceQuantityPurchasedChip v-if="showReceiptQuantity" class="ml-1" :priceQuantityPurchased="price.receipt_quantity" />
     </v-col>
@@ -16,6 +17,7 @@ import price_utils from '../utils/price.js'
 
 export default {
   components: {
+    CurrencyChip: defineAsyncComponent(() => import('../components/CurrencyChip.vue')),
     PriceDiscountChip: defineAsyncComponent(() => import('../components/PriceDiscountChip.vue')),
     PriceQuantityPurchasedChip: defineAsyncComponent(() => import('../components/PriceQuantityPurchasedChip.vue')),
   },

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -11,7 +11,7 @@
         <PriceCountChip v-if="!hidePriceCount" :count="proof.price_count" :withLabel="true" source="proof" @click="goToProof()" />
         <LocationChip :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
         <DateChip :date="proof.date" :showErrorIfDateMissing="true" :readonly="readonly" />
-        <CurrencyChip :currency="proof.currency" :showErrorIfCurrencyMissing="true" :readonly="readonly" />
+        <CurrencyChip :currency="proof.currency" :showErrorIfCurrencyMissing="true" :withLabel="true" :readonly="readonly" />
         <UserChip v-if="!hideProofOwner" :username="proof.owner" :readonly="readonly" />
         <UserCommentChip v-if="proof.owner_comment" :comment="proof.owner_comment" />
         <RelativeDateTimeChip :dateTime="proof.created" />

--- a/src/components/ProofTable.vue
+++ b/src/components/ProofTable.vue
@@ -13,7 +13,7 @@
       <DateChip :date="item.date" :readonly="true" />
     </template>
     <template #[`item.currency`]="{ item }">
-      <CurrencyChip :currency="item.currency" :readonly="true" />
+      <CurrencyChip :currency="item.currency" :withLabel="true" :readonly="true" />
     </template>
     <template #[`item.created`]="{ item }">
       <RelativeDateTimeChip :dateTime="item.created" />

--- a/src/utils/price.js
+++ b/src/utils/price.js
@@ -2,10 +2,21 @@ import i18n from '@/i18n'
 import constants from '../constants'
 
 /**
- * fr: 4,00 €
- * en-US: €4.00
+ * Formats a price with currency symbol according to locale.
+ *
+ * Examples:
+ * - price: 4, currency: 'EUR' => "4,00 €" (fr) or "€4.00" (en-US)
+ * - price: 4, currency: null => "4.00" (fallback without currency symbol)
  */
 function prettyPrice(price, currency) {
+  if (!currency) {
+    // Fallback to plain number formatting without currency
+    return price.toLocaleString(navigator.language, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    })
+  }
+
   return price.toLocaleString(navigator.language, {
     style: 'currency',
     currency: currency,


### PR DESCRIPTION
### What

The backend allows proofs to be created without date & currency. Sometimes (rarely) prices also have these fields missing.
This PR avoids the frontend to crash if it is the case.
- better manage price "locale display" when currency missing
- show a "currency missing chip" if it is the case

### Screenshot

|Before|After|
|-|-|
|<img width="398" height="216" alt="image" src="https://github.com/user-attachments/assets/e0a41049-5564-493f-bd98-0d11647782e9" />|<img width="398" height="216" alt="image" src="https://github.com/user-attachments/assets/22c75c20-7c94-482b-a06f-0d4c588c2c7e" />|