### PR TITLE
fix(Price Card): better manage when price date is missing

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -28,7 +28,7 @@ export default {
     },
     withLabel: {
       type: Boolean,
-      default: false
+      default: true
     },
     readonly: {
       type: Boolean,

--- a/src/components/DateChip.vue
+++ b/src/components/DateChip.vue
@@ -1,12 +1,15 @@
 <template>
-  <v-chip label size="small" :prepend-icon="DATE_ICON" density="comfortable" :color="dateMissingAndShowError ? 'error' : 'default'" :to="getDateUrl">
-    <span v-if="date">{{ getDateFormatted(date) }}</span>
-    <span v-else-if="dateMissingAndShowError">
-      <i class="text-lowercase">{{ $t('Common.Date') }}</i>
-      <v-tooltip activator="parent" open-on-click location="top">
-        {{ $t('Common.DateMissing') }}
-      </v-tooltip>
+  <v-chip label size="small" density="comfortable" :color="dateMissingAndShowError ? 'error' : 'default'" :to="getDateUrl">
+    <v-icon :start="withLabel" :icon="DATE_ICON" />
+    <span v-if="date" :title="date">
+      <span v-if="withLabel">{{ getDateFormatted(date) }}</span>
     </span>
+    <span v-else-if="dateMissingAndShowError">
+      <i v-if="withLabel" class="text-lowercase">{{ $t('Common.Date') }}</i>
+    </span>
+    <v-tooltip v-if="dateMissingAndShowError" activator="parent" open-on-click location="top">
+      {{ $t('Common.DateMissing') }}
+    </v-tooltip>
   </v-chip>
 </template>
 
@@ -23,6 +26,10 @@ export default {
     showErrorIfDateMissing: {
       type: Boolean,
       default: false
+    },
+    withLabel: {
+      type: Boolean,
+      default: true
     },
     readonly: {
       type: Boolean,

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -5,7 +5,7 @@
         <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
         <LocationChip v-if="!hidePriceLocation" :location="price.location" :locationId="price.location_id" :showErrorIfLocationMissing="true" :readonly="readonly" />
         <UserChip v-if="!hidePriceOwner" :username="price.owner" :readonly="readonly" />
-        <DateChip v-if="!hidePriceDate" :date="price.date" :readonly="readonly" />
+        <DateChip v-if="!hidePriceDate" :date="price.date" :showErrorIfDateMissing="true" :withLabel="false" :readonly="readonly" />
         <UserCommentChip v-if="price.owner_comment" :comment="price.owner_comment" />
         <RelativeDateTimeChip v-if="!hidePriceCreated" :dateTime="price.created" />
       </span>

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -11,7 +11,7 @@
         <PriceCountChip v-if="!hidePriceCount" :count="proof.price_count" :withLabel="true" source="proof" @click="goToProof()" />
         <LocationChip :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
         <DateChip :date="proof.date" :showErrorIfDateMissing="true" :readonly="readonly" />
-        <CurrencyChip :currency="proof.currency" :showErrorIfCurrencyMissing="true" :withLabel="true" :readonly="readonly" />
+        <CurrencyChip :currency="proof.currency" :showErrorIfCurrencyMissing="true" :readonly="readonly" />
         <UserChip v-if="!hideProofOwner" :username="proof.owner" :readonly="readonly" />
         <UserCommentChip v-if="proof.owner_comment" :comment="proof.owner_comment" />
         <RelativeDateTimeChip :dateTime="proof.created" />

--- a/src/components/ProofTable.vue
+++ b/src/components/ProofTable.vue
@@ -13,7 +13,7 @@
       <DateChip :date="item.date" :readonly="true" />
     </template>
     <template #[`item.currency`]="{ item }">
-      <CurrencyChip :currency="item.currency" :withLabel="true" :readonly="true" />
+      <CurrencyChip :currency="item.currency" :readonly="true" />
     </template>
     <template #[`item.created`]="{ item }">
       <RelativeDateTimeChip :dateTime="item.created" />


### PR DESCRIPTION
### What

Following #2314 (price discount missing mgmt)
Here we improve the price date display when it is missing

### Screenshot

|Before|After|
|-|-|
|<img width="398" height="216" alt="image" src="https://github.com/user-attachments/assets/ce11464e-4b6a-479c-b14f-b4b27b1e886f" />|<img width="398" height="216" alt="image" src="https://github.com/user-attachments/assets/1b154d5e-270b-464f-bb29-9767306ac3e2" />|
