### PR TITLE
fix(Date Chip): when date is missing, never display label (remove withLabel prop)

### DIFF
--- a/src/components/DateChip.vue
+++ b/src/components/DateChip.vue
@@ -1,12 +1,7 @@
 <template>
   <v-chip label size="small" density="comfortable" :color="dateMissingAndShowError ? 'error' : 'default'" :to="getDateUrl">
-    <v-icon :start="withLabel" :icon="DATE_ICON" />
-    <span v-if="date" :title="date">
-      <span v-if="withLabel">{{ getDateFormatted(date) }}</span>
-    </span>
-    <span v-else-if="dateMissingAndShowError">
-      <i v-if="withLabel" class="text-lowercase">{{ $t('Common.Date') }}</i>
-    </span>
+    <v-icon :start="!dateMissingAndShowError" :icon="DATE_ICON" />
+    <span v-if="date" :title="date">{{ getDateFormatted(date) }}</span>
     <v-tooltip v-if="dateMissingAndShowError" activator="parent" open-on-click location="top">
       {{ $t('Common.DateMissing') }}
     </v-tooltip>
@@ -26,10 +21,6 @@ export default {
     showErrorIfDateMissing: {
       type: Boolean,
       default: false
-    },
-    withLabel: {
-      type: Boolean,
-      default: true
     },
     readonly: {
       type: Boolean,

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -5,7 +5,7 @@
         <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
         <LocationChip v-if="!hidePriceLocation" :location="price.location" :locationId="price.location_id" :showErrorIfLocationMissing="true" :readonly="readonly" />
         <UserChip v-if="!hidePriceOwner" :username="price.owner" :readonly="readonly" />
-        <DateChip v-if="!hidePriceDate" :date="price.date" :showErrorIfDateMissing="true" :withLabel="false" :readonly="readonly" />
+        <DateChip v-if="!hidePriceDate" :date="price.date" :showErrorIfDateMissing="true" :readonly="readonly" />
         <UserCommentChip v-if="price.owner_comment" :comment="price.owner_comment" />
         <RelativeDateTimeChip v-if="!hidePriceCreated" :dateTime="price.created" />
       </span>


### PR DESCRIPTION
### What

in #2315 we improved the behavior when the date is missing.
But we didn't manage very well the withLabel behavior, and the date was actually missing from perfectly valid prices.

Here we simplify and remove entirely the `withLabel` prop.
- if date : icon + label (date)
- if date missing : icon (red) + tooltip