### PR TITLE
fix(Currency Chip): when currency is missing, never display label (remove withLabel prop)

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -1,12 +1,7 @@
 <template>
   <v-chip label size="small" density="comfortable" :color="currencyMissingAndShowError ? 'error' : 'default'" :to="getCurrencyUrl">
-    <v-icon :start="withLabel" :icon="CURRENCY_ICON" />
-    <span v-if="currency" :title="currency">
-      <span v-if="withLabel">{{ currency }}</span>
-    </span>
-    <span v-else-if="currencyMissingAndShowError">
-      <i v-if="withLabel" class="text-lowercase">{{ $t('Common.Currency') }}</i>
-    </span>
+    <v-icon :start="!currencyMissingAndShowError" :icon="CURRENCY_ICON" />
+    <span v-if="currency" :title="currency">{{ currency }}</span>
     <v-tooltip v-if="currencyMissingAndShowError" activator="parent" open-on-click location="top">
       {{ $t('Common.CurrencyMissing') }}
     </v-tooltip>
@@ -25,10 +20,6 @@ export default {
     showErrorIfCurrencyMissing: {
       type: Boolean,
       default: false
-    },
-    withLabel: {
-      type: Boolean,
-      default: true
     },
     readonly: {
       type: Boolean,

--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -3,7 +3,7 @@
     <v-col cols="12" class="pt-2 pb-2">
       <span class="mr-1">{{ getPriceValueDisplay(price.price) }}</span>
       <span v-if="showPriceProductPerUnit" class="mr-1">({{ getPricePerUnit(price.price) }})</span>
-      <CurrencyChip v-if="!price.currency" :currency="price.currency" :showErrorIfCurrencyMissing="true" :withLabel="false" :readonly="readonly" />
+      <CurrencyChip v-if="!price.currency" :currency="price.currency" :showErrorIfCurrencyMissing="true" :readonly="readonly" />
       <PriceDiscountChip v-if="hasDiscount" class="ml-1 mr-1" :price="price" />
       <PriceQuantityPurchasedChip v-if="showReceiptQuantity" class="ml-1" :priceQuantityPurchased="price.receipt_quantity" />
     </v-col>


### PR DESCRIPTION
### What

Similar to #2327

in #2314 we improved the behavior when the currency is missing.
But we didn't manage very well the withLabel behavior, and the currency was actually missing from perfectly valid prices.

Here we simplify and remove entirely the withLabel prop.
- if currency : icon + label (date)
- if currency missing : icon (red) + tooltip