### PR TITLE
refactor(Location Chip): don't display label if location missing (same as date & currency)

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -17,7 +17,7 @@ export default {
       type: String,
       default: null
     },
-    showErrorIfCurrencyMissing: {
+    showErrorIfMissing: {
       type: Boolean,
       default: false
     },
@@ -33,7 +33,7 @@ export default {
   },
   computed: {
     currencyMissingAndShowError() {
-      return !this.currency && this.showErrorIfCurrencyMissing
+      return !this.currency && this.showErrorIfMissing
     },
     getCurrencyUrl() {
       return this.currency && !this.readonly ? `/currencies/${this.currency}` : null

--- a/src/components/DateChip.vue
+++ b/src/components/DateChip.vue
@@ -18,7 +18,7 @@ export default {
       type: String,
       default: null
     },
-    showErrorIfDateMissing: {
+    showErrorIfMissing: {
       type: Boolean,
       default: false
     },
@@ -34,7 +34,7 @@ export default {
   },
   computed: {
     dateMissingAndShowError() {
-      return !this.date && this.showErrorIfDateMissing
+      return !this.date && this.showErrorIfMissing
     },
     dateShort() {
       return date_utils.dateShort(this.date)

--- a/src/components/LocationChip.vue
+++ b/src/components/LocationChip.vue
@@ -1,13 +1,11 @@
 <template>
-  <v-chip label size="small" :prepend-icon="getLocationIcon" density="comfortable" :color="locationMissingAndShowError ? 'error' : 'default'" :to="getLocationUrl">
+  <v-chip label size="small" density="comfortable" :color="locationMissingAndShowError ? 'error' : 'default'" :to="getLocationUrl">
+    <v-icon :start="!locationMissingAndShowError" :icon="getLocationIcon" />
     <span v-if="locationNotMissing">{{ getLocationTitle }}</span>
     <span v-if="getLocationEmoji" style="margin-inline-start:5px">{{ getLocationEmoji }}</span>
-    <span v-else-if="locationMissingAndShowError">
-      <i class="text-lowercase">{{ $t('Common.Location') }}</i>
-      <v-tooltip activator="parent" open-on-click location="top">
-        {{ $t('Common.LocationMissing') }}
-      </v-tooltip>
-    </span>
+    <v-tooltip v-if="locationMissingAndShowError" activator="parent" open-on-click location="top">
+      {{ $t('Common.LocationMissing') }}
+    </v-tooltip>
   </v-chip>
 </template>
 
@@ -25,14 +23,14 @@ export default {
       type: Number,
       default: null
     },
+    showErrorIfLocationMissing: {
+      type: Boolean,
+      default: false
+    },
     readonly: {
       type: Boolean,
       default: false
     },
-    showErrorIfLocationMissing: {
-      type: Boolean,
-      default: false
-    }
   },
   computed: {
     getLocationTitle() {

--- a/src/components/LocationChip.vue
+++ b/src/components/LocationChip.vue
@@ -23,7 +23,7 @@ export default {
       type: Number,
       default: null
     },
-    showErrorIfLocationMissing: {
+    showErrorIfMissing: {
       type: Boolean,
       default: false
     },
@@ -58,7 +58,7 @@ export default {
       return this.location || this.locationId
     },
     locationMissingAndShowError() {
-      return !this.locationNotMissing && this.showErrorIfLocationMissing
+      return !this.locationNotMissing && this.showErrorIfMissing
     },
     getLocationUrl() {
       return this.locationId && !this.readonly ? `/locations/${this.locationId}` : null

--- a/src/components/PriceFooterRow.vue
+++ b/src/components/PriceFooterRow.vue
@@ -3,9 +3,9 @@
     <v-col :cols="hideActionMenuButton ? '12' : '11'">
       <span class="chip-group">
         <ProofChip v-if="price.proof && !hidePriceProof" :proof="price.proof" />
-        <LocationChip v-if="!hidePriceLocation" :location="price.location" :locationId="price.location_id" :showErrorIfLocationMissing="true" :readonly="readonly" />
+        <LocationChip v-if="!hidePriceLocation" :location="price.location" :locationId="price.location_id" :showErrorIfMissing="true" :readonly="readonly" />
         <UserChip v-if="!hidePriceOwner" :username="price.owner" :readonly="readonly" />
-        <DateChip v-if="!hidePriceDate" :date="price.date" :showErrorIfDateMissing="true" :readonly="readonly" />
+        <DateChip v-if="!hidePriceDate" :date="price.date" :showErrorIfMissing="true" :readonly="readonly" />
         <UserCommentChip v-if="price.owner_comment" :comment="price.owner_comment" />
         <RelativeDateTimeChip v-if="!hidePriceCreated" :dateTime="price.created" />
       </span>

--- a/src/components/PricePriceRow.vue
+++ b/src/components/PricePriceRow.vue
@@ -3,7 +3,7 @@
     <v-col cols="12" class="pt-2 pb-2">
       <span class="mr-1">{{ getPriceValueDisplay(price.price) }}</span>
       <span v-if="showPriceProductPerUnit" class="mr-1">({{ getPricePerUnit(price.price) }})</span>
-      <CurrencyChip v-if="!price.currency" :currency="price.currency" :showErrorIfCurrencyMissing="true" :readonly="readonly" />
+      <CurrencyChip v-if="!price.currency" :currency="price.currency" :showErrorIfMissing="true" :readonly="readonly" />
       <PriceDiscountChip v-if="hasDiscount" class="ml-1 mr-1" :price="price" />
       <PriceQuantityPurchasedChip v-if="showReceiptQuantity" class="ml-1" :priceQuantityPurchased="price.receipt_quantity" />
     </v-col>

--- a/src/components/ProofFooterRow.vue
+++ b/src/components/ProofFooterRow.vue
@@ -9,9 +9,9 @@
         <ProofReceiptPriceTotalChip v-if="showReceiptPriceTotal" :totalCount="proof.receipt_price_total" :currency="proof.currency" />
         <ProofReceiptOnlineDeliveryCostsChip v-if="showReceiptOnlineDeliveryCosts" :price="proof.receipt_online_delivery_costs" :currency="proof.currency" />
         <PriceCountChip v-if="!hidePriceCount" :count="proof.price_count" :withLabel="true" source="proof" @click="goToProof()" />
-        <LocationChip :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfLocationMissing="true" />
-        <DateChip :date="proof.date" :showErrorIfDateMissing="true" :readonly="readonly" />
-        <CurrencyChip :currency="proof.currency" :showErrorIfCurrencyMissing="true" :readonly="readonly" />
+        <LocationChip :location="proof.location" :locationId="proof.location_id" :readonly="readonly" :showErrorIfMissing="true" />
+        <DateChip :date="proof.date" :showErrorIfMissing="true" :readonly="readonly" />
+        <CurrencyChip :currency="proof.currency" :showErrorIfMissing="true" :readonly="readonly" />
         <UserChip v-if="!hideProofOwner" :username="proof.owner" :readonly="readonly" />
         <UserCommentChip v-if="proof.owner_comment" :comment="proof.owner_comment" />
         <RelativeDateTimeChip :dateTime="proof.created" />


### PR DESCRIPTION
### What

Following recent fix in the DateChip (#2327) & CurrencyChip (#2328) - hiding the label if the data is missing - we do the same for the LocationChip to homogenize.

We also rename the props to a common `showErrorIfMissing`
