### PR TITLE
fix(Receipt Assistant): allow prices with an empty product_name

### DIFF
--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -273,7 +273,7 @@ export default {
           proof_id: this.proofObject.id,
           currency: this.proofObject.currency,
           price: receiptItems[i].price || receiptItems[i].predicted_data.price,
-          product_name: receiptItems[i].product_name || receiptItems[i].predicted_data.product_name
+          product_name: receiptItems[i].product_name || receiptItems[i]?.predicted_data?.product_name
         }
         if (receiptItems[i].price_id) {
           openPricesApi.updatePrice(receiptItems[i].price_id, priceData).then((price) => {


### PR DESCRIPTION
### What

When manually adding price items, if the Text column (`product_name` field) wasn't filled, it would return an error

```
Uncaught TypeError: can't access property "product_name", receiptItems[i].predicted_data is undefined
```

### Screenshot

<img width="785" height="253" alt="image" src="https://github.com/user-attachments/assets/502ff856-ba8f-4724-8b14-c63a64301a52" />
