### PR TITLE
refactor(Challenge): Home: show 'Ending soon' chip on promo banner if ending in less than 7 days

### DIFF
--- a/src/components/ChallengeCurrentPromoBanner.vue
+++ b/src/components/ChallengeCurrentPromoBanner.vue
@@ -10,6 +10,7 @@
       <h3 class="text-h6 mb-1">
         {{ $t('Challenge.Title') }}
         <NewChip v-if="isNew" />
+        <EndingSoonChip v-else-if="isEndingSoon" />
       </h3>
       <p>
         {{ $t('Challenge.Subtitle', {challenge_title: `${challenge.icon} ${challenge.title} ${challenge.icon}`, challenge_subtitle: challenge.subtitle}) }}
@@ -28,7 +29,8 @@ import constants from '../constants'
 
 export default {
   components: {
-    NewChip: defineAsyncComponent(() => import('./NewChip.vue'))
+    NewChip: defineAsyncComponent(() => import('./NewChip.vue')),
+    EndingSoonChip: defineAsyncComponent(() => import('./EndingSoonChip.vue')),
   },
   props: {
     challenge: {
@@ -49,6 +51,14 @@ export default {
       const startDate = new Date(this.challenge.start_date)
       const sevenDaysFromStartDate = new Date(startDate.getTime() + 7 * 24 * 60 * 60 * 1000)
       return today <= sevenDaysFromStartDate
+    },
+    isEndingSoon() {
+      // a challenge usually lasts 1 month
+      // ending soon = last 7 days of the challenge
+      const today = new Date()
+      const endDate = new Date(this.challenge.end_date)
+      const sevenDaysBeforeEndDate = new Date(endDate.getTime() - 7 * 24 * 60 * 60 * 1000)
+      return today >= sevenDaysBeforeEndDate
     },
     getUrl() {
       return `/challenge`

--- a/src/components/EndingSoonChip.vue
+++ b/src/components/EndingSoonChip.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-chip class="text-uppercase" size="small" color="warning" variant="flat">
+    {{ $t('Common.EndingSoon') }}
+  </v-chip>
+</template>
+
+<script>
+</script>
+
+<style scoped>
+</style>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -253,6 +253,7 @@
 		"DisplayPriceMap": "Map",
 		"DisplayPriceChart": "Chart",
 		"Done": "Done",
+		"EndingSoon": "Ending soon",
 		"Error": "Error",
 		"Experiment": "Experiment",
 		"Experiments": "Experiments",


### PR DESCRIPTION
### What

Similar to #2335 ("new" chip)

Challenge promo banner: add a "ending soon" tag if ending in less than 7 days

### Screenshot

|theme|image|
|-|-|
|dark mode|<img width="880" height="93" alt="Screenshot from 2026-08-16 12-49-50" src="https://github.com/user-attachments/assets/d7c380f8-1f74-432b-9355-1380daa0863e" />|
|light mode|<img width="880" height="93" alt="Screenshot from 2026-08-16 12-49-59" src="https://github.com/user-attachments/assets/6f7644d7-31aa-4fa1-b468-b0c5a7c12945" />|