### PR TITLE
refactor(User Comment Chip): replace 'title' with explicit tooltip (fixes interaction on mobile)

### DIFF
--- a/src/components/CurrencyChip.vue
+++ b/src/components/CurrencyChip.vue
@@ -1,7 +1,7 @@
 <template>
   <v-chip label size="small" density="comfortable" :color="currencyMissingAndShowError ? 'error' : 'default'" :to="getCurrencyUrl">
     <v-icon :start="!currencyMissingAndShowError" :icon="CURRENCY_ICON" />
-    <span v-if="currency" :title="currency">{{ currency }}</span>
+    <span v-if="currency">{{ currency }}</span>
     <v-tooltip v-if="currencyMissingAndShowError" activator="parent" open-on-click location="top">
       {{ $t('Common.CurrencyMissing') }}
     </v-tooltip>

--- a/src/components/UserCommentChip.vue
+++ b/src/components/UserCommentChip.vue
@@ -1,6 +1,9 @@
 <template>
-  <v-chip label size="small" variant="flat" density="comfortable" :title="comment">
+  <v-chip label size="small" variant="flat" density="comfortable">
     <v-icon :icon="USER_COMMENT_ICON" />
+    <v-tooltip activator="parent" open-on-click location="top">
+      {{ comment }}
+    </v-tooltip>
   </v-chip>
 </template>
 


### PR DESCRIPTION
### What

On mobile, it's hard (impossible ?) to interact with an html element that has a `title` property.

### Screenshot

|Before|After|
|-|-|
|<img width="621" height="250" alt="image" src="https://github.com/user-attachments/assets/1ff1ea99-4e89-44dd-bd14-e42e6895f35a" />|<img width="332" height="283" alt="image" src="https://github.com/user-attachments/assets/60853576-47d7-4012-9eb6-4765bc66c615" />|
