### PR TITLE
refactor(Badge Card): display more metrics & thresholds (new badges) (more complex)

### DIFF
--- a/src/components/BadgeCard.vue
+++ b/src/components/BadgeCard.vue
@@ -11,6 +11,7 @@
               <h3>{{ badge.name }}</h3>
               <p>{{ badge.description }}</p>
               <CountChip v-if="getCountChipKindFromBadgeMetric(badge.metric)" class="mr-2" :kind="getCountChipKindFromBadgeMetric(badge.metric)" :count="badge.threshold" :withLabel="true" />
+              <ProofTypeChip v-if="getProofTypeFromBadgeMetric(badge.metric)" class="mr-2" :kind="getProofTypeFromBadgeMetric(badge.metric)" />
               <DateChip v-if="achievedAt" :title="$t('Common.BadgeAchievementDate')" :date="achievedAt" :readonly="true" />
             </v-col>
           </v-row>
@@ -35,6 +36,7 @@ import constants from '../constants'
 export default {
   components: {
     CountChip: defineAsyncComponent(() => import('../components/CountChip.vue')),
+    ProofTypeChip: defineAsyncComponent(() => import('../components/ProofTypeChip.vue')),
     DateChip: defineAsyncComponent(() => import('../components/DateChip.vue')),
   },
   props: {
@@ -69,17 +71,38 @@ export default {
     getCountChipKindFromBadgeMetric(metric) {
       switch (metric) {
         case 'price_count':
+        case 'price_in_proof_not_owned_count':
           return 'price'
         case 'proof_count':
+        case 'proof_type_price_tag_count':
+        case 'proof_type_receipt_count':
+        case 'proof_type_gdpr_request_count':
+        case 'proof_type_shop_import_count':
           return 'proof'
         case 'location_count':
           return 'location'
+        case 'location_type_osm_city_count':
+          return 'city'
         case 'location_type_osm_country_count':
           return 'country'
-        case 'year_count':
-          return 'year'
         case 'challenge_count':
           return 'challenge'
+        case 'year_count':
+          return 'year'
+        default:
+          return null
+      }
+    },
+    getProofTypeFromBadgeMetric(metric) {
+      switch (metric) {
+        case 'proof_type_price_tag_count':
+          return constants.PROOF_TYPE_PRICE_TAG
+        case 'proof_type_receipt_count':
+          return constants.PROOF_TYPE_RECEIPT
+        case 'proof_type_gdpr_request_count':
+          return constants.PROOF_TYPE_GDPR_REQUEST
+        case 'proof_type_shop_import_count':
+          return constants.PROOF_TYPE_SHOP_IMPORT
         default:
           return null
       }


### PR DESCRIPTION
### What

Following #2285 & #2347
- add more metric/threshold details
- manage "double filters" like "proof_count & type=shop_import"

### Screenshot

|Before|After|
|-|-|
|<img width="894" height="922" alt="image" src="https://github.com/user-attachments/assets/ca2f1e91-c3d1-4676-8d78-7673a976e09b" />|<img width="894" height="950" alt="image" src="https://github.com/user-attachments/assets/33c955f4-72d3-42b4-9c33-31a3624f9897" />|
