### PR TITLE
fix(OFF Link): fallback to the world URL when the user country is unset

### DIFF
--- a/src/components/OpenFoodFactsAddMenu.vue
+++ b/src/components/OpenFoodFactsAddMenu.vue
@@ -57,7 +57,9 @@ export default {
     },
     getSourceAddUrlWithLocale(source) {
       const SOURCE_ADD_URL = `${this.getSourceUrl(source)}/cgi/product.pl?type=search_or_add&action=process&code=${this.productCode}`
-      return SOURCE_ADD_URL.replace('world', this.appStore.user.country.toLowerCase())
+      // user.country can be null/undefined (unset in settings, older persisted state): keep the 'world' URL
+      const country = this.appStore.user.country
+      return country ? SOURCE_ADD_URL.replace('world', country.toLowerCase()) : SOURCE_ADD_URL
     },
   }
 }

--- a/src/components/OpenFoodFactsLink.vue
+++ b/src/components/OpenFoodFactsLink.vue
@@ -63,7 +63,9 @@ export default {
       return this.OFF_URL
     },
     getUrlWithLocale() {
-      return this.getSourceUrl.replace('world', this.appStore.user.country.toLowerCase())
+      // user.country can be null/undefined (unset in settings, older persisted state): keep the 'world' URL
+      const country = this.appStore.user.country
+      return country ? this.getSourceUrl.replace('world', country.toLowerCase()) : this.getSourceUrl
     },
     getUrl() {
       if (this.facet && this.value) {


### PR DESCRIPTION
Fixes #2346

## Problem

Sentry reports `TypeError: null is not an object (evaluating 'this.appStore.user.country.toLowerCase')` in `getUrlWithLocale` (`OpenFoodFactsLink.vue`). `OpenFoodFactsAddMenu.vue` has the same unguarded call in `getSourceAddUrlWithLocale`.

`appStore.user.country` can be `null`/`undefined` — e.g. the country autocomplete in Settings left empty, or an older persisted state without the field — and then every render of an `OpenFoodFactsLink` (brand/category/label cards, product pages…) throws.

## Fix

When no country is set, keep the default `world.` URL instead of trying to localise it. Behaviour with a country set is unchanged. Same guard applied in both components.

## Verification

Reproduced with an SSR render of `OpenFoodFactsLink` through Vite (Pinia store with `user.country` forced to `null` / `undefined` / `'FR'`) and by calling `OpenFoodFactsAddMenu.getSourceAddUrlWithLocale` directly:

Before:
```
country=null      -> link: THROWS "Cannot read properties of null (reading 'toLowerCase')"   addMenu: THROWS (same)
country=undefined -> link: THROWS "Cannot read properties of undefined (reading 'toLowerCase')"  addMenu: THROWS (same)
country=FR        -> https://fr.openfoodfacts.org/brand/lidl
```
After:
```
country=null      -> https://world.openfoodfacts.org/brand/lidl   addMenu: https://world.openfoodfacts.org/cgi/product.pl?...
country=undefined -> https://world.openfoodfacts.org/brand/lidl   addMenu: https://world.openfoodfacts.org/cgi/product.pl?...
country=FR        -> https://fr.openfoodfacts.org/brand/lidl      (unchanged)
```

- `eslint --max-warnings=0` clean on both changed files (the repo-wide warnings are pre-existing in other files)
- `vite build` succeeds

Disclosure: prepared with AI assistance (Claude Code); the change and its verification were reviewed by me.