### PR TITLE
fix(Brand Detail): don't crash when the API returns an error payload

### DIFF
--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -101,9 +101,11 @@ export default {
       this.brandProductPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
+          this.loading = false
+          // error payload (e.g. 404 "Invalid page." or 400 "Maximum page reached"): no items to add
+          if (!data.items) return
           this.brandProductList.push(...data.items)
           this.brandProductTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -102,7 +102,6 @@ export default {
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
           this.loading = false
-          // error payload (e.g. 404 "Invalid page." or 400 "Maximum page reached"): no items to add
           if (!data.items) return
           this.brandProductList.push(...data.items)
           this.brandProductTotal = data.total


### PR DESCRIPTION
Fixes #2344 (Sentry `OPEN-PRICES-FRONTEND-18`: `TypeError: t.items is not iterable` in `BrandDetail`).

## Problem

`getBrandProducts()` does `this.brandProductList.push(...data.items)` unconditionally, but `GET /api/v1/products` can answer with an error payload that has no `items`:

| request | response |
|---|---|
| page past the last one (`?brands__like=zzqqxx&page=2`) | `404 {"detail":"Invalid page."}` |
| page ≥ 1000 | `400 {"detail":"Maximum page reached. See … for alternate ways to access the data."}` |

The first case is easy to hit in normal use: the scroll handler has no in-flight guard, so while the last page is still loading any further scroll event increments `brandProductPage` again and requests a page that doesn't exist. `data.items` is then `undefined` and the spread throws.

### Reproduction (before)

Local mock of the API (30 products → 2 pages of 25, page 2 delayed a few seconds, page > 2 returns the real `404 {"detail":"Invalid page."}` body), `npm run dev`, open `/brands/carrefour`, scroll to the bottom and keep scrolling while the spinner is visible. Mock log:

```
GET /api/v1/products?…&page=2&size=25&brands__like=carrefour… -> page 2
GET /api/v1/products?…&page=3&size=25&brands__like=carrefour… -> page 3
  responding 404 {"detail":"Invalid page."}
GET /api/v1/products?…&page=4&size=25&brands__like=carrefour… -> page 4
  responding 404 {"detail":"Invalid page."}
```

Browser console:

```
TypeError: data.items is not iterable (cannot read property undefined)
    at src/views/BrandDetail.vue:71:33
TypeError: data.items is not iterable (cannot read property undefined)
    at src/views/BrandDetail.vue:71:33
```

## Fix

Return early when the payload has no `items` — the same guard `BadgeDetail`, `LocationDetail` and `ProofDetail` already use — and set `loading = false` before it so the spinner doesn't stay on screen.

## Verification

- Same scenario after the fix: the mock still logs the two `404 Invalid page.` responses, the console has no exception, all 30 products render (`30 / 30`) and the spinner disappears.
- `npm run lint`: 0 errors (42 pre-existing warnings, none in `BrandDetail.vue`).

Note: most other list views (`CategoryDetail`, `LabelDetail`, `PriceList`, `ProductList`, `ProofList`, …) spread `data.items` the same way and would throw on the same payloads; I kept this PR to the view named in the Sentry issue, happy to apply the guard elsewhere in a follow-up if you'd like.
