### PR TITLE
feat(Challenge): add a card linking to Hunger Games to categorize products

### DIFF
--- a/src/components/ChallengeCategoriesCard.vue
+++ b/src/components/ChallengeCategoriesCard.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-card
+    class="d-flex flex-column"
+    :title="$t('Challenge.StepCategories.Title')"
+  >
+    <v-card-text class="flex-grow-1 pb-0">
+      <p class="mb-2">
+        {{ $t('Challenge.StepCategories.line1', { name: OFF_NAME }) }}
+      </p>
+      <p class="mb-2">
+        {{ $t('Challenge.StepCategories.line2') }}
+      </p>
+      <p class="mb-2">
+        {{ $t('Challenge.StepCategories.line3') }}
+      </p>
+      <p class="mb-2">
+        {{ $t('Challenge.StepCategories.line4') }}
+      </p>
+      <p class="mb-2">
+        <v-chip
+          v-for="category in challenge.categories"
+          :key="category"
+          label
+          color="primary"
+          variant="flat"
+          size="small"
+          density="comfortable"
+          append-icon="mdi-open-in-new"
+          class="mr-1 mb-1"
+          :href="getHungerGamesCategoryUrl(category)"
+          target="_blank"
+        >
+          {{ categoryLocalizedNames[category] || category }}
+        </v-chip>
+      </p>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import { mapStores } from 'pinia'
+import { useAppStore } from '../store'
+import constants from '../constants'
+import data_utils from '../utils/data.js'
+
+export default {
+  props: {
+    challenge: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  data() {
+    return {
+      OFF_NAME: constants.OFF_NAME,
+      categoryLocalizedNames: {},  // see mounted
+    }
+  },
+  computed: {
+    ...mapStores(useAppStore),
+  },
+  mounted() {
+    this.setCategoryLocalizedNames()
+  },
+  methods: {
+    setCategoryLocalizedNames() {
+      this.challenge.categories.forEach((category) => {
+        data_utils.getLocaleCategoryTagName(this.appStore.getUserLanguage, category).then((categoryName) => {
+          this.categoryLocalizedNames[category] = categoryName
+        })
+      })
+    },
+    getHungerGamesCategoryUrl(category) {
+      const params = new URLSearchParams({ type: 'category', value_tag: category, sorted: 'true' })
+      return `${constants.OFF_HUNGER_GAMES_URL}/questions?${params.toString()}`
+    }
+  }
+}
+</script>

--- a/src/components/ChallengeCategoriesCard.vue
+++ b/src/components/ChallengeCategoriesCard.vue
@@ -17,21 +17,23 @@
         {{ $t('Challenge.StepCategories.line4') }}
       </p>
       <p class="mb-2">
-        <v-chip
-          v-for="category in challenge.categories"
-          :key="category"
-          label
-          color="primary"
-          variant="flat"
-          size="small"
-          density="comfortable"
-          append-icon="mdi-open-in-new"
-          class="mr-1 mb-1"
-          :href="getHungerGamesCategoryUrl(category)"
-          target="_blank"
-        >
-          {{ categoryLocalizedNames[category] || category }}
-        </v-chip>
+        <span class="chip-group">
+          <v-chip
+            v-for="category in challenge.categories"
+            :key="category"
+            label
+            color="primary"
+            variant="flat"
+            size="small"
+            density="comfortable"
+            append-icon="mdi-open-in-new"
+            class="mr-1 mb-1"
+            :href="getHungerGamesCategoryUrl(category)"
+            target="_blank"
+          >
+            {{ categoryLocalizedNames[category] || category }}
+          </v-chip>
+        </span>
       </p>
     </v-card-text>
   </v-card>

--- a/src/constants.js
+++ b/src/constants.js
@@ -84,6 +84,7 @@ export default {
   OFF_API_URL: 'https://world.openfoodfacts.org/api/v2/product',
   OFF_SEARCHALICIOUS_API_URL: 'https://search.openfoodfacts.org',
   OFF_CROWDIN_URL: 'https://translate.openfoodfacts.org',
+  OFF_HUNGER_GAMES_URL: 'https://hunger.openfoodfacts.org',
   OBF_NAME: OBF_NAME,
   OBF_URL: 'https://world.openbeautyfacts.org',
   OBF_ICON: OBF_ICON,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,7 +148,7 @@
 			"line1": "Many products belong to the challenge categories but are not yet categorized as such in {name}, so their prices don't count towards the challenge.",
 			"line2": "Hunger Games is a game where you confirm the categories our robots have guessed for products. Answering the questions for the challenge categories will add the missing products.",
 			"line3": "Questions are grouped by sub-category, so the game will first show you a list of sub-categories to choose from.",
-			"line4": "Pick a category to start playing:"
+			"line4": "Pick a category to start playing!"
 		},
 		"PicturesAddedByYou": "Pictures added by you",
 		"Prices": "{challenge_title} prices",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -143,6 +143,13 @@
 			"line3": "If you're having trouble reading the label, mark it as unreadable.",
 			"line4": "This is a collaborative effort, even if you didn't send pictures, you can still help others by validating."
 		},
+		"StepCategories": {
+			"Title": "Add products to the categories",
+			"line1": "Many products belong to the challenge categories but are not yet categorized as such in {name}, so their prices don't count towards the challenge.",
+			"line2": "Hunger Games is a game where you confirm the categories our robots have guessed for products. Answering the questions for the challenge categories will add the missing products.",
+			"line3": "Questions are grouped by sub-category, so the game will first show you a list of sub-categories to choose from.",
+			"line4": "Pick a category to start playing:"
+		},
 		"PicturesAddedByYou": "Pictures added by you",
 		"Prices": "{challenge_title} prices",
 		"PricesAdded": "{challenge_title} prices added",

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -28,10 +28,10 @@
         {{ $t('About.HowContribute') }}
       </h2>
     </v-col>
-    <v-col cols="12" md="4">
+    <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
       <ChallengeTakePicturesCard :challenge="challenge" />
     </v-col>
-    <v-col cols="12" md="4">
+    <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
       <ChallengeValidateCard :challenge="challenge" height="100%" />
     </v-col>
     <v-col v-if="challenge.categories.length" cols="12" md="4">

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -28,11 +28,14 @@
         {{ $t('About.HowContribute') }}
       </h2>
     </v-col>
-    <v-col cols="12" md="6">
+    <v-col cols="12" md="4">
       <ChallengeTakePicturesCard :challenge="challenge" />
     </v-col>
-    <v-col cols="12" md="6">
+    <v-col cols="12" md="4">
       <ChallengeValidateCard :challenge="challenge" height="100%" />
+    </v-col>
+    <v-col v-if="challenge.categories.length" cols="12" md="4">
+      <ChallengeCategoriesCard :challenge="challenge" height="100%" />
     </v-col>
   </v-row>
 
@@ -120,6 +123,7 @@ export default {
     ChallengeTimeline: defineAsyncComponent(() => import('../components/ChallengeTimeline.vue')),
     ChallengeTakePicturesCard: defineAsyncComponent(() => import('../components/ChallengeTakePicturesCard.vue')),
     ChallengeValidateCard: defineAsyncComponent(() => import('../components/ChallengeValidateCard.vue')),
+    ChallengeCategoriesCard: defineAsyncComponent(() => import('../components/ChallengeCategoriesCard.vue')),
     StatCard: defineAsyncComponent(() => import('../components/StatCard.vue')),
     RankingTableCard: defineAsyncComponent(() => import('../components/RankingTableCard.vue')),
     StatsLastUpdatedAlert: defineAsyncComponent(() => import('../components/StatsLastUpdatedAlert.vue')),


### PR DESCRIPTION
### What

Closes #2341

Adds a third "How can I contribute?" card on the challenge page: **Add products to the categories**. It explains that many products belong to the challenge categories but aren't categorized as such yet (so their prices don't count), and links, per challenge category, to the Hunger Games category questions:

`https://hunger.openfoodfacts.org/questions?type=category&value_tag=<category>&sorted=true`

- one chip per `challenge.categories` entry (same style as the category chips at the top of the page, so long tags like `en:potatoes-and-their-products` wrap instead of overflowing), opening in a new tab
- labels reuse the same localized category names as `CategoryTagChip` (falls back to the raw tag when the local subset doesn't have it)
- the card is only rendered when the challenge has categories
- the three cards are now `md="4"` each
- new `OFF_HUNGER_GAMES_URL` constant; new `Challenge.StepCategories.*` strings in `en.json` (other locales via Crowdin)
- the copy warns that questions are grouped by sub-category, so the game first shows a list of sub-categories to pick from (as noted in the issue)

### Verification

- `yarn lint` (eslint): no errors, no new warnings
- Ran `vite --mode prod` locally against the production API and checked in Chrome:
  - `/challenges/15` (1 category): card rendered, link is `https://hunger.openfoodfacts.org/questions?type=category&value_tag=en:condiments&sorted=true`, `target="_blank"`
  - `/challenges/11` (6 categories): 6 chips wrap cleanly, `Potatoes` gets its localized name, the others fall back to the tag
  - opening the link lands on Hunger Games with the `category` / `value: en:condiments` / `popularity` filters applied and the sub-category list shown
  - before the change the page had only the two existing cards and no Hunger Games link

