### PR TITLE
fix(Lists): don't crash when the API returns an error payload

### DIFF
--- a/src/components/UserRecentProofsDialog.vue
+++ b/src/components/UserRecentProofsDialog.vue
@@ -121,9 +121,10 @@ export default {
       this.userProofPage += 1
       return openPricesApi.getProofs(this.getProofParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.userProofList.push(...data.items)
           this.userProofTotal = data.total
-          this.loading = false
         })
         .catch((error) => {
           console.error(error)

--- a/src/views/BadgeList.vue
+++ b/src/views/BadgeList.vue
@@ -60,9 +60,10 @@ export default {
       this.badgePage += 1
       openPricesApi.getBadges(this.getBadgesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.badgeList.push(...data.items)
           this.badgeTotal = data.total
-          this.loading = false
         })
     },
   },

--- a/src/views/CategoryDetail.vue
+++ b/src/views/CategoryDetail.vue
@@ -103,9 +103,10 @@ export default {
       this.categoryProductPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.categoryProductList.push(...data.items)
           this.categoryProductTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ChallengeList.vue
+++ b/src/views/ChallengeList.vue
@@ -121,9 +121,10 @@ export default {
       this.challengePage += 1
       return openPricesApi.getChallenges(this.getChallengesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.challengeList.push(...data.items)
           this.challengeTotal = data.total
-          this.loading = false
         })
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars

--- a/src/views/ChallengePriceList.vue
+++ b/src/views/ChallengePriceList.vue
@@ -101,9 +101,10 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ChallengeProofList.vue
+++ b/src/views/ChallengeProofList.vue
@@ -104,9 +104,10 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
-          this.loading = false
         })
     },
     handleProofUpdated() {

--- a/src/views/CountryCityDetail.vue
+++ b/src/views/CountryCityDetail.vue
@@ -113,9 +113,10 @@ export default {
       this.countryCityLocationPage += 1
       return openPricesApi.getLocations(this.getLocationsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.countryCityLocationList.push(...data.items)
           this.countryCityLocationTotal = data.total
-          this.loading = false
         })
     },
     updateDisplay(displayKey) {

--- a/src/views/CountryDetail.vue
+++ b/src/views/CountryDetail.vue
@@ -111,9 +111,10 @@ export default {
       this.countryLocationPage += 1
       return openPricesApi.getLocations(this.getLocationsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.countryLocationList.push(...data.items)
           this.countryLocationTotal = data.total
-          this.loading = false
         })
     },
     updateDisplay(displayKey) {

--- a/src/views/CurrencyDetail.vue
+++ b/src/views/CurrencyDetail.vue
@@ -92,9 +92,10 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
-          this.loading = false
         })
     },
     updateOrder(orderKey) {

--- a/src/views/DateDetail.vue
+++ b/src/views/DateDetail.vue
@@ -133,6 +133,8 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
           data.items.forEach((price) => {
@@ -140,7 +142,6 @@ export default {
               utils.addObjectToArray(this.priceLocationList, price.location)
             }
           })
-          this.loading = false
         })
     },
     updateOrder(orderKey) {

--- a/src/views/LabelDetail.vue
+++ b/src/views/LabelDetail.vue
@@ -103,9 +103,10 @@ export default {
       this.labelProductPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.labelProductList.push(...data.items)
           this.labelProductTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -93,9 +93,10 @@ export default {
       this.locationPage += 1
       return openPricesApi.getLocations(this.getLocationsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.locationList.push(...data.items)
           this.locationTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/LocationProofList.vue
+++ b/src/views/LocationProofList.vue
@@ -104,9 +104,10 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
-          this.loading = false
         })
     },
     handleProofUpdated() {

--- a/src/views/ModerationDashboard.vue
+++ b/src/views/ModerationDashboard.vue
@@ -134,9 +134,10 @@ export default {
       this.flagPage += 1
       return openPricesApi.getFlags(this.getFlagsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.flagList.push(...data.items)
           this.flagTotal = data.total
-          this.loading = false
         })
     },
     getFlagObjectUrl(flag) {

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -289,8 +289,9 @@ export default {
       this.loading = true
       return openPricesApi.getPrices({ proof_id: this.proofObject.id, size: this.proofObject.price_count, order_by: 'created' })
         .then((data) => {
-          this.proofPriceExistingList.push(...data.items)
           this.loading = false
+          if (!data.items) return
+          this.proofPriceExistingList.push(...data.items)
         })
     },
     clearProductPriceForm() {

--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -179,9 +179,10 @@ export default {
       this.priceTagPage += 1
       return openPricesApi.getPriceTags(this.getPriceTagsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.priceTagList.push(...data.items)
           this.priceTagTotal = data.total
-          this.loading = false
           for (let i = 0; i < data.items.length; i++) {
             // only validate price tags with predictions
             if (data.items[i]['predictions'].filter(prediction => prediction.type === 'PRICE_TAG_EXTRACTION').length > 0) {

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -100,9 +100,10 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -202,8 +202,7 @@ export default {
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
           this.loading = false
-          // product not found: the API will return an empty list
-          // if (!data.items) return
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
           data.items.forEach((price) => {

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -96,9 +96,10 @@ export default {
       this.productPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.productList.push(...data.items)
           this.productTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ProofList.vue
+++ b/src/views/ProofList.vue
@@ -91,9 +91,10 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -108,9 +108,10 @@ export default {
         const code = barcodeUtils.normalizeBarcode(this.productSearchForm.q)
         return openPricesApi.getProducts({ code: code })
           .then((data) => {
+            this.loading = false
+            if (!data.items) return
             this.productList.push(...data.items)
             this.productTotal = data.total
-            this.loading = false
             if (data.items.length) {
               this.getProductLatestPrices()
             }

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -128,6 +128,8 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
           data.items.forEach((price) => {
@@ -135,7 +137,6 @@ export default {
               utils.addObjectToArray(this.priceLocationList, price.location)
             }
           })
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -136,6 +136,8 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
           data.items.forEach((proof) => {
@@ -143,7 +145,6 @@ export default {
               utils.addObjectToArray(this.proofLocationList, proof.location)
             }
           })
-          this.loading = false
         })
     },
     handleProofUpdated() {

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -134,8 +134,7 @@ export default {
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
           this.loading = false
-          // user not found: the API will return an empty list
-          // if (!data.items) return
+          if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
         })

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -88,9 +88,10 @@ export default {
       this.userPage += 1
       return openPricesApi.getUsers(this.getUsersParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.userList.push(...data.items)
           this.userTotal = data.total
-          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/UserProofList.vue
+++ b/src/views/UserProofList.vue
@@ -104,9 +104,10 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
+          this.loading = false
+          if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
-          this.loading = false
         })
     },
     handleProofUpdated() {


### PR DESCRIPTION
Follow-up to #2357 (#2344, Sentry `OPEN-PRICES-FRONTEND-18`), as discussed in https://github.com/openfoodfacts/open-prices-frontend/pull/2357#discussion_r3879989506.

## Problem

Every other paginated list view does `this.xList.push(...data.items)` unconditionally. When the API answers with an error payload that has no `items` — `404 {"detail":"Invalid page."}` for a page past the last one (easy to hit: the scroll handlers have no in-flight guard, so scrolling while the last page is loading requests the next one), or `400 {"detail":"Maximum page reached…"}` for page ≥ 1000 — the spread throws and `loading` stays `true`.

### Reproduction (before)

Local proxy in front of the real API that answers any `?page=2` request with the API's real `404 {"detail":"Invalid page."}` body, `npm run dev`, scroll to the bottom of the page:

```
GET /api/v1/prices?page=2&size=25&order_by=-created -> 404 {"detail":"Invalid page."}
GET /api/v1/products?page=2&size=25&order_by=-price_count -> 404 {"detail":"Invalid page."}
GET /api/v1/products?page=2&size=25&categories_tags__contains=en%3Abreakfast-cereals&order_by=-price_count -> 404 {"detail":"Invalid page."}
```

```
TypeError: data.items is not iterable (cannot read property undefined)   at src/views/PriceList.vue:78
TypeError: data.items is not iterable (cannot read property undefined)   at src/views/ProductList.vue:74
TypeError: data.items is not iterable (cannot read property undefined)   at src/views/CategoryDetail.vue:73
```

## Fix

Same guard `BadgeDetail`, `BrandDetail`, `LocationDetail`, `ProofDetail` and `UserBadgeList` already use, applied to the 26 remaining call sites: `this.loading = false`, then `if (!data.items) return` before the spread. `ProductDetail` and `UserDetail` had the guard commented out — enabled it. No other logic changed (`loading = false` just moves to the top of the `.then`, where it already is in the guarded views).

## Verification

- Same scenario after the change on `/prices`, `/products`, `/categories/en:breakfast-cereals`, `/proofs`, `/locations`: the proxy still logs the page-2 `404`s, the console has no exception, the 25 loaded items stay rendered and the spinner disappears.
- `npx eslint <changed files>`: clean. `npm run lint`: 0 errors (42 pre-existing warnings).
