### PR TITLE
fix(Router): do a full page load when a view's js chunk can't be loaded (after a new deploy)

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -114,6 +114,16 @@ const router = createRouter({
 })
 
 /**
+ * When a new version is deployed, the (hashed) js chunks of the previous version disappear from the server.
+ * Users who still have the previous version open then fail to lazy-load any view they haven't visited yet
+ * ("Failed to fetch dynamically imported module"), and the navigation silently does nothing.
+ * In that case, do a full page load of the target route (see router.onError below): it picks up the new version.
+ * The sessionStorage key avoids a reload loop if the chunk is still missing after the reload.
+ */
+const CHUNK_LOAD_ERROR_RELOAD_KEY = 'chunk-load-error-reload'
+const CHUNK_LOAD_ERROR_REGEX = /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i  // Chrome / Firefox / Safari
+
+/**
  * After each page change, update the document title and meta tags based on the route meta.
  */
 router.afterEach((to) => {
@@ -139,6 +149,24 @@ router.afterEach((to) => {
   utils.setMeta('property', 'og:description', routeDescription)
   utils.setMeta('name', 'twitter:title', resolvedTitle)
   utils.setMeta('name', 'twitter:description', routeDescription)
+
+  // navigation succeeded: forget any chunk-load reload (see router.onError)
+  sessionStorage.removeItem(CHUNK_LOAD_ERROR_RELOAD_KEY)
+})
+
+/**
+ * On navigation error: reload the page if a view's js chunk couldn't be loaded (see CHUNK_LOAD_ERROR_REGEX above).
+ */
+router.onError((error, to) => {
+  if (!CHUNK_LOAD_ERROR_REGEX.test(error?.message)) {
+    return
+  }
+  if (sessionStorage.getItem(CHUNK_LOAD_ERROR_RELOAD_KEY) === to.fullPath) {
+    // already reloaded once for this route: don't loop, let the error surface
+    return
+  }
+  sessionStorage.setItem(CHUNK_LOAD_ERROR_RELOAD_KEY, to.fullPath)
+  window.location.assign(to.fullPath)
 })
 
 export default router

--- a/src/router.js
+++ b/src/router.js
@@ -89,6 +89,16 @@ const router = createRouter({
 })
 
 /**
+ * When a new version is deployed, the (hashed) js chunks of the previous version disappear from the server.
+ * Users who still have the previous version open then fail to lazy-load any view they haven't visited yet
+ * ("Failed to fetch dynamically imported module"), and the navigation silently does nothing.
+ * In that case, do a full page load of the target route (see router.onError below): it picks up the new version.
+ * The sessionStorage key avoids a reload loop if the chunk is still missing after the reload.
+ */
+const CHUNK_LOAD_ERROR_RELOAD_KEY = 'chunk-load-error-reload'
+const CHUNK_LOAD_ERROR_REGEX = /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i  // Chrome / Firefox / Safari
+
+/**
  * Before each page change:
  * - check the user's preferred language and update the app's language if necessary
  * - check if it needs authentication. If required, but the user is not authenticated (token unknown):
@@ -114,17 +124,8 @@ const router = createRouter({
 })
 
 /**
- * When a new version is deployed, the (hashed) js chunks of the previous version disappear from the server.
- * Users who still have the previous version open then fail to lazy-load any view they haven't visited yet
- * ("Failed to fetch dynamically imported module"), and the navigation silently does nothing.
- * In that case, do a full page load of the target route (see router.onError below): it picks up the new version.
- * The sessionStorage key avoids a reload loop if the chunk is still missing after the reload.
- */
-const CHUNK_LOAD_ERROR_RELOAD_KEY = 'chunk-load-error-reload'
-const CHUNK_LOAD_ERROR_REGEX = /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i  // Chrome / Firefox / Safari
-
-/**
- * After each page change, update the document title and meta tags based on the route meta.
+ * After each page change:
+ * - update the document title and meta tags based on the route meta
  */
 router.afterEach((to) => {
   const routeTitle = to.meta?.title
@@ -155,14 +156,15 @@ router.afterEach((to) => {
 })
 
 /**
- * On navigation error: reload the page if a view's js chunk couldn't be loaded (see CHUNK_LOAD_ERROR_REGEX above).
+ * On navigation error:
+ * - reload the page if a view's js chunk couldn't be loaded
  */
 router.onError((error, to) => {
   if (!CHUNK_LOAD_ERROR_REGEX.test(error?.message)) {
     return
   }
+  // already reloaded once for this route: don't loop, let the error surface
   if (sessionStorage.getItem(CHUNK_LOAD_ERROR_RELOAD_KEY) === to.fullPath) {
-    // already reloaded once for this route: don't loop, let the error surface
     return
   }
   sessionStorage.setItem(CHUNK_LOAD_ERROR_RELOAD_KEY, to.fullPath)


### PR DESCRIPTION
### What

Fixes #2365

Every view is lazy-loaded (`() => import('./views/X.vue')`) and built into a hashed chunk. When a new version is deployed, the previous version's chunks disappear from the server, so a user who still has the old app open can't navigate to any view they haven't visited yet: the dynamic import rejects with `TypeError: Failed to fetch dynamically imported module: …/assets/Settings-<hash>.js`, vue-router aborts the navigation, and clicking the drawer entry silently does nothing.

I think that's what happened in #2365: the issue was filed at 09:00 UTC, 5 minutes after the 1.173.1 release (#2359) was merged at 08:55, from a tab that was open on the "Create product" page before the deploy. Clicking Settings from that page works fine otherwise (checked on `main`, dev server and production build, light/dark, logged in).

(Sentry reports the same error class in #2345, but for an async *component* (`defineAsyncComponent` in `ProductDetailsRow.vue`), which doesn't go through the router — this PR doesn't cover that one.)

### Fix

`router.onError`: when the error is a chunk-load error (Chrome / Firefox / Safari messages), do a full page load of the target route (`window.location.assign(to.fullPath)`), which picks up the new version. A `sessionStorage` key (cleared in `afterEach` once a navigation succeeds) prevents a reload loop if the chunk is still missing after the reload — in that case the error surfaces as before.

### Verification

Simulated a deploy with two production builds (A = this branch, B = same + a change in `constants.js` so every chunk hash differs), served with `vite preview`, driven in Chrome:

- **Before** (`main`, build served, then `Settings-<hash>.js` removed from the server as a deploy would): open `/experiments/create-off-product`, drawer → Settings: drawer stays open, nothing happens, console: `TypeError: Failed to fetch dynamically imported module: http://localhost:5181/assets/Settings-CXSIv4yD.js`.
- **After** (build A loaded in the tab, then build B's `dist/` swapped in on the server): drawer → Settings: request for the old `Settings-C7eRYfR8.js` fails, the page does a full load of `/settings`, comes back on build B (`index-Cxcm_bEr.js`, `Settings-BQ93Zmdy.js`, title shows the B marker), Settings page renders, no console error, `sessionStorage['chunk-load-error-reload']` cleared by `afterEach`.
- Loop guard: with an inconsistent server state (chunk still missing after the reload) it reloads once and then stops.
- `npm run lint` clean; `npm run build` OK (the `ProofMetadataInputRow.vue` sourcemap warning is pre-existing on `main`).
