### PR TITLE
refactor(API): reject with an OpenPricesApiError when the API answers with a non-2xx status

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -253,8 +253,11 @@ export default {
       }
       openPricesApi
         .getProductByCode(code)
-        .then((data) => {
-          const product = data.id ? data : {'code': code, 'price_count': 0}
+        .catch((error) => {
+          if (error.status === 404) return {'code': code, 'price_count': 0}  // product not in Open Prices (yet)
+          throw error
+        })
+        .then((product) => {
           if (search) {
             this.productSearchResultList.push(product)
           } else {

--- a/src/components/ProductInputRow.vue
+++ b/src/components/ProductInputRow.vue
@@ -221,8 +221,12 @@ export default {
       this.productForm.product = null
       openPricesApi
         .getProductByCode(code)
-        .then((data) => {
-          this.productForm.product = data.id ? data : {'code': code, 'price_count': 0}
+        .catch((error) => {
+          if (error.status === 404) return {'code': code, 'price_count': 0}  // product not in Open Prices (yet)
+          throw error
+        })
+        .then((product) => {
+          this.productForm.product = product
         })
         .catch((error) => {
           alert(this.$t('Common.ServerError'))

--- a/src/components/ProofUploadCard.vue
+++ b/src/components/ProofUploadCard.vue
@@ -363,16 +363,11 @@ export default {
               .createProof(proofImageCompressed, this.proofForm, this.$route.path)
               .then((data) => {
                 this.loading = false
-                if (data.id) {
-                  resolve(data)
-                } else {
-                  alert(`Error: ${JSON.stringify(data)}`)
-                  console.log(JSON.stringify(data))
-                }
+                resolve(data)
               })
               .catch((error) => {
-                alert(`Error: ${JSON.stringify(error)}`)
-                console.log(JSON.stringify(error))
+                alert(`Error: ${error.message}`)
+                console.log(error)
                 this.loading = false
               })
           })
@@ -387,16 +382,11 @@ export default {
         .finalizeDraftProof(proofDraft.id, this.proofForm, this.$route.path)
         .then((data) => {
           this.loading = false
-          if (data.id) {
-            this.proofObjectList = this.proofObjectList.concat(data)
-          } else {
-            alert(`Error: ${JSON.stringify(data)}`)
-            console.log(JSON.stringify(data))
-          }
+          this.proofObjectList = this.proofObjectList.concat(data)
         })
         .catch((error) => {
-          alert(`Error: ${JSON.stringify(error)}`)
-          console.log(JSON.stringify(error))
+          alert(`Error: ${error.message}`)
+          console.log(error)
           this.loading = false
         })
     },

--- a/src/components/ReceiptAnonymizerDialog.vue
+++ b/src/components/ReceiptAnonymizerDialog.vue
@@ -171,17 +171,12 @@ export default {
             .createDraftProof(proofImageCompressed, constants.PROOF_TYPE_RECEIPT)
             .then((data) => {
               this.loading = false
-              if (data.id) {
-                this.draftProof = data
-                this.loadProofAnonymizationPrediction()
-              } else {
-                alert(`Error: ${JSON.stringify(data)}`)
-                console.log(JSON.stringify(data))
-              }
+              this.draftProof = data
+              this.loadProofAnonymizationPrediction()
             })
             .catch((error) => {
-              alert(`Error: ${JSON.stringify(error)}`)
-              console.log(JSON.stringify(error))
+              alert(`Error: ${error.message}`)
+              console.log(error)
               this.loading = false
             })
         })

--- a/src/components/ReceiptTableCard.vue
+++ b/src/components/ReceiptTableCard.vue
@@ -328,8 +328,11 @@ export default {
     findProduct(item) {
       openPricesApi
         .getProductByCode(item.product_code)
-        .then((data) => {
-          const product = data.id ? data : {'code': item.product_code, 'price_count': 0}
+        .catch((error) => {
+          if (error.status === 404) return {'code': item.product_code, 'price_count': 0}  // product not in Open Prices (yet)
+          throw error
+        })
+        .then((product) => {
           item.product = product
         })
         .catch((error) => {

--- a/src/services/openPricesApi.js
+++ b/src/services/openPricesApi.js
@@ -85,6 +85,22 @@ function extraProofCreateOrUpdateFiltering(data) {
 }
 
 /**
+ * Error rejected by fetchOpenPrices when the API answers with a non-2xx status
+ * - status: the HTTP status code
+ * - data: the error payload returned by the API (usually {detail: ...}), or null if it isn't JSON
+ * - message: the payload's "detail" when it is a string, otherwise the whole payload
+ */
+export class OpenPricesApiError extends Error {
+  constructor(response, data) {
+    const detail = data && data.detail
+    super(typeof detail === 'string' ? detail : (data ? JSON.stringify(data) : `${response.status} ${response.statusText}`))
+    this.name = 'OpenPricesApiError'
+    this.status = response.status
+    this.data = data
+  }
+}
+
+/**
  * Wrapper around fetch
  * 1. to avoid repeating the URL prefix (VITE_OPEN_PRICES_API_URL)
  * 2. to avoid repeating headers (e.g. Authorization & Content-Type)
@@ -92,6 +108,8 @@ function extraProofCreateOrUpdateFiltering(data) {
  * - Open Prices backend API allows both cookie & token authentication
  * - but Open Prices frontend (this app) only uses token authentication
  * - sending both can lead to issues (e.g. the cookie coming from Django admin)
+ * 4. to reject with an OpenPricesApiError when the API answers with a non-2xx status,
+ *    so that API errors end up in the callers' .catch() instead of in their .then()
  */
 function fetchOpenPrices(endpointWithParams, options, withToken = false) {
   // set URL
@@ -110,6 +128,12 @@ function fetchOpenPrices(endpointWithParams, options, withToken = false) {
     ...options,
     headers: headers,
     credentials: 'omit'
+  })
+  .then((response) => {
+    if (response.ok) return response
+    return response.json()
+      .catch(() => null)
+      .then((data) => { throw new OpenPricesApiError(response, data) })
   })
 }
 

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -501,6 +501,10 @@ export default {
     },
     getProduct(callback) {
       return openPricesApi.getProductByCode(this.productForm.product_code)
+        .catch((error) => {
+          if (error.status === 404) return { code: this.productForm.product_code, price_count: 0 }  // product not in Open Prices (yet)
+          throw error
+        })
         .then((product) => {
           this.product = product
           if(callback) callback(product)

--- a/src/views/LocationOSMDetail.vue
+++ b/src/views/LocationOSMDetail.vue
@@ -49,13 +49,14 @@ export default {
     getLocation() {
       return openPricesApi.getLocationByOsmTypeAndId(this.locationOsmType, this.locationOsmId)
         .then((data) => {
-          if (data.id) {
-            this.$router.replace({ name: 'location-detail', params: { id: data.id } })
-          } else {
-            this.location = {
-              osm_type: this.locationOsmType,
-              osm_id: this.locationOsmId,
-            }
+          this.$router.replace({ name: 'location-detail', params: { id: data.id } })
+        })
+        .catch((error) => {
+          if (error.status !== 404) throw error
+          // location not in Open Prices (yet): display it from its OSM type & id
+          this.location = {
+            osm_type: this.locationOsmType,
+            osm_id: this.locationOsmId,
           }
         })
     },

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -149,7 +149,7 @@ import { defineAsyncComponent } from 'vue'
 import { useGoTo } from 'vuetify'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
-import openPricesApi from '../services/openPricesApi'
+import openPricesApi, { OpenPricesApiError } from '../services/openPricesApi'
 import constants from '../constants'
 import date_utils from '../utils/date.js'
 
@@ -315,19 +315,17 @@ export default {
       openPricesApi
         .createPrice(Object.assign({}, this.addPriceMultipleForm, this.productPriceForm), this.$route.path)
         .then((data) => {
-          this.loading = false
-          if (data.id) {
-            this.proofPriceNewList.push(JSON.parse(JSON.stringify(data)))  // deep copy
-            this.priceSuccessMessage = true
-            // show new price form immediately
-            this.initNewProductPriceForm()
-          } else {
-            alert(`Error: ${JSON.stringify(data)}`)
-          }
+          this.proofPriceNewList.push(JSON.parse(JSON.stringify(data)))  // deep copy
+          this.priceSuccessMessage = true
+          // show new price form immediately
+          this.initNewProductPriceForm()
         })
         .catch((error) => {
-          alert(this.$t('Common.ServerError'))
+          alert(error instanceof OpenPricesApiError ? `Error: ${error.message}` : this.$t('Common.ServerError'))
           console.log(error)
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     done() {

--- a/src/views/PriceAddSingle.vue
+++ b/src/views/PriceAddSingle.vue
@@ -66,7 +66,7 @@
 import { defineAsyncComponent } from 'vue'
 import { mapStores } from 'pinia'
 import { useAppStore } from '../store'
-import openPricesApi from '../services/openPricesApi'
+import openPricesApi, { OpenPricesApiError } from '../services/openPricesApi'
 import date_utils from '../utils/date.js'
 
 export default {
@@ -132,18 +132,14 @@ export default {
       this.loading = true
       openPricesApi
         .createPrice(this.addPriceSingleForm, this.$route.path)
-        .then((data) => {
-          this.loading = false
-          if (data.id) {
-            this.goToUserDashboard()
-          } else {
-            alert(`Error: ${JSON.stringify(data)}`)
-            console.log(JSON.stringify(data))
-          }
+        .then(() => {
+          this.goToUserDashboard()
         })
         .catch((error) => {
-          alert(this.$t('Common.ServerError'))
+          alert(error instanceof OpenPricesApiError ? `Error: ${error.message}` : this.$t('Common.ServerError'))
           console.log(error)
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -47,7 +47,7 @@
 import { mapStores } from 'pinia'
 import { defineAsyncComponent } from 'vue'
 import constants from '../constants.js'
-import openPricesApi from '../services/openPricesApi'
+import openPricesApi, { OpenPricesApiError } from '../services/openPricesApi'
 import { useAppStore } from '../store.js'
 import date_utils from '../utils/date.js'
 import proof_utils from '../utils/proof.js'
@@ -222,15 +222,10 @@ export default {
         .createPrice(Object.assign({}, priceData), this.$route.path)
         .then((data) => {
           productPriceData.loading = false
-          if (data.id) {
-            return data
-          } else {
-            alert(`Error: ${JSON.stringify(data)}`)
-            console.log(JSON.stringify(data))
-          }
+          return data
         })
         .catch((error) => {
-          alert(this.$t('Common.ServerError'))
+          alert(error instanceof OpenPricesApiError ? `Error: ${error.message}` : this.$t('Common.ServerError'))
           console.log(error)
           productPriceData.loading = false
         })

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -186,12 +186,12 @@ export default {
       } else {
         return openPricesApi.getProductByCode(this.productId)
           .then((data) => {
-            if (data.id) {
-              this.product = data
-            } else {
-              // product not found: set a minimal product to display the ProductCard
-              this.product = { code: this.productId, price_count: this.priceTotal }
-            }
+            this.product = data
+          })
+          .catch((error) => {
+            if (error.status !== 404) throw error
+            // product not found: set a minimal product to display the ProductCard
+            this.product = { code: this.productId, price_count: this.priceTotal }
           })
       }
     },

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -155,7 +155,11 @@ export default {
       }
     },
     handleAuthError(error) {
-      alert(this.$t('Common.ServerError'))
+      if (error.status === 401) {
+        alert(this.$t('SignIn.WrongCredentials'))
+      } else {
+        alert(this.$t('Common.ServerError'))
+      }
       console.log(error)
       this.loading = false
     },


### PR DESCRIPTION
Follow-up to #2360, as discussed in https://github.com/openfoodfacts/open-prices-frontend/pull/2360#discussion_r3883868058.

### Problem

`fetchOpenPrices` resolves with `response.json()` whatever the HTTP status, so an API error like `{"detail": "Maximum page reached. …"}` reaches the callers' `.then()` as if it were data. That is why the list views needed the `if (!data.items) return` guards (#2360), why form submits sniff `data.id`, why the sign-in view sniffs `data.access_token`, and why every other call site silently swallows API errors (nothing in the console, nothing in Sentry).

### Fix (2 commits, best reviewed separately)

1. **`refactor(API): reset loading flags in .finally() instead of .then()`** — mechanical, no behaviour change on success. Every `openPricesApi` chain that reset a `loading` flag inside `.then()` (and had no `.catch()`) now does it in `.finally()`. Needed so that the loading flags don't stay stuck once errors reject (44 files, one hunk each, applied by a script and reviewed by hand).

2. **`fix(API): reject with an OpenPricesApiError when the API answers with a non-2xx status`** — `fetchOpenPrices` now rejects with an `OpenPricesApiError` (`status`, `data` = parsed payload, `message` = the payload's `detail`) on any non-2xx response, so API errors flow to `.catch()` like network errors already did. The callers that read error payloads from the resolved promise are updated so that the user-visible behaviour stays the same:
   - `SignIn`: 401 → "wrong credentials" alert (was: no `access_token` in the body)
   - `getProductByCode` callers (`BarcodeScannerDialog`, `ProductInputRow`, `ReceiptTableCard`, `ProductDetail`, `CreateOffProduct`): 404 → placeholder product, as before
   - `LocationOSMDetail`: 404 → location built from the OSM type & id, as before
   - price/proof create & upload forms: the alert now comes from `.catch()` and shows the API's `detail` (e.g. `Error: Authentication credentials were not provided.` instead of `Error: {"detail":"…"}`); the `else` branches that displayed it are gone, and their `loading` flags are reset in `.finally()`

The `if (!data.items) return` guards from #2360 are kept (belt and braces).

**Impact to be aware of:** call sites without a `.catch()` (mostly the list views) now surface API errors as an unhandled rejection — `OpenPricesApiError: Maximum page reached. …` in the console, and in Sentry in prod — instead of ignoring them. The UI stays stable (loading flags reset, items already displayed are kept). If you'd rather keep some of them quiet, tell me which and I'll add a `.catch()`.

### Verification

Local setup: `.env.local` pointing `VITE_OPEN_PRICES_API_URL` to a small Node proxy on `127.0.0.1:8000` that forwards to the live API but answers any `?page>=2` request with the real API's `400 {"detail":"Maximum page reached. …"}`; `vite --port 5180`; driven in Chrome with `window.alert` replaced by a logger and an `unhandledrejection` listener.

| scenario | before (`main` @ 7f46ea17) | after (this branch) |
|---|---|---|
| `/prices`, scroll to the bottom → page 2 answered with 400 | request made, **nothing** logged, `loading=false`, 25 items | `OpenPricesApiError status=400 "Maximum page reached. …"` as an unhandled rejection, `loading=false` (via `.finally()`), no spinner, 25 items kept |
| `/sign-in`, wrong credentials (real `POST /auth` → 401) | alert `Error: wrong credentials` | alert `Error: wrong credentials` |
| `/prices/add/single`, barcode `12345678901234567890` (real `GET /products/code/…` → 404) | `productForm.product = {"code":"…","price_count":0}` | same |
| `/prices/add/single`, submit with an invalid token (real `POST /prices` → 403) | alert `Error: {"detail":"Authentication credentials were not provided."}`, `loading=false` | alert `Error: Authentication credentials were not provided.`, `loading=false` |
| `/products/12345678901234567890` (404) | — | `product = {"code":"…","price_count":0}`, "Unknown product" card rendered, no rejection |
| `/locations/osm/node/1` (404) | — | `location = {"osm_type":"node","osm_id":"1"}`, no rejection |

`npx eslint --max-warnings=0` on the 52 changed files: clean. `npm run lint`: 0 errors (warnings are pre-existing).



Related: the Sentry crash in #2343 (`SyntaxError: Unexpected end of JSON input` in the openPricesApi bundle) is most likely this same problem surfacing on an error response with an empty body — with this PR, non-2xx bodies are parsed with a `.catch(() => null)` guard, so that path no longer throws a SyntaxError.
