### PR TITLE
refactor(API): reset loading flags in .finally() instead of .then()

### DIFF
--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -284,8 +284,10 @@ export default {
       const website_url_cleaned = utils.getURLOrigin(this.locationOnlineForm.website_url)
       openPricesApi.createLocationOnline({website_url: website_url_cleaned})
         .then((location) => {
-          this.loading = false
           this.selectLocation(location)
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     selectLocation(location) {

--- a/src/components/ModerationFlagCreateDialog.vue
+++ b/src/components/ModerationFlagCreateDialog.vue
@@ -158,9 +158,11 @@ export default {
       openPricesApi
         .createFlag(this.objectType, this.objectId, this.flagForm)
         .then((response) => {  // eslint-disable-line no-unused-vars
-          this.loading = false
           this.$emit('flag')
           this.close()
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     close() {

--- a/src/components/PriceDeleteConfirmationDialog.vue
+++ b/src/components/PriceDeleteConfirmationDialog.vue
@@ -101,10 +101,12 @@ export default {
         .deletePrice(this.price.id)
         .then((response) => {  // eslint-disable-line no-unused-vars
           // if response.status == 204
-          this.loading = false
           this.removePriceCard()
           this.$emit('delete')
           this.close()
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     removePriceCard() {

--- a/src/components/ProofDeleteConfirmationDialog.vue
+++ b/src/components/ProofDeleteConfirmationDialog.vue
@@ -101,10 +101,12 @@ export default {
         .deleteProof(this.proof.id)
         .then((response) => {  // eslint-disable-line no-unused-vars
           // if response.status == 204
-          this.loading = false
           this.deleteSuccessMessage = true
           this.$emit('delete')
           this.close()
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     close() {

--- a/src/components/ReceiptAnonymizerDialog.vue
+++ b/src/components/ReceiptAnonymizerDialog.vue
@@ -227,8 +227,10 @@ export default {
     save() {
       this.loading = true
       openPricesApi.anonymizeDraftProof(this.draftProof.id, this.extractedBoundings).then((response) => {  // eslint-disable-line no-unused-vars
-        this.loading = false
         this.$emit('done', this.draftProof)
+      })
+      .finally(() => {
+        this.loading = false
       })
     }
   },

--- a/src/views/BadgeDetail.vue
+++ b/src/views/BadgeDetail.vue
@@ -79,10 +79,12 @@ export default {
       this.badgeUserPage += 1
       openPricesApi.getBadgeUsers(this.badgeId, this.getBadgeUsersParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.badgeUserList.push(...data.items)
           this.badgeUserTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars

--- a/src/views/BadgeList.vue
+++ b/src/views/BadgeList.vue
@@ -60,10 +60,12 @@ export default {
       this.badgePage += 1
       openPricesApi.getBadges(this.getBadgesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.badgeList.push(...data.items)
           this.badgeTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
   },

--- a/src/views/BrandDetail.vue
+++ b/src/views/BrandDetail.vue
@@ -101,10 +101,12 @@ export default {
       this.brandProductPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.brandProductList.push(...data.items)
           this.brandProductTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/CategoryDetail.vue
+++ b/src/views/CategoryDetail.vue
@@ -103,10 +103,12 @@ export default {
       this.categoryProductPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.categoryProductList.push(...data.items)
           this.categoryProductTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -167,12 +167,14 @@ export default {
       }
       openPricesApi.getChallenges(params)
       .then((data) => {
-        this.loading = false
         if (data.items.length) {
           this.challenge = data.items[0]
           this.getStats()
           this.getLatestPrices()
         }
+      })
+      .finally(() => {
+        this.loading = false
       })
     },
     getStats() {
@@ -180,6 +182,8 @@ export default {
       openPricesApi.getPriceStats(this.defaultParams)
       .then((data) => {
         this.challenge.numberOfContributions = data.price__count
+      })
+      .finally(() => {
         this.loading = false
       })
 

--- a/src/views/ChallengeList.vue
+++ b/src/views/ChallengeList.vue
@@ -121,10 +121,12 @@ export default {
       this.challengePage += 1
       return openPricesApi.getChallenges(this.getChallengesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.challengeList.push(...data.items)
           this.challengeTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handleScroll(event) {  // eslint-disable-line no-unused-vars

--- a/src/views/ChallengePriceList.vue
+++ b/src/views/ChallengePriceList.vue
@@ -101,10 +101,12 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ChallengeProofList.vue
+++ b/src/views/ChallengeProofList.vue
@@ -104,10 +104,12 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handleProofUpdated() {

--- a/src/views/CountryCityDetail.vue
+++ b/src/views/CountryCityDetail.vue
@@ -113,10 +113,12 @@ export default {
       this.countryCityLocationPage += 1
       return openPricesApi.getLocations(this.getLocationsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.countryCityLocationList.push(...data.items)
           this.countryCityLocationTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateDisplay(displayKey) {

--- a/src/views/CountryDetail.vue
+++ b/src/views/CountryDetail.vue
@@ -111,10 +111,12 @@ export default {
       this.countryLocationPage += 1
       return openPricesApi.getLocations(this.getLocationsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.countryLocationList.push(...data.items)
           this.countryLocationTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateDisplay(displayKey) {

--- a/src/views/CountryList.vue
+++ b/src/views/CountryList.vue
@@ -86,6 +86,8 @@ export default {
             data.sort((a, b) => b.location_count - a.location_count)
           }
           this.countryList = data
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/CreateOffProduct.vue
+++ b/src/views/CreateOffProduct.vue
@@ -461,6 +461,8 @@ export default {
             })
             this.missingProductsWithPrices = Array.from(productMap.values())
             this.productTotal = data.total // Only true if products have only one price, but it's good enough ..
+          })
+          .finally(() => {
             this.loading = false
           })
       }
@@ -470,6 +472,8 @@ export default {
         .then((data) => {
           this.missingProductsWithPrices = data.items
           this.productTotal = data.total
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/CurrencyDetail.vue
+++ b/src/views/CurrencyDetail.vue
@@ -92,10 +92,12 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateOrder(orderKey) {

--- a/src/views/DateDetail.vue
+++ b/src/views/DateDetail.vue
@@ -133,7 +133,6 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
@@ -142,6 +141,9 @@ export default {
               utils.addObjectToArray(this.priceLocationList, price.location)
             }
           })
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateOrder(orderKey) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -115,6 +115,8 @@ export default {
         .then((data) => {
           this.latestPriceList = data.items
           this.totalPriceCount = data.total
+        })
+        .finally(() => {
           this.loading = false
         })
     },
@@ -123,6 +125,8 @@ export default {
       return openPricesApi.getPrices({ created__gte: date_utils.currentStartOfDay(), size: 1 })
         .then((data) => {
           this.todayPriceCount = data.total
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/LabelDetail.vue
+++ b/src/views/LabelDetail.vue
@@ -103,10 +103,12 @@ export default {
       this.labelProductPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.labelProductList.push(...data.items)
           this.labelProductTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/LocationDetail.vue
+++ b/src/views/LocationDetail.vue
@@ -138,10 +138,12 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/LocationList.vue
+++ b/src/views/LocationList.vue
@@ -93,10 +93,12 @@ export default {
       this.locationPage += 1
       return openPricesApi.getLocations(this.getLocationsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.locationList.push(...data.items)
           this.locationTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/LocationProofList.vue
+++ b/src/views/LocationProofList.vue
@@ -104,10 +104,12 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handleProofUpdated() {

--- a/src/views/LocationsCompare.vue
+++ b/src/views/LocationsCompare.vue
@@ -195,7 +195,6 @@ export default {
       this.selectedLocationB.totalPrice = 0
 
       openPricesApi.getLocationsCompare(this.selectedLocationA.id, this.selectedLocationB.id).then((response) => {
-        this.loading = false
         if (!response.shared_products || response.shared_products.length === 0) {
           this.productsList = []
           return
@@ -210,6 +209,9 @@ export default {
         })
         this.selectedLocationA.totalPrice = response.total_sum_location_a
         this.selectedLocationB.totalPrice = response.total_sum_location_b
+      })
+      .finally(() => {
+        this.loading = false
       })
     },
     // Step 4: reset comparison = clear query params

--- a/src/views/ModerationDashboard.vue
+++ b/src/views/ModerationDashboard.vue
@@ -134,10 +134,12 @@ export default {
       this.flagPage += 1
       return openPricesApi.getFlags(this.getFlagsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.flagList.push(...data.items)
           this.flagTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     getFlagObjectUrl(flag) {

--- a/src/views/PriceAddMultiple.vue
+++ b/src/views/PriceAddMultiple.vue
@@ -289,9 +289,11 @@ export default {
       this.loading = true
       return openPricesApi.getPrices({ proof_id: this.proofObject.id, size: this.proofObject.price_count, order_by: 'created' })
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.proofPriceExistingList.push(...data.items)
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     clearProductPriceForm() {

--- a/src/views/PriceAddValidate.vue
+++ b/src/views/PriceAddValidate.vue
@@ -179,7 +179,6 @@ export default {
       this.priceTagPage += 1
       return openPricesApi.getPriceTags(this.getPriceTagsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceTagList.push(...data.items)
           this.priceTagTotal = data.total
@@ -189,6 +188,9 @@ export default {
               this.handlePriceTag(data.items[i])
             }
           }
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handlePriceTag(priceTag) {

--- a/src/views/PriceDetail.vue
+++ b/src/views/PriceDetail.vue
@@ -43,6 +43,8 @@ export default {
           if (data.id) {
             this.price = data
           }
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/PriceList.vue
+++ b/src/views/PriceList.vue
@@ -100,10 +100,12 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -201,7 +201,6 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
@@ -210,6 +209,9 @@ export default {
               utils.addObjectToArray(this.priceLocationList, price.location)
             }
           })
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ProductList.vue
+++ b/src/views/ProductList.vue
@@ -96,10 +96,12 @@ export default {
       this.productPage += 1
       return openPricesApi.getProducts(this.getProductsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.productList.push(...data.items)
           this.productTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ProofDetail.vue
+++ b/src/views/ProofDetail.vue
@@ -137,10 +137,12 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     getPriceTagsBoundingBoxes() {

--- a/src/views/ProofList.vue
+++ b/src/views/ProofList.vue
@@ -91,10 +91,12 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/ReceiptAssistant.vue
+++ b/src/views/ReceiptAssistant.vue
@@ -206,8 +206,10 @@ export default {
       this.loadProofWithReceiptItems(receiptItems => {
         this.receiptItems = receiptItems
         openPricesApi.getPrices({proof_id: this.proofObject.id}).then(data => {
-          this.loadingPredictions = false
           this.proofPriceExistingList = data.items
+        })
+        .finally(() => {
+          this.loadingPredictions = false
         })
       })
     },

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -108,13 +108,15 @@ export default {
         const code = barcodeUtils.normalizeBarcode(this.productSearchForm.q)
         return openPricesApi.getProducts({ code: code })
           .then((data) => {
-            this.loading = false
             if (!data.items) return
             this.productList.push(...data.items)
             this.productTotal = data.total
             if (data.items.length) {
               this.getProductLatestPrices()
             }
+          })
+          .finally(() => {
+            this.loading = false
           })
       }
     },

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -317,6 +317,8 @@ export default {
           for (const key in this.stats) {
             this.stats[key] = (key in data) ? data[key] : this.stats[key]
           }
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/UserBadgeList.vue
+++ b/src/views/UserBadgeList.vue
@@ -66,6 +66,8 @@ export default {
           if (!data.items) return
           this.userBadgeList.push(...data.items)
           this.userBadgeTotal = data.total
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/UserDashboard.vue
+++ b/src/views/UserDashboard.vue
@@ -264,6 +264,8 @@ export default {
       return openPricesApi.getUserById(this.username)
         .then((data) => {
           this.user = data
+        })
+        .finally(() => {
           this.loading = false
         })
     },
@@ -286,11 +288,13 @@ export default {
             this.userPriceList = data.items
             this.userPriceCount = data.total
           }
-          this.loading = false
           // check if the user added a price today
           if (data.items.length && data.items[0].created > date_utils.currentStartOfDay()) {
             this.getUserPriceCount(true)
           }
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     getUserPriceCount(today=false) {
@@ -318,6 +322,8 @@ export default {
               this.userPriceCount = data.total
             }
           }
+        })
+        .finally(() => {
           this.loading = false
         })
     },
@@ -350,6 +356,8 @@ export default {
               this.getUserProofCount(true)
             }
           }
+        })
+        .finally(() => {
           this.loading = false
         })
     },

--- a/src/views/UserDashboardPriceList.vue
+++ b/src/views/UserDashboardPriceList.vue
@@ -128,7 +128,6 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
@@ -137,6 +136,9 @@ export default {
               utils.addObjectToArray(this.priceLocationList, price.location)
             }
           })
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/UserDashboardProofList.vue
+++ b/src/views/UserDashboardProofList.vue
@@ -136,7 +136,6 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
@@ -145,6 +144,9 @@ export default {
               utils.addObjectToArray(this.proofLocationList, proof.location)
             }
           })
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handleProofUpdated() {

--- a/src/views/UserDetail.vue
+++ b/src/views/UserDetail.vue
@@ -138,10 +138,12 @@ export default {
       this.pricePage += 1
       return openPricesApi.getPrices(this.getPricesParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.priceList.push(...data.items)
           this.priceTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/UserList.vue
+++ b/src/views/UserList.vue
@@ -88,10 +88,12 @@ export default {
       this.userPage += 1
       return openPricesApi.getUsers(this.getUsersParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.userList.push(...data.items)
           this.userTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     updateFilterList(newFilterList) {

--- a/src/views/UserProofList.vue
+++ b/src/views/UserProofList.vue
@@ -104,10 +104,12 @@ export default {
       this.proofPage += 1
       return openPricesApi.getProofs(this.getProofsParams)
         .then((data) => {
-          this.loading = false
           if (!data.items) return
           this.proofList.push(...data.items)
           this.proofTotal = data.total
+        })
+        .finally(() => {
+          this.loading = false
         })
     },
     handleProofUpdated() {


### PR DESCRIPTION
### What

First of the 2 stacked PRs split out of #2368, as requested by @raphodn in [this review thread](https://github.com/openfoodfacts/open-prices-frontend/pull/2368#discussion_r3889042403) — mechanical commit only, no behavior change.

Moves every `loading = false` / `this.loading = false` reset that lived inside a `.then()` of an `openPricesApi` promise chain into a `.finally()` (50 chains across 52 files; one chain intentionally left as-is because its `.then()` navigates away). This is a no-op today because `fetchOpenPrices` never rejects — it becomes meaningful in the follow-up PR #2368, which makes the API layer reject on non-2xx responses (without this commit, a rejection would leave spinners stuck on).

### Verification

- Change applied by script (AST-free, per-chain) and the diff checked for uniformity with `sort | uniq`.
- `npx eslint --max-warnings=0` clean on all 52 changed files; `npm run lint` 0 errors (48 pre-existing warnings); `vite build` OK.
- Full before/after runtime verification of the pair of commits is described in #2368 (live-API proxy + Chrome-driven checks on /prices, /sign-in, /prices/add/single, invalid-token createPrice).

Part 2 (stacked on this): #2368 — I'll rebase it onto main once this one is merged.