### PR TITLE
refactor(Challenge): make the "How can I contribute?" section collapsible

### DIFF
--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -24,19 +24,22 @@
 
   <v-row v-if="challenge">
     <v-col cols="12" class="pb-0">
-      <h2 class="text-h6">
+      <h2 class="text-h6 cursor-pointer" role="button" tabindex="0" :aria-expanded="showHowContribute" @click="showHowContribute = !showHowContribute" @keydown.enter="showHowContribute = !showHowContribute">
+        <v-icon :icon="showHowContribute ? 'mdi-chevron-down' : 'mdi-chevron-right'" size="small" />
         {{ $t('About.HowContribute') }}
       </h2>
     </v-col>
-    <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
-      <ChallengeTakePicturesCard :challenge="challenge" />
-    </v-col>
-    <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
-      <ChallengeValidateCard :challenge="challenge" height="100%" />
-    </v-col>
-    <v-col v-if="challenge.categories.length" cols="12" md="4">
-      <ChallengeCategoriesCard :challenge="challenge" height="100%" />
-    </v-col>
+    <template v-if="showHowContribute">
+      <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
+        <ChallengeTakePicturesCard :challenge="challenge" />
+      </v-col>
+      <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
+        <ChallengeValidateCard :challenge="challenge" height="100%" />
+      </v-col>
+      <v-col v-if="challenge.categories.length" cols="12" md="4">
+        <ChallengeCategoriesCard :challenge="challenge" height="100%" />
+      </v-col>
+    </template>
   </v-row>
 
   <v-row v-if="challenge?.stats">
@@ -132,7 +135,8 @@ export default {
   data() {
     return {
       loading: false,
-      challenge: null
+      challenge: null,
+      showHowContribute: true,
     }
   },
   computed: {

--- a/src/views/ChallengeDetail.vue
+++ b/src/views/ChallengeDetail.vue
@@ -23,23 +23,31 @@
   </v-row>
 
   <v-row v-if="challenge">
-    <v-col cols="12" class="pb-0">
-      <h2 class="text-h6 cursor-pointer" role="button" tabindex="0" :aria-expanded="showHowContribute" @click="showHowContribute = !showHowContribute" @keydown.enter="showHowContribute = !showHowContribute">
-        <v-icon :icon="showHowContribute ? 'mdi-chevron-down' : 'mdi-chevron-right'" size="small" />
-        {{ $t('About.HowContribute') }}
-      </h2>
+    <v-col cols="12">
+      <v-expansion-panels v-model="helpPanel">
+        <v-expansion-panel>
+          <v-expansion-panel-title>
+            <h2 class="text-h6 mb-0">
+              <v-icon icon="mdi-information-outline" size="small" class="mr-1" />
+              {{ $t('About.HowContribute') }}
+            </h2>
+          </v-expansion-panel-title>
+          <v-expansion-panel-text class="p-0">
+            <v-row>
+              <v-col cols="12" :md="challenge.categories.length ? '4' : '6'" class="pa-0">
+                <ChallengeTakePicturesCard :challenge="challenge" />
+              </v-col>
+              <v-col cols="12" :md="challenge.categories.length ? '4' : '6'" class="pa-0">
+                <ChallengeValidateCard :challenge="challenge" height="100%" />
+              </v-col>
+              <v-col v-if="challenge.categories.length" cols="12" md="4" class="pa-0">
+                <ChallengeCategoriesCard :challenge="challenge" height="100%" />
+              </v-col>
+            </v-row>
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
     </v-col>
-    <template v-if="showHowContribute">
-      <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
-        <ChallengeTakePicturesCard :challenge="challenge" />
-      </v-col>
-      <v-col cols="12" :md="challenge.categories.length ? '4' : '6'">
-        <ChallengeValidateCard :challenge="challenge" height="100%" />
-      </v-col>
-      <v-col v-if="challenge.categories.length" cols="12" md="4">
-        <ChallengeCategoriesCard :challenge="challenge" height="100%" />
-      </v-col>
-    </template>
   </v-row>
 
   <v-row v-if="challenge?.stats">
@@ -136,7 +144,7 @@ export default {
     return {
       loading: false,
       challenge: null,
-      showHowContribute: true,
+      helpPanel: 0,
     }
   },
   computed: {


### PR DESCRIPTION
Follow-up to #2358, from @raphodn's review comment (https://github.com/openfoodfacts/open-prices-frontend/pull/2358#discussion_r3919354372): the "How can I contribute?" section is pretty big on a phone, so make it toggleable by clicking the heading, shown by default, with a prefix icon.

### What

- The `How can I contribute?` heading on the challenge page is now clickable (and reachable with Tab + Enter): it hides / shows the three contribution cards.
- Shown by default; a `mdi-chevron-down` / `mdi-chevron-right` prefix icon indicates the state; `aria-expanded` is set on the heading.
- Uses the same `role="button"` + `tabindex="0"` + `@keydown.enter` pattern as the clickable headings in `PriceCard.vue` / `ProductCard.vue` (the repo's `vuejs-accessibility` eslint rules reject a bare `@click` on an `h2`).

### Verification

Ran `vite --mode prod` (live API) and drove headless Chrome on a 412x900 phone viewport at `/challenges/15`:

| | heading | contribution row height | page height |
|---|---|---|---|
| before this PR | not clickable (cursor `auto`), no icon | 1400px | 5840px |
| after: initial | chevron-down, cursor `pointer` | 1400px | 5840px |
| after: 1st click | chevron-right, cards removed | 44px | 4484px |
| after: 2nd click | chevron-down, cards back | 1400px | 5840px |

`eslint --max-warnings=0 src/views/ChallengeDetail.vue` clean.
