### PR TITLE
fix(Links): add rel="noopener noreferrer" to every target="_blank" link

### DIFF
--- a/src/components/BarcodeScannerDialog.vue
+++ b/src/components/BarcodeScannerDialog.vue
@@ -79,8 +79,8 @@
         <div>
           <i18n-t keypath="BarcodeScanner.Htlm5-qrcode.Text" tag="span">
             <template #url>
-              <a v-if="barcodeScannerLibrary === 'html5-qrcode'" :href="HTML5_QRCODE_URL" target="_blank">{{ HTML5_QRCODE_NAME }}</a>
-              <a v-else :href="BARCODE_SCANNER_URL" target="_blank">{{ BARCODE_SCANNER_NAME }}</a>
+              <a v-if="barcodeScannerLibrary === 'html5-qrcode'" :href="HTML5_QRCODE_URL" target="_blank" rel="noopener noreferrer">{{ HTML5_QRCODE_NAME }}</a>
+              <a v-else :href="BARCODE_SCANNER_URL" target="_blank" rel="noopener noreferrer">{{ BARCODE_SCANNER_NAME }}</a>
             </template>
           </i18n-t>
         </div>

--- a/src/components/ChallengeCategoriesCard.vue
+++ b/src/components/ChallengeCategoriesCard.vue
@@ -30,6 +30,7 @@
             class="mr-1 mb-1"
             :href="getHungerGamesCategoryUrl(category)"
             target="_blank"
+            rel="noopener noreferrer"
           >
             {{ categoryLocalizedNames[category] || category }}
           </v-chip>

--- a/src/components/ChallengeNewFormAlert.vue
+++ b/src/components/ChallengeNewFormAlert.vue
@@ -7,7 +7,7 @@
   >
     <i18n-t keypath="Challenge.AlertNew" tag="span">
       <template #url>
-        <a :href="APP_GITHUB_CHALLENGE_DISCUSSION_URL" target="_blank" class="text-lowercase">{{ $t('Common.Here') }}</a>
+        <a :href="APP_GITHUB_CHALLENGE_DISCUSSION_URL" target="_blank" rel="noopener noreferrer" class="text-lowercase">{{ $t('Common.Here') }}</a>
       </template>
     </i18n-t>
   </v-alert>

--- a/src/components/ChallengeTakePicturesCard.vue
+++ b/src/components/ChallengeTakePicturesCard.vue
@@ -4,7 +4,7 @@
       <p class="mb-2">
         {{ $t('Challenge.StepTakePictures.line1') }}
       </p>
-      <a :href="challenge.example_proof_url" target="_blank">
+      <a :href="challenge.example_proof_url" target="_blank" rel="noopener noreferrer">
         <v-img :src="challenge.example_proof_url" max-height="200px" />
       </a>
       <p class="mb-2 mt-2">

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -11,7 +11,7 @@
         <v-btn class="mx-2" variant="text" :prepend-icon="ABOUT_ICON" to="/about">
           {{ $t('Common.About') }}
         </v-btn>
-        <v-btn class="mx-2 my-2" variant="text" prepend-icon="mdi-github" :href="APP_GITHUB_FRONTEND_URL" target="_blank">
+        <v-btn class="mx-2 my-2" variant="text" prepend-icon="mdi-github" :href="APP_GITHUB_FRONTEND_URL" target="_blank" rel="noopener noreferrer">
           {{ GITHUB_NAME }}
         </v-btn>
       </v-col>
@@ -25,7 +25,7 @@
           </template>
         </i18n-t>
         <br>
-        <v-btn v-for="source in sourceList" :key="source.source" class="mr-1 my-2" size="x-small" active :prepend-icon="source.icon" :href="source.url" target="_blank">
+        <v-btn v-for="source in sourceList" :key="source.source" class="mr-1 my-2" size="x-small" active :prepend-icon="source.icon" :href="source.url" target="_blank" rel="noopener noreferrer">
           {{ source.label }}
           <v-tooltip activator="parent" open-on-click location="top">
             {{ source.name }}

--- a/src/components/LeafletMap.vue
+++ b/src/components/LeafletMap.vue
@@ -65,7 +65,7 @@ export default {
       mapBounds: null,
       theme: useTheme(),
       tiles: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-      attribution: '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      attribution: '&copy; <a target="_blank" rel="noopener noreferrer" href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     }
   },
   mounted() {

--- a/src/components/LocationSelectorDialog.vue
+++ b/src/components/LocationSelectorDialog.vue
@@ -108,7 +108,7 @@
                       {{ OSM_NAME }}
                     </template>
                     <template #osm_url>
-                      <a :href="OSM_URL" target="_blank">
+                      <a :href="OSM_URL" target="_blank" rel="noopener noreferrer">
                         {{ OSM_URL }}
                       </a>
                     </template>
@@ -146,10 +146,10 @@
         <div>
           <i18n-t keypath="LocationSelector.PoweredBy.text" tag="span">
             <template #url>
-              <a v-if="searchProvider === 'nominatim'" :href="OSM_NOMINATIM_URL" target="_blank">
+              <a v-if="searchProvider === 'nominatim'" :href="OSM_NOMINATIM_URL" target="_blank" rel="noopener noreferrer">
                 {{ OSM_NOMINATIM_ATTRIBUTION }}
               </a>
-              <a v-if="searchProvider === 'photon'" :href="OSM_PHOTON_URL" target="_blank">
+              <a v-if="searchProvider === 'photon'" :href="OSM_PHOTON_URL" target="_blank" rel="noopener noreferrer">
                 {{ OSM_PHOTON_ATTRIBUTION }}
               </a>
             </template>

--- a/src/components/OpenFoodFactsAddMenu.vue
+++ b/src/components/OpenFoodFactsAddMenu.vue
@@ -11,7 +11,7 @@
     </template>
     <v-list>
       <template v-for="(source, index) in sourceList" :key="source.key">
-        <v-list-item :slim="true" :href="getSourceAddUrlWithLocale(source)" target="_blank">
+        <v-list-item :slim="true" :href="getSourceAddUrlWithLocale(source)" target="_blank" rel="noopener noreferrer">
           <template #prepend>
             <v-icon :icon="source.icon" />
           </template>

--- a/src/components/OpenFoodFactsLink.vue
+++ b/src/components/OpenFoodFactsLink.vue
@@ -1,11 +1,11 @@
 <template>
-  <a v-if="display === 'link'" :href="getUrl" target="_blank" :disabled="disabled">
+  <a v-if="display === 'link'" :href="getUrl" target="_blank" rel="noopener noreferrer" :disabled="disabled">
     {{ getSourceName }}
   </a>
-  <v-btn v-else-if="display === 'button'" size="small" :prepend-icon="getSourceIcon" append-icon="mdi-open-in-new" :href="getUrl" target="_blank" :disabled="disabled">
+  <v-btn v-else-if="display === 'button'" size="small" :prepend-icon="getSourceIcon" append-icon="mdi-open-in-new" :href="getUrl" target="_blank" rel="noopener noreferrer" :disabled="disabled">
     {{ getSourceName }}
   </v-btn>
-  <v-list-item v-else-if="display === 'list-item'" :slim="true" :prepend-icon="getSourceIcon" append-icon="mdi-open-in-new" :href="getUrl" target="_blank" :disabled="disabled">
+  <v-list-item v-else-if="display === 'list-item'" :slim="true" :prepend-icon="getSourceIcon" append-icon="mdi-open-in-new" :href="getUrl" target="_blank" rel="noopener noreferrer" :disabled="disabled">
     {{ getSourceName }}
   </v-list-item>
 </template>

--- a/src/components/OpenStreetMapLink.vue
+++ b/src/components/OpenStreetMapLink.vue
@@ -1,11 +1,11 @@
 <template>
-  <a v-if="display === 'link'" :href="getLocationOSMUrl" target="_blank">
+  <a v-if="display === 'link'" :href="getLocationOSMUrl" target="_blank" rel="noopener noreferrer">
     {{ OSM_NAME }}
   </a>
-  <v-btn v-else-if="display === 'button'" size="small" append-icon="mdi-open-in-new" :href="getLocationOSMUrl" target="_blank">
+  <v-btn v-else-if="display === 'button'" size="small" append-icon="mdi-open-in-new" :href="getLocationOSMUrl" target="_blank" rel="noopener noreferrer">
     {{ OSM_NAME }}
   </v-btn>
-  <v-list-item v-else-if="display === 'list-item'" :slim="true" :prepend-icon="LOCATION_TYPE_OSM_ICON" append-icon="mdi-open-in-new" :href="getLocationOSMUrl" target="_blank">
+  <v-list-item v-else-if="display === 'list-item'" :slim="true" :prepend-icon="LOCATION_TYPE_OSM_ICON" append-icon="mdi-open-in-new" :href="getLocationOSMUrl" target="_blank" rel="noopener noreferrer">
     {{ OSM_NAME }}
   </v-list-item>
 </template>

--- a/src/components/ProofActionMenuButton.vue
+++ b/src/components/ProofActionMenuButton.vue
@@ -15,7 +15,7 @@
         <v-list-item :slim="true" prepend-icon="mdi-eye-outline" :to="getProofDetailUrl">
           {{ $t('Common.Details') }}
         </v-list-item>
-        <v-list-item :slim="true" prepend-icon="mdi-open-in-new" :href="getProofImageFullUrl" target="_blank">
+        <v-list-item :slim="true" prepend-icon="mdi-open-in-new" :href="getProofImageFullUrl" target="_blank" rel="noopener noreferrer">
           {{ $t('Common.PictureFull') }}
         </v-list-item>
         <v-list-item v-if="proof.priceTagsBoundingBoxes" :slim="true" prepend-icon="mdi-star-box-multiple-outline" @click="toggleShowPriceTagsBoundingBoxes">

--- a/src/components/ProofTypeChip.vue
+++ b/src/components/ProofTypeChip.vue
@@ -1,7 +1,7 @@
 <template>
   <v-chip label size="small" :prepend-icon="getProofTypeIcon" density="comfortable">
     <span v-if="proofType === PROOF_TYPE_GDPR_REQUEST">
-      <a :href="OFF_WIKI_GDPR_REQUEST_URL" target="_blank">
+      <a :href="OFF_WIKI_GDPR_REQUEST_URL" target="_blank" rel="noopener noreferrer">
         {{ getProofTypeName }}
         <v-icon size="x-small" icon="mdi-open-in-new" />
       </a>

--- a/src/components/ReuseCard.vue
+++ b/src/components/ReuseCard.vue
@@ -20,6 +20,7 @@
         append-icon="mdi-open-in-new"
         :href="reuse.url"
         target="_blank"
+        rel="noopener noreferrer"
         :title="$t('Common.View')"
       >
         {{ $t('Common.View') }}
@@ -30,6 +31,7 @@
         icon="mdi-xml"
         :href="reuse.code_url"
         target="_blank"
+        rel="noopener noreferrer"
         :title="$t('Common.SourceCode')"
       />
     </v-card-actions>

--- a/src/components/ReuseNewFormAlert.vue
+++ b/src/components/ReuseNewFormAlert.vue
@@ -7,7 +7,7 @@
   >
     <i18n-t keypath="Reuses.AlertNew" tag="span">
       <template #url>
-        <a :href="APP_GITHUB_REUSE_DISCUSSION_URL" target="_blank" class="text-lowercase">{{ $t('Common.Here') }}</a>
+        <a :href="APP_GITHUB_REUSE_DISCUSSION_URL" target="_blank" rel="noopener noreferrer" class="text-lowercase">{{ $t('Common.Here') }}</a>
       </template>
     </i18n-t>
   </v-alert>

--- a/src/components/SurveyBanner.vue
+++ b/src/components/SurveyBanner.vue
@@ -12,7 +12,7 @@
         </template>
       </i18n-t>
       <p>
-        <a :href="survey.url" target="_blank">
+        <a :href="survey.url" target="_blank" rel="noopener noreferrer">
           {{ $t(`Surveys.Survey${survey.name}`) }}
         </a>
       </p>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -10,16 +10,16 @@
         {{ APP_NAME }}
       </template>
       <template #op_api_url>
-        <a :href="APP_API_URL" target="_blank">API</a>
+        <a :href="APP_API_URL" target="_blank" rel="noopener noreferrer">API</a>
       </template>
       <template #off_url>
         <OpenFoodFactsLink display="link" />
       </template>
       <template #odbl_url>
-        <a :href="LICENSE_ODBL_URL" target="_blank">{{ LICENSE_ODBL_NAME }}</a>
+        <a :href="LICENSE_ODBL_URL" target="_blank" rel="noopener noreferrer">{{ LICENSE_ODBL_NAME }}</a>
       </template>
       <template #ccbysa_url>
-        <a :href="LICENSE_CC_BY_SA_URL" target="_blank">{{ LICENSE_CC_BY_SA_NAME }}</a>
+        <a :href="LICENSE_CC_BY_SA_URL" target="_blank" rel="noopener noreferrer">{{ LICENSE_CC_BY_SA_NAME }}</a>
       </template>
     </i18n-t>
   </v-sheet>
@@ -46,16 +46,16 @@
           {{ APP_NAME }}
         </template>
         <template #op_api_url>
-          <a :href="APP_API_URL" target="_blank">API</a>
+          <a :href="APP_API_URL" target="_blank" rel="noopener noreferrer">API</a>
         </template>
         <template #op_dumb_prices_url>
-          <a :href="APP_DUMP_PRICES_URL" class="text-lowercase" target="_blank">{{ $t('Common.Prices') }}</a>
+          <a :href="APP_DUMP_PRICES_URL" class="text-lowercase" target="_blank" rel="noopener noreferrer">{{ $t('Common.Prices') }}</a>
         </template>
         <template #op_dumb_proofs_url>
-          <a :href="APP_DUMP_PROOFS_URL" class="text-lowercase" target="_blank">{{ $t('Common.Proofs') }}</a>
+          <a :href="APP_DUMP_PROOFS_URL" class="text-lowercase" target="_blank" rel="noopener noreferrer">{{ $t('Common.Proofs') }}</a>
         </template>
         <template #op_dumb_locations_url>
-          <a :href="APP_DUMP_LOCATIONS_URL" class="text-lowercase" target="_blank">{{ $t('Common.Locations') }}</a>
+          <a :href="APP_DUMP_LOCATIONS_URL" class="text-lowercase" target="_blank" rel="noopener noreferrer">{{ $t('Common.Locations') }}</a>
         </template>
         <template #off_url>
           <OpenFoodFactsLink display="link" />
@@ -70,7 +70,7 @@
           {{ OSM_NAME }}
         </template>
         <template #odbl_url>
-          <a :href="LICENSE_ODBL_URL" target="_blank">{{ LICENSE_ODBL_NAME }}</a>
+          <a :href="LICENSE_ODBL_URL" target="_blank" rel="noopener noreferrer">{{ LICENSE_ODBL_NAME }}</a>
         </template>
       </i18n-t>
     </v-sheet>

--- a/src/views/Community.vue
+++ b/src/views/Community.vue
@@ -7,8 +7,8 @@
     </v-col>
     <v-col>
       <ul class="pl-4">
-        <li><a :href="APP_GITHUB_BACKEND_URL" target="_blank">Github</a></li>
-        <li><a :href="OFF_SLACK_URL" target="_blank">Open Food Facts Slack (#prices)</a></li>
+        <li><a :href="APP_GITHUB_BACKEND_URL" target="_blank" rel="noopener noreferrer">Github</a></li>
+        <li><a :href="OFF_SLACK_URL" target="_blank" rel="noopener noreferrer">Open Food Facts Slack (#prices)</a></li>
       </ul>
     </v-col>
   </v-row>
@@ -21,10 +21,10 @@
     </v-col>
     <v-col>
       <ul class="pl-4">
-        <li><a :href="APP_API_URL" target="_blank">API</a></li>
-        <li><a :href="APP_HUGGING_FACE_URL" target="_blank">Hugging Face</a></li>
-        <li><a :href="APP_DATA_GOUV_URL" target="_blank">data.gouv</a></li>
-        <li><a :href="APP_DUMP_PRICES_URL" target="_blank">prices.jsonl.gz</a> | <a :href="APP_DUMP_PROOFS_URL" target="_blank">proofs.jsonl.gz</a> | <a :href="APP_DUMP_LOCATIONS_URL" target="_blank">locations.jsonl.gz</a></li>
+        <li><a :href="APP_API_URL" target="_blank" rel="noopener noreferrer">API</a></li>
+        <li><a :href="APP_HUGGING_FACE_URL" target="_blank" rel="noopener noreferrer">Hugging Face</a></li>
+        <li><a :href="APP_DATA_GOUV_URL" target="_blank" rel="noopener noreferrer">data.gouv</a></li>
+        <li><a :href="APP_DUMP_PRICES_URL" target="_blank" rel="noopener noreferrer">prices.jsonl.gz</a> | <a :href="APP_DUMP_PROOFS_URL" target="_blank" rel="noopener noreferrer">proofs.jsonl.gz</a> | <a :href="APP_DUMP_LOCATIONS_URL" target="_blank" rel="noopener noreferrer">locations.jsonl.gz</a></li>
       </ul>
     </v-col>
   </v-row>

--- a/src/views/Contribute.vue
+++ b/src/views/Contribute.vue
@@ -14,10 +14,10 @@
     </v-col>
     <v-col>
       <ul class="pl-4">
-        <li>You have a fidelty card? You can <a :href="OFF_WIKI_GDPR_REQUEST_URL" target="_blank">make a GDPR request and upload the list of prices</a></li>
+        <li>You have a fidelty card? You can <a :href="OFF_WIKI_GDPR_REQUEST_URL" target="_blank" rel="noopener noreferrer">make a GDPR request and upload the list of prices</a></li>
         <li><router-link to="/challenges">Participate in one of our challenges</router-link></li>
         <li><router-link to="/community">Learn more about the Open Prices project and its community</router-link></li>
-        <li><a :href="OFF_CONTRIBUTE_URL" target="_blank">Contribute to Open Food Facts</a></li>
+        <li><a :href="OFF_CONTRIBUTE_URL" target="_blank" rel="noopener noreferrer">Contribute to Open Food Facts</a></li>
       </ul>
     </v-col>
   </v-row>

--- a/src/views/ModerationDashboard.vue
+++ b/src/views/ModerationDashboard.vue
@@ -14,7 +14,7 @@
     <v-col cols="12">
       <v-data-table :headers="tableHeaders" :items="flagList" :items-per-page="tablePageLimit" class="elevation-1" fixed-header hide-default-footer mobile-breakpoint="md" :mobile="null" :disable-sort="true" density="comfortable">
         <template #[`item.object`]="{ item }">
-          <router-link :to="getFlagObjectUrl(item)" target="_blank">
+          <router-link :to="getFlagObjectUrl(item)" target="_blank" rel="noopener noreferrer">
             {{ item.content_type }} {{ item.object_id }}
           </router-link>
         </template>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -42,7 +42,7 @@
             hide-details="auto"
           />
           <p class="mt-1">
-            <a :href="OFF_CROWDIN_URL" target="_blank">
+            <a :href="OFF_CROWDIN_URL" target="_blank" rel="noopener noreferrer">
               {{ $t('UserSettings.TranslationHelp') }}
               <v-icon size="small" icon="mdi-open-in-new" />
             </a>


### PR DESCRIPTION
### What

Follow-up to the review on #2358 (https://github.com/openfoodfacts/open-prices-frontend/pull/2358#discussion_r3919255159): links opened with `target="_blank"` should carry `rel="noopener noreferrer"`, in a dedicated PR.

This adds `rel="noopener noreferrer"` to all 45 `target="_blank"` links in `src/` (20 files, 42 lines), matching the one place that already had it (`LocationActionMenuButton.vue`). Includes the Leaflet attribution string in `LeafletMap.vue`. No other changes.

### Why

Without `rel`, the opened page receives the `Referer` header, and in browsers that do not imply `noopener` for `target="_blank"` it also gets a live `window.opener` (reverse tabnabbing).

### Verification

- Before (on `main`): `git grep 'target="_blank"' -- src | grep -vc noopener` → 42 lines. In headless Chrome (via CDP) on the home page: 6 `[target="_blank"]` elements, all without `rel`; clicking the footer GitHub link opened a popup whose navigation request carried `Referer: http://127.0.0.1:5181/`.
- After: tag-aware scan finds 45 `target="_blank"` tags, 0 missing `rel="noopener noreferrer"`. Same headless Chrome check: 0 elements without `rel`, the footer link has `rel="noopener noreferrer"`, and the popup's navigation request has no `Referer` header.
- `eslint` on the 20 changed files: 0 errors, 23 warnings, identical to `main` (all pre-existing `no-raw-text` / a11y warnings). `git diff --check` clean. `vite build --mode prod` succeeds.
